### PR TITLE
fix(ci): open a PR from the changelog workflow instead of pushing to master

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,7 +1,13 @@
 name: changelog
 # Regenerates CHANGELOG.md from tags + merged PRs + closed issues
-# (github-changelog-generator) after every GitHub release, and commits it
-# straight to master. workflow_dispatch covers backfills / manual refreshes.
+# (github-changelog-generator) after every GitHub release, then opens a PR.
+# workflow_dispatch covers backfills / manual refreshes.
+#
+# It opens a PR rather than pushing to master because the `protect_default_branch`
+# ruleset requires a pull request there and only bypasses for org admins — a
+# direct push from GITHUB_TOKEN is rejected with GH013. The bot's PR does not
+# trigger `pull_request` workflows (GitHub's loop prevention), so its required
+# checks stay Expected and an org admin merges it with their standing bypass.
 
 on:
   release:
@@ -10,6 +16,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   changelog:
@@ -22,13 +29,28 @@ jobs:
         uses: janheinrichmerker/action-github-changelog-generator@e60b5a2bd9fcd88dadf6345ff8327863fb8b490f  # v2.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Commit and push
+      - name: Open changelog PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
-          git diff --cached --quiet && exit 0
+          if git diff --cached --quiet; then
+            echo "::notice::CHANGELOG.md unchanged — nothing to open."
+            exit 0
+          fi
+          # One long-lived branch, force-pushed: a superseded changelog PR is
+          # never worth keeping, and this leaves no branch litter per release.
+          git checkout -B chore/changelog
           git commit -s -m "docs(changelog): regenerate for ${TAG:-manual refresh}"
-          git push origin master
-        env:
-          TAG: ${{ github.event.release.tag_name }}
+          git push --force origin chore/changelog
+          if [ -z "$(gh pr list --head chore/changelog --state open --json number --jq '.[].number')" ]; then
+            gh pr create --base master --head chore/changelog \
+              --title "docs(changelog): regenerate for ${TAG:-manual refresh}" \
+              --body "Automated \`CHANGELOG.md\` regeneration from tags, merged PRs, and closed issues.
+
+Required checks stay \`Expected\` because GitHub does not run \`pull_request\` workflows for PRs opened by \`GITHUB_TOKEN\`. Merge with the org-admin ruleset bypass."
+          fi


### PR DESCRIPTION
## What changed
The changelog job now force-pushes a single `chore/changelog` branch and opens a PR, rather than committing straight to `master`. Adds `pull-requests: write`.

## Why
The first run on the v0.2.0 release generated `CHANGELOG.md` correctly, then failed the push:

```
remote: error: GH013: Repository rule violations found for refs/heads/master.
- Changes must be made through a pull request.
- 3 of 3 required status checks are expected.
```

The `protect_default_branch` ruleset requires a PR on master and bypasses only for `OrganizationAdmin`; `GITHUB_TOKEN` is not one. (This is a ruleset, not classic branch protection — which is why `/branches/master/protection` 404s.)

## Known tradeoff
GitHub does not run `pull_request` workflows for PRs opened by `GITHUB_TOKEN`, so the changelog PR's three required checks stay `Expected` and it needs the org-admin bypass to merge. Documented in the workflow header. The alternative — adding the github-actions app to the ruleset's bypass list for fully hands-off commits — is a protection-loosening call, deliberately left to a human.

## How tested
The failure mode is reproduced and diagnosed from run 30797635257; this path is exercised by the next `workflow_dispatch` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kdnqu6annsZgM1o2EMxNUq