### PR TITLE
chore(release): v0.2.0 — lockstep version bump + changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,34 @@
+name: changelog
+# Regenerates CHANGELOG.md from tags + merged PRs + closed issues
+# (github-changelog-generator) after every GitHub release, and commits it
+# straight to master. workflow_dispatch covers backfills / manual refreshes.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  changelog:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: master
+      - name: Generate CHANGELOG.md
+        uses: janheinrichmerker/action-github-changelog-generator@e60b5a2bd9fcd88dadf6345ff8327863fb8b490f  # v2.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --cached --quiet && exit 0
+          git commit -s -m "docs(changelog): regenerate for ${TAG:-manual refresh}"
+          git push origin master
+        env:
+          TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -26,7 +26,8 @@ name: release-pypi
 #     the individual account, then dispatch target=pypi (or push a v*.*.* tag).
 #     Projects transfer into the OpenRAL org later with no re-publish.
 #
-# Every workspace package is pinned to 0.1.x — see CLAUDE.md.
+# Every workspace package shares one lockstep version — bump all pyprojects
+# (root + python/*) together for a release.
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A VLA alone is not an agent — OpenRAL wraps it in the loop it needs. It is a t
 
 We compose ROS 2, tf2, MoveIt 2 (with optional CUDA-accelerated **cuMotion** planning), Nav2, NVIDIA Isaac ROS (**cuVSLAM + nvblox** vision SLAM), and `ros2_control` — we don't reinvent them.
 
-**Shipped today** (all workspace packages at `0.1.0`):
+**Shipped today** (all workspace packages at `0.2.0`):
 - `openral_core` schemas + the `openral` CLI (bare `openral` drops into a REPL)
 - HAL adapters for [15+ robot platforms](docs/reference/robots.md) — manipulators, mobile manipulators, bimanual arms, humanoids
 - [Sensor catalog](docs/reference/sensors_landscape.md) — RGB-D, F/T, and USB-UVC adapters
@@ -167,7 +167,7 @@ The `openral` CLI lives in `.venv/bin/openral`. Run via `uv run openral ...` or 
 ┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
 │ Python             │ ok      │ 3.12.9                         │
 │ Platform           │ info    │ Linux 6.14.0                   │
-│ openral-core       │ ok      │ 0.1.0                          │
+│ openral-core       │ ok      │ 0.2.0                          │
 │ ROS 2 binary       │ ok      │ /opt/ros/jazzy/bin/ros2        │
 │ ROS 2 distro       │ ok      │ jazzy                          │
 │ RMW                │ info    │ rmw_fastrtps_cpp (default)     │

--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -31,7 +31,7 @@ Example output on a well-configured Ubuntu 24.04 machine with an NVIDIA GPU:
 ┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
 │ Python             │ ok      │ 3.12.3                         │
 │ Platform           │ info    │ Linux 6.8.0-47-generic         │
-│ openral-core   │ ok      │ 0.1.0                          │
+│ openral-core   │ ok      │ 0.2.0                          │
 │ ROS 2 binary       │ ok      │ /opt/ros/jazzy/bin/ros2        │
 │ ROS 2 distro       │ ok      │ jazzy                          │
 │ RMW                │ info    │ rmw_fastrtps_cpp (default)     │
