### PR TITLE
fix(ci): force deterministic robosuite reinstall in robocasa lanes

### DIFF
--- a/.github/workflows/test-selective.yml
+++ b/.github/workflows/test-selective.yml
@@ -277,6 +277,20 @@ jobs:
             log=$(mktemp)
             rc=0
             python3 scripts/repair_hf_libero_install.py || true
+            # robocasa + robocasa-gr1 both need robosuite 1.5.2 from the git pin
+            # (232ce7d4). The libero lane runs first and leaves robosuite 1.4.0
+            # installed; a bare `uv run --group robocasa` group switch does not
+            # reliably reinstall the git package (uv evicts master for a wheel —
+            # see python/sim/src/openral_sim/_deps.py), leaving a partial/1.4
+            # robosuite: SO100 absent from REGISTERED_ROBOTS, NullMount not a
+            # MountModel. Reinstall from the lock so every uv run below lands on
+            # the pinned tree deterministically.
+            # ponytail: reinstalls once per robocasa lane; if robocasa +
+            # robocasa-gr1 are both selected it rebuilds twice (rare, correctness
+            # over one extra git build).
+            if [ "$dependency_group" = "robocasa" ]; then
+              uv sync --frozen --all-packages --group robocasa --reinstall-package robosuite
+            fi
             if [ "$group" = "onnx-export" ]; then
               uv run --all-packages --group onnx-export python tools/export_rtdetr_onnx.py \
                 --out rskills/rtdetr-coco-r18/model.onnx || rc=$?

--- a/docs/contributing/selective-testing.md
+++ b/docs/contributing/selective-testing.md
@@ -98,6 +98,16 @@ suite.
    lane (e.g. `rclpy` on the no-ROS libero lane host), so its run is judged by
    exit code — a real failure fails the lane; an all-/partial-skip does not.
 
+   The `robocasa` and `robocasa-gr1` lanes need robosuite 1.5.2 from the git pin
+   (`232ce7d4`). The `libero` lane runs first and leaves robosuite 1.4.0
+   installed, and a bare `uv run --group robocasa` group switch does not reliably
+   reinstall the git package (uv evicts master for a wheel — see
+   `python/sim/src/openral_sim/_deps.py`), which surfaces as SO100 missing from
+   `REGISTERED_ROBOTS` or `NullMount` not being a `MountModel`. `run_lane` guards
+   this with an explicit `uv sync --frozen --all-packages --group robocasa
+   --reinstall-package robosuite` before the lane's `uv run`s, so the env lands
+   on the pinned tree deterministically.
+
 Every selected target carries a human-readable reason.
 
 ### Usage


### PR DESCRIPTION
Stacked on #8 (`docs/refactor`).

## What changed
`run_lane` in `.github/workflows/test-selective.yml` now runs an explicit
`uv sync --frozen --all-packages --group robocasa --reinstall-package robosuite`
before the lane's `uv run`s, gated on `dependency_group = robocasa` (covers both
the `robocasa` pytest path and the `robocasa-gr1` verify path). Docs updated in
`docs/contributing/selective-testing.md`.

## Why
The robocasa lanes need robosuite 1.5.2 from the git pin (`232ce7d4`). Lanes run
sequentially in one job: `run_lane libero` installs robosuite 1.4.0 first, then
the robocasa lane's bare `uv run --group robocasa` group switch does not reliably
reinstall the git package — uv evicts master for a wheel (documented in
`python/sim/src/openral_sim/_deps.py`). The env is left on a partial/1.4
robosuite, surfacing as **SO100 missing from `REGISTERED_ROBOTS`** and
**`NullMount` not a `MountModel`**. Forcing `--reinstall-package robosuite` from
the frozen lock makes resolution deterministic per lane.

Latent on `master` — normal PRs don't select these tests. #8 exposed it only
because regenerating schema JSON required a docstring edit in
`openral_core/schemas.py`, widening selection to the whole sim suite.

## How tested
CI-only workflow change; cannot exercise the robocasa lane locally (passes
locally where the env is already correct). Verified:
- `test-selective.yml` parses as valid YAML.
- Extracted `run_lane` block passes `bash -n`.
- `--reinstall-package` / `--frozen` / `--all-packages` are valid `uv sync` flags
  on the CI-pinned uv (0.11.24, `astral-sh/setup-uv@v8.3.2`).
- No test asserts on the workflow file (`tests/unit/test_deps_install_plans.py`
  covers `_deps.py` runtime plans, not the YAML).

Real verification is this lane going green in CI on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGDbp9enmXVeHLvhQt9c8K