### PR TITLE
chore(ci): revert release-pypi to OIDC-only Trusted Publishing

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -136,19 +136,11 @@ jobs:
       - name: build sdist + wheel
         working-directory: ${{ matrix.package }}
         run: uv build --out-dir dist
-      - name: publish (${{ needs.resolve.outputs.index }})
+      - name: publish (${{ needs.resolve.outputs.index }}, Trusted Publishing)
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           packages-dir: ${{ matrix.package }}/dist
           repository-url: ${{ needs.resolve.outputs.repository-url }}
-          # BOOTSTRAP: PyPI's pending-publisher model can't create N projects
-          # from one shared workflow (uniqueness on owner/repo/workflow/env), so
-          # the first publish that creates all 14 projects uses an account-scoped
-          # API token. Once the projects exist, add per-project trusted publishers
-          # (they may share this workflow) and revert this to OIDC — see the
-          # header note. attestations require a Trusted Publisher, off for token.
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          attestations: false
           # Skip-existing lets a re-run of the matrix after a partial failure
           # skip the already-published packages instead of erroring out.
           skip-existing: true


### PR DESCRIPTION
## What changed
Removes the one-time API-token bootstrap from the `build-and-publish` step of `release-pypi.yml` — drops `password: ${{ secrets.PYPI_API_TOKEN }}` and `attestations: false`, and restores the step name to `publish (…, Trusted Publishing)`.

## Why
All **14 `openral-*` packages are now published on PyPI at 0.1.0**. The initial release used an account-scoped API token because PyPI's *pending-publisher* model can't create N projects from a single shared workflow (uniqueness on owner/repo/workflow/env). Now that every project exists, we return to OIDC-only Trusted Publishing — no long-lived token in CI, and attestations come back on.

## Follow-ups (manual, outside this PR)
- Add a **per-project trusted publisher** on pypi.org for each of the 14 projects (owner `OpenRAL`, repo `openral`, workflow `release-pypi.yml`) — existing projects may share the same config (the uniqueness limit is only on *pending* publishers).
- **Delete the `PYPI_API_TOKEN`** repo secret once the trusted publishers are in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)