@@ -69,7 +69,7 @@ openral doctor --json
 [
   {"check": "Python",           "status": "ok",   "details": "3.12.3"},
   {"check": "Platform",         "status": "info", "details": "Linux 6.8.0"},
-  {"check": "openral-core", "status": "ok",   "details": "0.1.0"},
+  {"check": "openral-core", "status": "ok",   "details": "0.2.0"},
   {"check": "ROS 2 binary",     "status": "ok",   "details": "/opt/ros/jazzy/bin/ros2"},
   {"check": "ROS 2 distro",     "status": "ok",   "details": "jazzy"},
   {"check": "RMW",              "status": "info", "details": "rmw_fastrtps_cpp (default)"},

--- a/docs/reference/schemas/all.json
+++ b/docs/reference/schemas/all.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "openral_core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "schemas": {
     "EmbodimentKind": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openral-workspace"
-version = "0.1.0"
+version = "0.2.0"
 description = "OpenRAL — open-source robot agent harness for VLA models"
 requires-python = ">=3.12,<3.13"
 license = { text = "Apache-2.0" }

--- a/python/cli/pyproject.toml
+++ b/python/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openral-cli"
-version = "0.1.0"
+version = "0.2.0"
 description = "OpenRAL command-line tool"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/python/cli/src/openral_cli/__init__.py
+++ b/python/cli/src/openral_cli/__init__.py
@@ -1,6 +1,6 @@
 """openral CLI — the `ros` command entry point."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __all__ = ["app"]
 
 from openral_cli.main import app

--- a/python/core/pyproject.toml
+++ b/python/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openral-core"
-version = "0.1.0"
+version = "0.2.0"
 description = "OpenRAL Pydantic schemas — normative contract for the OpenRAL layer interfaces"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/python/core/src/openral_core/__init__.py
+++ b/python/core/src/openral_core/__init__.py
@@ -419,4 +419,4 @@ __all__ = [
     "scene_task_space_compatible",
     "task_space_compatible",
 ]
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/python/dataset/pyproject.toml
+++ b/python/dataset/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openral-dataset"
-version = "0.1.0"
+version = "0.2.0"
 description = "OpenRAL dataset bridge — RolloutRecorder + LeRobotDataset v3 / rosbag2 sinks for every skill execution"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/python/detect/pyproject.toml
+++ b/python/detect/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openral-detect"
-version = "0.1.0"
+version = "0.2.0"
 description = "Hardware probing + RobotDescription assembly + skill compatibility report"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/python/detect/src/openral_detect/__init__.py
+++ b/python/detect/src/openral_detect/__init__.py
@@ -1,6 +1,6 @@
 """openral auto-provisioning — `openral detect` machinery."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 from openral_detect.assemble import assemble_robot_description, build_compute_spec
 from openral_detect.compatibility import (

--- a/python/hal/pyproject.toml
+++ b/python/hal/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openral-hal"
-version = "0.1.0"
+version = "0.2.0"
 description = "OpenRAL Hardware Abstraction Layer — HAL Protocol and ros2_control adapter"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/python/observability/pyproject.toml
+++ b/python/observability/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openral-observability"
-version = "0.1.0"
+version = "0.2.0"
 description = "OpenRAL observability — OpenTelemetry tracing + structlog→OTLP logging bridge for Skill / inference / safety spans"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/python/reasoner/pyproject.toml
+++ b/python/reasoner/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openral-reasoner"
-version = "0.1.0"
+version = "0.2.0"
 description = "OpenRAL S2 reasoner — typed LLM client + Plan → BT XML emission"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/python/reasoner/src/openral_reasoner/__init__.py
+++ b/python/reasoner/src/openral_reasoner/__init__.py
@@ -125,4 +125,4 @@ __all__ = [
     "save_ladder_state",
     "should_rebuild_mission",
 ]
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/python/rskill/pyproject.toml
+++ b/python/rskill/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openral-rskill"
-version = "0.1.0"
+version = "0.2.0"
 description = "OpenRAL Skill base class — lifecycle state machine and mock skill"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/python/rskill/src/openral_rskill/__init__.py
+++ b/python/rskill/src/openral_rskill/__init__.py
@@ -56,4 +56,4 @@ __all__ = [
     "rSkillBase",
     "resolve_runtime_backend",
 ]
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/python/runner/pyproject.toml
+++ b/python/runner/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openral-runner"
-version = "0.1.0"
+version = "0.2.0"
 description = "OpenRAL inference runner — closes WorldState → Skill → HAL at a cadence"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/python/runner/src/openral_runner/__init__.py
+++ b/python/runner/src/openral_runner/__init__.py
@@ -72,7 +72,7 @@ __all__ = [
     "precise_sleep",
     "sleep_until",
 ]
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 
 _LAZY_ATTRS: dict[str, tuple[str, str]] = {

--- a/python/sensors/pyproject.toml
+++ b/python/sensors/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openral-sensors"
-version = "0.1.0"
+version = "0.2.0"
 description = "OpenRAL sensor adapters — launch generators and calibration helpers"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/python/sensors/src/openral_sensors/__init__.py
+++ b/python/sensors/src/openral_sensors/__init__.py
@@ -53,4 +53,4 @@ __all__ = [
     "realsense_d435_bundle",
     "realsense_d435i_bundle",
 ]
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/python/sim/pyproject.toml
+++ b/python/sim/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openral-sim"
-version = "0.1.0"
+version = "0.2.0"
 description = "OpenRAL sim eval — robot × scene × task × VLA factory and runner for rSkill validation before hardware deployment"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/python/sim/src/openral_sim/__init__.py
+++ b/python/sim/src/openral_sim/__init__.py
@@ -64,4 +64,4 @@ __all__ = [
     "save_episode_mp4",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/python/state_adapter/pyproject.toml
+++ b/python/state_adapter/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openral-state-adapter"
-version = "0.1.0"
+version = "0.2.0"
 description = "OpenRAL layout-adapter registry — assembles per-checkpoint state vectors"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/python/state_adapter/src/openral_state_adapter/__init__.py
+++ b/python/state_adapter/src/openral_state_adapter/__init__.py
@@ -23,4 +23,4 @@ __all__ = [
     "register",
     "registered_layouts",
 ]
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/python/wam/pyproject.toml
+++ b/python/wam/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openral-wam"
-version = "0.1.0"
+version = "0.2.0"
 description = "OpenRAL World Action Model layer — WorldModel Protocol + Rollout schema (CLAUDE.md §6.3)"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/python/wam/src/openral_wam/__init__.py
+++ b/python/wam/src/openral_wam/__init__.py
@@ -33,4 +33,4 @@ __all__ = [
     "Rollout",
     "WorldModel",
 ]
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/python/world_state/pyproject.toml
+++ b/python/world_state/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openral-world-state"
-version = "0.1.0"
+version = "0.2.0"
 description = "OpenRAL World State aggregator — tf2-aware snapshot producer"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/python/world_state/src/openral_world_state/__init__.py
+++ b/python/world_state/src/openral_world_state/__init__.py
@@ -101,4 +101,4 @@ __all__ = [
     "rotation_to_quat_wxyz",
     "scene_objects_payload",
 ]
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -20,12 +20,14 @@ suite by accident.
 
 from __future__ import annotations
 
+import importlib.metadata
+
 import openral_core as core
 
 
 def test_version_is_set() -> None:
-    """Verify the package version is set."""
-    assert core.__version__ == "0.1.0"
+    """Verify the package version is set and matches the installed distribution."""
+    assert core.__version__ == importlib.metadata.version("openral-core")
 
 
 def test_can_construct_minimal_robot_description() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2625,7 +2625,7 @@ wheels = [
 
 [[package]]
 name = "openral-cli"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "python/cli" }
 dependencies = [
     { name = "fastapi" },
@@ -2662,7 +2662,7 @@ requires-dist = [
 
 [[package]]
 name = "openral-core"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "python/core" }
 dependencies = [
     { name = "numpy" },
@@ -2679,7 +2679,7 @@ requires-dist = [
 
 [[package]]
 name = "openral-dataset"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "python/dataset" }
 dependencies = [
     { name = "mcap" },
@@ -2715,7 +2715,7 @@ provides-extras = ["lerobot", "ros"]
 
 [[package]]
 name = "openral-detect"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "python/detect" }
 dependencies = [
     { name = "openral-cli" },
@@ -2755,7 +2755,7 @@ provides-extras = ["nvidia", "jetson", "realsense"]
 
 [[package]]
 name = "openral-hal"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "python/hal" }
 dependencies = [
     { name = "lerobot", extra = ["feetech"] },
@@ -2793,7 +2793,7 @@ provides-extras = ["so100", "arm-sim"]
 
 [[package]]
 name = "openral-observability"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "python/observability" }
 dependencies = [
     { name = "mcap" },
@@ -2837,7 +2837,7 @@ provides-extras = ["dashboard", "mdns"]
 
 [[package]]
 name = "openral-reasoner"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "python/reasoner" }
 dependencies = [
     { name = "anthropic" },
@@ -2860,7 +2860,7 @@ requires-dist = [
 
 [[package]]
 name = "openral-rskill"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "python/rskill" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -2881,7 +2881,7 @@ requires-dist = [
 
 [[package]]
 name = "openral-runner"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "python/runner" }
 dependencies = [
     { name = "msgpack" },
@@ -2917,7 +2917,7 @@ provides-extras = ["opencv", "gstreamer"]
 
 [[package]]
 name = "openral-sensors"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "python/sensors" }
 dependencies = [
     { name = "openral-core" },
@@ -2928,7 +2928,7 @@ requires-dist = [{ name = "openral-core", editable = "python/core" }]
 
 [[package]]
 name = "openral-sim"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "python/sim" }
 dependencies = [
     { name = "imageio", extra = ["ffmpeg"] },
@@ -2959,7 +2959,7 @@ requires-dist = [
 
 [[package]]
 name = "openral-state-adapter"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "python/state_adapter" }
 dependencies = [
     { name = "numpy" },
@@ -2974,7 +2974,7 @@ requires-dist = [
 
 [[package]]
 name = "openral-wam"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "python/wam" }
 dependencies = [
     { name = "openral-core" },
@@ -2993,7 +2993,7 @@ requires-dist = [
 
 [[package]]
 name = "openral-workspace"
-version = "0.1.0"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "matplotlib" },
@@ -3290,7 +3290,7 @@ simpler-env = [
 
 [[package]]
 name = "openral-world-state"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "python/world_state" }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## What changed
- All 15 workspace packages (root + `python/*`) bumped `0.1.0` → `0.2.0` (pyprojects + `__version__` strings), `uv.lock` refreshed.
- New `.github/workflows/changelog.yml`: regenerates `CHANGELOG.md` via [github-changelog-generator](https://github.com/marketplace/actions/generate-changelog) on every published GitHub release (+ `workflow_dispatch` for backfill) and commits it to master.
- `release-pypi.yml` stale "pinned to 0.1.x" comment updated; doctor examples in README/quickstart show 0.2.0.

## Why
75 commits of features since v0.1.0 (BEHAVIOR-1K, Galaxea A1 HAL, G1 humanoid VLN, Cosmos 3 Edge reasoner, InternVLA-N1, LingBot-VLA2, PyCuVSLAM) → minor release. Repo had no changelog.

## How tested
`ruff check` + `ruff format --check` clean; `uv lock` diff is only the 15 workspace version pins. Release itself is exercised by the existing `release-pypi.yml` on the `v0.2.0` tag push after merge.

## Release steps after merge
1. `git tag v0.2.0 && git push origin v0.2.0` → publishes all 14 packages to real PyPI (Trusted Publishing).
2. `gh release create v0.2.0 --generate-notes` → triggers the changelog workflow, which commits the first `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kdnqu6annsZgM1o2EMxNUq