### PR TITLE
feat(install): default Tier-0 to CPU-only torch (~1.6 GB, no CUDA wheels)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ openral install sim             # opt-in: CPU sim physics
 openral install ros             # opt-in: ROS 2 + apt (needs sudo)
 ```
 
+The base install is **CPU-only** (~1.6 GB — torch `+cpu`, no NVIDIA wheels), matching Tier-0's CPU harness. On an NVIDIA GPU host, pull CUDA torch into the base venv instead by prepending `OPENRAL_TORCH_BACKEND=auto` (uv auto-detects the driver) — or a specific `cu130` — to the install line. `openral doctor` reports the GPU either way.
+
 Heavy extras (LIBERO, RoboCasa, MetaWorld, ManiSkill3, SimplerEnv, ROS 2) are installed on demand via `openral install <group>` or automatically on first `openral sim run` against a scene that needs them. See `openral install list` for the full menu.
 
 > **Pre-PyPI gap.** `openral-cli` is not yet on PyPI. Until then:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -35,6 +35,17 @@
 #                            PyPI for them (`--index-strategy unsafe-best-match`
 #                            then pulls the broken placeholders instead). Use
 #                            TestPyPI to verify a *publish*, not a full install.
+#   OPENRAL_TORCH_BACKEND    PyTorch wheel backend (default: cpu). Tier-0 is the
+#                            CPU harness (doctor / detect / connect / CPU sim),
+#                            so the base install takes CPU-only torch — ~1.6 GB
+#                            instead of the ~5-6 GB CUDA stack, and no NVIDIA
+#                            wheels. GPU inference is a heavier opt-in: set
+#                            `auto` (uv detects the installed CUDA driver) or a
+#                            specific `cu128` / `cu130` / … to pull CUDA torch
+#                            into the base venv. Set empty to skip the flag and
+#                            take uv's default (PyPI's manylinux CUDA wheels).
+#                            `openral doctor` reports the GPU either way (it
+#                            probes via NVML, not torch).
 #   OPENRAL_INSTALL_DEBUG    1 → set -x.
 
 set -euo pipefail
@@ -121,11 +132,25 @@ if [[ -n "${OPENRAL_INSTALL_INDEX:-}" ]]; then
     extra_index_args=(--extra-index-url "${OPENRAL_INSTALL_INDEX}")
 fi
 
+# PyTorch backend selection. openral-cli's dependency chain pulls torch, which
+# defaults to PyPI's ~5-6 GB CUDA wheel + NVIDIA cu12/cu13 stack even on a
+# GPU-less host. Tier-0 is the CPU harness, so default to CPU-only torch
+# (~1.6 GB, zero NVIDIA wheels). GPU users opt in with OPENRAL_TORCH_BACKEND=auto
+# (uv detects the CUDA driver) or an explicit cuXXX. Same bash-3.2-safe empty
+# expansion as extra_index_args; an empty knob skips the flag.
+OPENRAL_TORCH_BACKEND="${OPENRAL_TORCH_BACKEND-cpu}"
+torch_backend_args=()
+if [[ -n "${OPENRAL_TORCH_BACKEND}" ]]; then
+    info "torch backend: ${OPENRAL_TORCH_BACKEND}"
+    torch_backend_args=(--torch-backend "${OPENRAL_TORCH_BACKEND}")
+fi
+
 info "installing ${spec} (uv tool install)"
 # --force re-installs even when the tool is already present; matches the
 # `curl … | bash` muscle memory of "running it again gives me the latest".
 uv tool install --force --python 3.12 \
-    ${extra_index_args[@]+"${extra_index_args[@]}"} "${spec}"
+    ${extra_index_args[@]+"${extra_index_args[@]}"} \
+    ${torch_backend_args[@]+"${torch_backend_args[@]}"} "${spec}"
 
 # ── 4. PATH guidance ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What changed
The Tier-0 curl-bash installer (`scripts/install.sh`) now installs **CPU-only PyTorch by default**, via a new `OPENRAL_TORCH_BACKEND` env knob passed to `uv tool install --torch-backend`.

- Default `cpu`: `torch==2.9.1+cpu`, **zero `nvidia-*` CUDA wheels**, ~**1.6 GB** venv.
- Opt into CUDA: `OPENRAL_TORCH_BACKEND=auto` (uv auto-detects the installed CUDA driver) or an explicit `cu128`/`cu130`/…
- Empty value skips the flag (uv's PyPI default).

## Why
`openral-cli`'s dependency chain (`openral-sim`/`-rskill`/`-hal`) pulls `torch`, which resolves to PyPI's **~5–6 GB CUDA wheel + full NVIDIA cu12/cu13 stack even on a GPU-less host** — directly at odds with the installer's own "Tier-0 only — no GPU" contract. A `curl … | bash` that quietly downloads ~5 GB of CUDA libraries on a laptop is a bad first impression. GPU inference is a heavier opt-in path anyway (rSkills/VLA groups), so the CPU base is the right Tier-0 default. `openral doctor` still reports the GPU either way — it probes via NVML (`nvidia-ml-py`), not torch.

## How tested
Real end-to-end runs of the **edited** installer on a pristine `ubuntu:24.04` container (no Python, no uv) as a non-root user:

| Scenario | torch | `nvidia-*` wheels | pkgs | venv | `openral doctor` |
|---|---|---|---|---|---|
| default (`cpu`) | `2.9.1+cpu` | **0** | 102 | **1.6 G** | ✅ Python 3.12.13, openral-core 0.1.0 |
| `OPENRAL_TORCH_BACKEND=auto` (GPU driver visible) | `2.9.1+cu130` | 16 | 118 | ~5–6 G | ✅ |

All 11 `openral-cli` closure packages resolved from **real PyPI** at `0.1.0`. `bash -n` clean.

## Notes
- Scope is intentionally limited to the installer. The stale README "Pre-PyPI gap" note is left for the PyPI-publish wrap-up (separate change).
- `docs/` updated in the same commit (README Quick start note) per the docs-travel-with-code rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)