### PR TITLE
fix(ci): repair changelog.yml YAML — dedented PR body broke the run block

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -62,7 +62,5 @@ jobs:
           if [ -z "$(gh pr list --head chore/changelog --state open --json number --jq '.[].number')" ]; then
             gh pr create --base master --head chore/changelog \
               --title "docs(changelog): regenerate for ${TAG:-manual refresh}" \
-              --body "Automated \`CHANGELOG.md\` regeneration from tags, merged PRs, and closed issues.
-
-Required checks stay \`Expected\` because GitHub does not run \`pull_request\` workflows for PRs opened by \`GITHUB_TOKEN\`. Merge with the org-admin ruleset bypass."
+              --body "Automated \`CHANGELOG.md\` regeneration. Required checks stay \`Expected\` because GitHub does not run \`pull_request\` workflows for PRs opened by \`GITHUB_TOKEN\`; merge with the org-admin ruleset bypass."
           fi


### PR DESCRIPTION
The multi-line `--body` string in the PR-opening step dedented to column 1 inside the `run: |` literal block, terminating it early. GitHub silently registered the workflow **without triggers** — visible as the workflow's name falling back to its file path in `/actions/workflows`, and `workflow_dispatch` returning 422. Body is now a single line; verified with `yaml.safe_load` locally.

Introduced in #37; #39 kept it. This is why the earlier dispatch attempts 422'd — it was never GitHub cache lag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kdnqu6annsZgM1o2EMxNUq