### PR TITLE
ci: wire OPENRAL_TEST_ROS_LIVE tests into CI (issue #46)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,8 +7,9 @@ name: docker-build
 # weeks):
 #   * pull_request → build + smoke only (no push)
 #   * push to master → build + push openral:x86 to GHCR
-# The `paths:` filter means it only runs when the image's build inputs change,
-# not on every commit. workflow_dispatch stays for manual runs (no push).
+# The `paths:` filter means it only runs when the image's build inputs change
+# (or the live-ROS tests it hosts), not on every commit. workflow_dispatch stays
+# for manual runs (no push).
 on:
   workflow_dispatch:
   pull_request:
@@ -20,6 +21,11 @@ on:
       - cpp/**
       - python/**
       - .github/workflows/docker-build.yml
+      # The live-ROS suite runs in this job and nowhere else (issue #46), so a
+      # diff that only touches those tests must still rebuild + run them.
+      - scripts/ros_live_tests.sh
+      - tests/integration/test_reasoner_*.py
+      - tests/integration/test_critic_producer_node.py
   push:
     branches: [master]
     paths:
@@ -30,6 +36,11 @@ on:
       - cpp/**
       - python/**
       - .github/workflows/docker-build.yml
+      # The live-ROS suite runs in this job and nowhere else (issue #46), so a
+      # diff that only touches those tests must still rebuild + run them.
+      - scripts/ros_live_tests.sh
+      - tests/integration/test_reasoner_*.py
+      - tests/integration/test_critic_producer_node.py
 
 permissions:
   contents: read
@@ -77,6 +88,31 @@ jobs:
             openral deploy run --config scenes/deploy/so101_bench.yaml --dry-run | grep -q "hal_mode:=real"
             echo "OK: deploy run --dry-run resolves"
           '
+
+      # Live-ROS suite (issue #46). These tests are gated on
+      # OPENRAL_TEST_ROS_LIVE=1 because they need a real rclpy, a real DDS
+      # graph, and the colcon-built openral_msgs / openral_reasoner_ros /
+      # openral_prompt_router overlay. This image is the ONLY CI surface that
+      # has any of that — the ubuntu-hosted test-selective runner has no ROS 2
+      # at all, so every one of them importorskips there. Without this step
+      # they run nowhere, and safety-adjacent gates like the reasoner's
+      # pre-dispatch VRAM refusal rot unnoticed (PR #44).
+      #
+      # tests/ + conftest.py + scripts/ are NOT baked into the deploy image
+      # (it ships a runtime, not a test tree), so bind-mount them from the
+      # checkout — that also guarantees the PR's version of the tests runs
+      # against the PR's image. No GPU on the runner and none needed: the
+      # free-VRAM readings are pinned at the nvidia-smi process boundary.
+      - name: Live ROS tests (OPENRAL_TEST_ROS_LIVE)
+        run: |
+          # --entrypoint /entrypoint.sh drops the image's hardcoded `openral`
+          # argument while keeping the ROS + colcon-overlay sourcing the tests
+          # depend on.
+          docker run --rm --entrypoint /entrypoint.sh \
+            -v "$PWD/tests:/workspace/tests:ro" \
+            -v "$PWD/conftest.py:/workspace/conftest.py:ro" \
+            -v "$PWD/scripts:/workspace/scripts:ro" \
+            openral:x86 bash scripts/ros_live_tests.sh -q
 
       # Default-entrypoint smoke: the steps above override --entrypoint, so
       # they never exercise what `docker run openral:x86 …` actually does.

--- a/Justfile
+++ b/Justfile
@@ -306,6 +306,15 @@ hal-twin-sweep:
 test-integration:
     PYTHONPATH="$(pwd)/packages/world_state:${PYTHONPATH}" uv run pytest tests/integration/ -v --tb=short
 
+# Real rclpy + a real DDS graph + the colcon overlay; no GPU needed. Requires
+#     source /opt/ros/jazzy/setup.bash && just ros2-build && source install/setup.bash
+# scripts/ros_live_tests.sh owns the target list, and the `docker-build`
+# workflow runs that same script inside `openral:x86` — so this recipe and CI
+# can never select a different set of tests. `-k <expr>` narrows the run.
+# Live-ROS suite (OPENRAL_TEST_ROS_LIVE=1) — see docs/contributing/development.md
+test-ros-live *args:
+    uv run bash scripts/ros_live_tests.sh -q {{args}}
+
 # Subset by keyword
 # `-p no:launch_testing -p no:launch_ros`: same ROS-env workaround as
 # `just test` — the launch_testing pytest plugin silently aborts

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -132,7 +132,39 @@ source /opt/ros/jazzy/setup.bash
 just ros2-build             # colcon build --merge-install
 source install/setup.bash
 just ros2-test              # colcon test + colcon test-result --verbose
+just test-ros-live          # the live-ROS pytest suite (see below)
 ```
+
+#### The live-ROS suite (`OPENRAL_TEST_ROS_LIVE`)
+
+A set of integration tests — the reasoner node's dispatch, VRAM and async-LLM
+paths, plus the Tier-C critic producer — needs more than an importable `rclpy`:
+a real DDS graph and the colcon-built `openral_msgs` / `openral_reasoner_ros` /
+`openral_prompt_router` overlay. They are gated behind `OPENRAL_TEST_ROS_LIVE=1`
+so the ordinary `uv run pytest` run (where rclpy + DDS init can clash with a
+glib pulled in transitively by torch/pyarrow) does not trip over them.
+
+`scripts/ros_live_tests.sh` holds the target list and sets the variable. Both
+callers exec it, so they cannot select different tests:
+
+| Caller | Environment |
+| --- | --- |
+| `just test-ros-live` | your host, after `just ros2-build && source install/setup.bash` |
+| `docker-build` workflow, "Live ROS tests" step | inside `openral:x86`, which bakes ROS 2 Jazzy + the colcon overlay |
+
+No GPU is required — the free-VRAM readings are pinned at the `nvidia-smi`
+process boundary. Pass extra pytest flags through the recipe, e.g.
+`just test-ros-live -k dispatch_watchdog`.
+
+Adding a live-ROS test means adding its file to `TARGETS` in that script, and
+nowhere else. The `docker-build` workflow is the only CI surface with a real
+ROS 2 install; the `test-selective` runner has none, so anything not listed here
+silently `importorskip`s in CI.
+
+One live test — `tests/unit/test_gstreamer_perception_tee.py`'s end-to-end
+publish — is deliberately excluded: it also needs PyGObject, which the open
+deploy image does not ship (the GStreamer media stack is OpenRAL Pro). `just
+test` runs it on a host that has the `gstreamer` extra installed.
 
 ### Sim evals (closed-loop, opt-in — needs HF weights ± GPU)
 

--- a/packages/openral_reasoner_ros/test/test_reasoner_node.py
+++ b/packages/openral_reasoner_ros/test/test_reasoner_node.py
@@ -4,9 +4,13 @@ This file is a thin shim consumed by ``ament_add_pytest_test`` so
 ``colcon test --packages-select openral_reasoner_ros`` passes a real
 test instead of a missing-file error. The substantive integration test
 lives in ``tests/integration/test_reasoner_node_end_to_end.py`` (gated
-on ``OPENRAL_TEST_ROS_LIVE`` per the repo-wide convention); we duplicate
+on ``OPENRAL_TEST_ROS_LIVE``, and run in CI by the ``docker-build``
+workflow via ``scripts/ros_live_tests.sh`` — see issue #46); we duplicate
 the import-only smoke test here so the colcon CI surface stays green
 without the env gate.
+
+This file itself carries NO env gate — plain ``importorskip`` is enough, so
+``just test`` / ``colcon test`` pick it up wherever the deps exist.
 """
 
 from __future__ import annotations

--- a/scripts/ros_live_tests.sh
+++ b/scripts/ros_live_tests.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# The live-ROS test suite (`OPENRAL_TEST_ROS_LIVE=1`) — one list, two callers.
+#
+# `just test-ros-live` and the `docker-build` workflow's "Live ROS tests" step
+# both exec this file, so the target list cannot drift between the dev loop and
+# CI. Adding a live-ROS test means adding it to TARGETS below and nowhere else.
+#
+# What these tests need that a plain `pytest` runner does not have: a real
+# `rclpy`, a real DDS graph, and the colcon-built `openral_msgs` /
+# `openral_reasoner_ros` / `openral_prompt_router` overlay. No GPU — the
+# free-VRAM readings are pinned at the `nvidia-smi` process boundary.
+#
+#   dev host:  source /opt/ros/jazzy/setup.bash && just ros2-build \
+#              && source install/setup.bash && just test-ros-live
+#   CI:        inside `openral:x86`, which bakes all of the above.
+#
+# NOT in TARGETS: the one live test in tests/unit/test_gstreamer_perception_tee.py.
+# It additionally needs PyGObject, which the open deploy image deliberately does
+# not ship (the GStreamer media stack is OpenRAL Pro), so no CI surface can run
+# it. `just test` picks it up on a dev host that has the `gstreamer` extra.
+#
+# `python` resolves to the workspace venv: `just` invokes this under `uv run`,
+# and the image puts /workspace/.venv/bin first on PATH.
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+TARGETS=(
+    tests/integration/test_reasoner_node_end_to_end.py
+    tests/integration/test_reasoner_dispatch_robustness.py
+    tests/integration/test_reasoner_async_llm.py
+    tests/integration/test_reasoner_vram_pair_refusal.py
+    tests/integration/test_reasoner_vram_eviction.py
+    tests/integration/test_critic_producer_node.py
+)
+
+export OPENRAL_TEST_ROS_LIVE=1
+
+exec python -m pytest "${TARGETS[@]}" "$@"

--- a/tests/integration/test_critic_producer_node.py
+++ b/tests/integration/test_critic_producer_node.py
@@ -13,13 +13,13 @@ This is the deterministic counterpart of the live ``deploy sim`` run: it
 elements actually fire end-to-end. The only test double is the
 ``FakeToolUseClient`` at the LLM process boundary (CLAUDE.md §1.11).
 
-Gated on ``OPENRAL_TEST_ROS_LIVE=1`` like the sibling reasoner/failure-bus
-integration tests. Run with::
+Gated on ``OPENRAL_TEST_ROS_LIVE=1`` like the sibling reasoner integration
+tests, and listed in the live-ROS suite (``scripts/ros_live_tests.sh``). CI runs
+it inside ``openral:x86`` (the ``docker-build`` workflow). Locally::
 
-    just ros2-build
+    source /opt/ros/jazzy/setup.bash && just ros2-build
     source install/setup.bash
-    OPENRAL_TEST_ROS_LIVE=1 uv run pytest tests/integration/test_critic_producer_node.py \\
-        -v -p no:launch_testing -p no:launch_ros
+    just test-ros-live            # whole suite; `-k <expr>` narrows it
 """
 
 from __future__ import annotations

--- a/tests/integration/test_reasoner_async_llm.py
+++ b/tests/integration/test_reasoner_async_llm.py
@@ -18,12 +18,13 @@ plus a bounded dispatch/abort soak over the multithreaded executor.
 
 Gated on ``OPENRAL_TEST_ROS_LIVE=1`` like
 ``test_reasoner_node_end_to_end.py`` (rclpy + DDS init clash with glib
-pulled in by torch/pyarrow in the regular pytest invocation)::
+pulled in by torch/pyarrow in the regular pytest invocation). Part of the
+live-ROS suite (``scripts/ros_live_tests.sh``); CI runs it inside
+``openral:x86`` (the ``docker-build`` workflow). Locally::
 
-    just ros2-build
+    source /opt/ros/jazzy/setup.bash && just ros2-build
     source install/setup.bash
-    OPENRAL_TEST_ROS_LIVE=1 uv run pytest tests/integration/test_reasoner_async_llm.py \\
-        -v -p no:launch_testing -p no:launch_ros
+    just test-ros-live            # whole suite; `-k <expr>` narrows it
 """
 
 from __future__ import annotations

--- a/tests/integration/test_reasoner_dispatch_robustness.py
+++ b/tests/integration/test_reasoner_dispatch_robustness.py
@@ -27,11 +27,10 @@ failure mode. The only doubles: the free-VRAM reading is pinned via
 monkeypatch (process boundary — ``nvidia-smi``) and the fixture manifest is
 injected at the guard's seam.
 
-Gated on ``OPENRAL_TEST_ROS_LIVE=1`` like the rest of the live reasoner suite::
-
-    OPENRAL_TEST_ROS_LIVE=1 uv run pytest \\
-        tests/integration/test_reasoner_dispatch_robustness.py -v \\
-        -p no:launch_testing -p no:launch_ros
+Gated on ``OPENRAL_TEST_ROS_LIVE=1`` like the rest of the live reasoner suite
+(``scripts/ros_live_tests.sh``). CI runs it inside ``openral:x86`` (the
+``docker-build`` workflow); locally, after ``just ros2-build &&
+source install/setup.bash``, run ``just test-ros-live`` (``-k <expr>`` narrows).
 """
 
 from __future__ import annotations

--- a/tests/integration/test_reasoner_node_end_to_end.py
+++ b/tests/integration/test_reasoner_node_end_to_end.py
@@ -3,12 +3,15 @@
 Gated on ``OPENRAL_TEST_ROS_LIVE=1`` to match the convention in
 ``tests/integration/test_failure_bus.py`` / ``test_world_state_integration.py``
 (rclpy + DDS init clash with a glib pulled in by torch/pyarrow during the
-regular ``uv run pytest`` invocation). Run with::
+regular ``uv run pytest`` invocation).
 
-    just ros2-build
+Part of the live-ROS suite listed in ``scripts/ros_live_tests.sh``. CI runs it
+inside ``openral:x86`` (the ``docker-build`` workflow — the only CI surface with
+a real rclpy + colcon overlay). Locally::
+
+    source /opt/ros/jazzy/setup.bash && just ros2-build
     source install/setup.bash
-    OPENRAL_TEST_ROS_LIVE=1 uv run pytest tests/integration/test_reasoner_node_end_to_end.py \\
-        -v -p no:launch_testing -p no:launch_ros
+    just test-ros-live            # whole suite; `-k <expr>` narrows it
 
 The test exercises the full ``/openral/prompt_in/cli`` →
 ``/openral/prompt`` → reasoner tick → dispatch round-trip with a real

--- a/tests/integration/test_reasoner_vram_eviction.py
+++ b/tests/integration/test_reasoner_vram_eviction.py
@@ -12,14 +12,13 @@ This exercises the real reasoner node + a real active ``LifecycleNode`` standing
 in for the detector + a real ``ExecuteRskill`` ``ActionServer``; the only test
 double is ``FakeToolUseClient`` at the LLM process boundary (CLAUDE.md §1.11).
 
-Gated on ``OPENRAL_TEST_ROS_LIVE=1`` like the rest of
-``tests/integration/test_reasoner_node_end_to_end.py``. Run with::
+Gated on ``OPENRAL_TEST_ROS_LIVE=1`` like the rest of the live reasoner suite
+(``scripts/ros_live_tests.sh``). CI runs it inside ``openral:x86`` (the
+``docker-build`` workflow). Locally::
 
-    just ros2-build
+    source /opt/ros/jazzy/setup.bash && just ros2-build
     source install/setup.bash
-    OPENRAL_TEST_ROS_LIVE=1 uv run pytest \\
-        tests/integration/test_reasoner_vram_eviction.py -v \\
-        -p no:launch_testing -p no:launch_ros
+    just test-ros-live            # whole suite; `-k <expr>` narrows it
 """
 
 from __future__ import annotations

--- a/tests/integration/test_reasoner_vram_pair_refusal.py
+++ b/tests/integration/test_reasoner_vram_pair_refusal.py
@@ -14,13 +14,14 @@ three guard inputs set directly on the node (``__init__`` reads the reward /
 gpu-total params at construction, before a test can set them — the param→attr
 plumbing is covered live by the VRAM-pair-refusal ARMED log).
 
-Gated on ``OPENRAL_TEST_ROS_LIVE=1`` like the rest of the live reasoner suite::
+Gated on ``OPENRAL_TEST_ROS_LIVE=1`` like the rest of the live reasoner suite
+(``scripts/ros_live_tests.sh``). CI runs it inside ``openral:x86`` (the
+``docker-build`` workflow) — this file is the falsification test for issue #46:
+a structurally dead ``_refuse_unfittable_vla`` turns it red. Locally::
 
-    just ros2-build
+    source /opt/ros/jazzy/setup.bash && just ros2-build
     source install/setup.bash
-    OPENRAL_TEST_ROS_LIVE=1 uv run pytest \\
-        tests/integration/test_reasoner_vram_pair_refusal.py -v \\
-        -p no:launch_testing -p no:launch_ros
+    just test-ros-live            # whole suite; `-k <expr>` narrows it
 """
 
 from __future__ import annotations

--- a/tests/unit/test_gstreamer_perception_tee.py
+++ b/tests/unit/test_gstreamer_perception_tee.py
@@ -259,6 +259,14 @@ def test_topic_prefix_locked_to_adr_path() -> None:
 # clash with a glib pulled in by torch/pyarrow during the regular pytest run.
 # Importorskips live *inside* the test function so the pure-Python tests above
 # stay collectible on hosts without PyGObject / rclpy.
+#
+# Deliberately NOT in the CI live-ROS suite (``scripts/ros_live_tests.sh``,
+# issue #46): unlike the reasoner tests it also needs PyGObject, and the only CI
+# image with a real rclpy is ``openral:x86`` — THE gstreamer-free deploy image
+# (the media stack is OpenRAL Pro). No CI surface has gi + rclpy together, so
+# wiring it up would buy a guaranteed skip. Retiring the gate would not help
+# either: it is a crash guard, not just an availability check. `just test` runs
+# this file on a dev host that has the ``gstreamer`` extra installed.
 
 _LIVE_ROS = bool(os.getenv("OPENRAL_TEST_ROS_LIVE"))
 _LIVE_ROS_REASON = (


### PR DESCRIPTION
## What changed

**The issue's premise needed correcting first.** It says "the workflows already
build the colcon overlay for `launch_testing` integration tests, so the
environment exists". They do not — there is no ROS CI job:

- `test-selective.yml` is the only test workflow with a PR trigger. It runs on a
  plain `ubuntu-24.04` runner with **no ROS 2 at all**; every gated test
  `importorskip`s there even with the variable set.
- `test-python.yml` and `hal.yml` are `workflow_dispatch:`-only ("out of Actions
  credits").
- `tools/test_selection.toml` still lists `.github/workflows/test-ros2.yml` in
  `full_run_globs` — that workflow does not exist. (Left alone here; inert
  dangling glob, pre-existing, not this PR's scope per CLAUDE.md §1.15.)

The one PR-triggered job with a real ROS 2 + colcon overlay is **`docker-build`**,
which builds `openral:x86` (ROS Jazzy + `colcon build` of `openral_msgs`,
`openral_reasoner_ros`, `openral_prompt_router`, …). That is where the tests now run.

1. **`scripts/ros_live_tests.sh`** — new. Owns the target list and sets
   `OPENRAL_TEST_ROS_LIVE=1`. Single source of truth: both callers exec it, so
   the dev loop and CI cannot drift apart.
2. **`.github/workflows/docker-build.yml`** — new "Live ROS tests" step runs that
   script inside the freshly-built image. `tests/`, `conftest.py` and `scripts/`
   are bind-mounted (the deploy image ships a runtime, not a test tree), which
   also guarantees the PR's tests run against the PR's image. `paths:` extended
   so a diff touching only these tests still triggers the job.
3. **`Justfile`** — `just test-ros-live` (issue option 2), same script.
4. **Docs** — `docs/contributing/development.md` gains a "live-ROS suite"
   section; the six test-module docstrings swap their hand-typed
   `OPENRAL_TEST_ROS_LIVE=1 uv run pytest …` incantations for the one command.

### File-by-file decision (option 1 vs 3), as requested

| File | Decision | Why |
| --- | --- | --- |
| `test_reasoner_node_end_to_end.py` (21) | → CI | needs real rclpy + DDS + overlay; all present in `openral:x86` |
| `test_reasoner_dispatch_robustness.py` (3) | → CI | same |
| `test_reasoner_async_llm.py` (5) | → CI | same |
| `test_reasoner_vram_pair_refusal.py` (2) | → CI | same; **this is the falsification test** |
| `test_reasoner_vram_eviction.py` (1) | → CI | same |
| `test_critic_producer_node.py` (1) | → CI | same |
| `tests/unit/test_gstreamer_perception_tee.py` (1 gated) | **gate kept** | also needs PyGObject. `openral:x86` is *the* GStreamer-free image by design (media stack is OpenRAL Pro), so no CI surface has `gi` + `rclpy` together — wiring it would buy a guaranteed skip. Option 3 rejected too: the gate is a documented **crash guard** (rclpy/DDS vs. a glib pulled in by torch/pyarrow), not just an availability check. Rationale recorded in-file. |
| `packages/openral_reasoner_ros/test/test_reasoner_node.py` | **no change needed** | it is **not gated** — plain `pytest.importorskip`; it only *mentioned* the variable in a stale docstring, which is why the issue's grep caught it. Docstring corrected. |

Test counts: 21+3+5+2+1+1 = **33**, matching the issue exactly. The gstreamer
file's 1 gated test and the un-gated colcon shim are the other two of the nine.

`tests/integration/test_reasoner_palette_primes_vram_gate.py` is listed in the
issue but is **not on `master`** — it lands with PR #44 (still open, based on
`fix/x86-compile-bytecode`). It is not in `TARGETS`; add it there when #44 merges.

## Why

A gated safety-adjacent gate can rot indefinitely with nothing watching. PR #44
found `_refuse_unfittable_vla` structurally dead for every VLA in the palette;
it surfaced only on real hardware, as a 20 s patience-ceiling timeout.

## How tested

The local host has ROS 2 Jazzy and a prebuilt `openral:x86`, so **the exact CI
command was run locally**, not approximated.

**Green** — the literal `docker run …` line from the new workflow step:

```
33 passed in 39.82s      EXIT=0        (~40 s, no GPU on the container)
```

**Red (acceptance criterion)** — `_refuse_unfittable_vla` made structurally dead
(`return False` inserted before its first statement, reproducing the PR #44 bug),
mounted over the image's installed `reasoner_node.py`, same command:

```
3 failed, 30 passed in 61.87s        DOCKER_EXIT=1

FAILED test_reasoner_dispatch_robustness.py::test_resident_vla_redispatch_skips_the_free_vram_probe
FAILED test_reasoner_vram_pair_refusal.py::test_execute_rskill_refused_when_vla_reward_pair_exceeds_vram
FAILED test_reasoner_vram_pair_refusal.py::test_execute_rskill_refused_when_live_free_vram_is_below_vla_min
```

The deliberate breakage was never committed — it lived only in a scratch file
bind-mounted over the container path. Worth noting: on `master` the pair-refusal
test does **not** merely stub the broken method (as the issue suspected); it
catches the dead gate on its own, so the criterion is met without #44's palette test.

Also run: `bash -n scripts/ros_live_tests.sh`, `just --list`, workflow YAML
parse, `ruff check` + `ruff format --check` clean on all changed Python.

**Not verifiable locally:** the real GitHub Actions run — whether the ~16 GB
image build plus this step fits the hosted runner's time/disk budget. The step
itself adds ~40 s and no disk. Only the first CI run on this PR can confirm that,
and this PR touches `.github/workflows/docker-build.yml`, so it will trigger.

Fixes #46

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
