### PR TITLE
ci(docker): registry-backed layer cache so PR builds stop rebuilding from zero

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,6 +9,13 @@ name: docker-build
 #   * push to master → build + push openral:x86 to GHCR
 # The `paths:` filter means it only runs when the image's build inputs change,
 # not on every commit. workflow_dispatch stays for manual runs (no push).
+#
+# The paths deliberately include python/**, packages/**, cpp/** and the lock
+# files: the image BAKES the code in (COPY + uv sync + colcon build), it does
+# not mount it, so code changes are real build inputs. Rebuild cost is kept
+# down by a registry-backed BuildKit layer cache on GHCR ($IMAGE:buildcache):
+# master pushes write it, every run reads it, so a typical PR reuses the
+# CUDA/apt/venv layers and only re-runs the layers its diff invalidates.
 on:
   workflow_dispatch:
   pull_request:
@@ -57,11 +64,47 @@ jobs:
           docker image prune -af || true
           df -h /
 
+      # Registry-backed layer cache: runners are ephemeral, so without this
+      # every run re-pulls the CUDA base, re-apt-installs ROS Jazzy, and
+      # re-resolves the full torch venv from zero (~30+ min). The docker-
+      # container driver is required — the default docker driver cannot
+      # export a registry cache.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+
+      # Cache reads need auth on pull_request runs too (the GHCR package may
+      # be private); GITHUB_TOKEN carries packages:read for same-repo PRs.
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # PRs only READ the cache (a PR cannot poison it); master pushes also
+      # WRITE it. mode=max exports the builder stage's layers too — that is
+      # where the expensive apt + uv-sync work lives in the multi-stage
+      # Dockerfile, and mode=min would only cache the final stage.
       - name: Build openral:x86 (GStreamer-free)
         run: |
+          cache_to=""
+          if [ "${{ github.event_name }}" = "push" ]; then
+            cache_to="--cache-to type=registry,ref=$IMAGE:buildcache,mode=max"
+          fi
+          # shellcheck disable=SC2086 -- intentional word-splitting of $cache_to.
           docker buildx build --progress=plain \
             -f docker/inference/Dockerfile.x86 \
+            --cache-from type=registry,ref=$IMAGE:buildcache \
+            $cache_to \
             -t openral:x86 --load .
+
+      # `--load` copies the image out of the buildkit container into dockerd,
+      # so both stores briefly hold it. Drop the buildkit copy before the
+      # smoke tests to keep the tight runner disk from filling.
+      - name: Reclaim buildkit store
+        run: |
+          docker buildx prune -af || true
+          df -h /
 
       # GStreamer-free deploy smoke: gi absent; cv2 / feetech / onnxruntime /
       # omdet present; `deploy run --dry-run` resolves the real launch.
@@ -89,15 +132,8 @@ jobs:
           docker run --rm openral:x86 | grep -qi "deploy"
           echo "OK: bare-openral entrypoint (doctor + default CMD)"
 
-      # Push only on merge to master (never on PRs).
-      - name: Log in to GHCR
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
+      # Push only on merge to master (never on PRs). GHCR login already
+      # happened above (it is needed unconditionally for the layer cache).
       - name: Tag + push to GHCR
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |


### PR DESCRIPTION
## What changed

`docker-build` gets a GHCR-backed BuildKit layer cache (`ghcr.io/openral/openral:buildcache`):

- **docker-container buildx driver** (the default driver can't export a registry cache), `setup-buildx-action` pinned at v4.2.0 (SHA verified against upstream tags).
- **Every run reads** the cache; **only master pushes write** it (`mode=max`, so the builder stage's expensive apt + uv-sync layers are covered). PRs can't poison the cache.
- GHCR **login moved ahead of the build and made unconditional** — cache reads need auth when the package is private, and `GITHUB_TOKEN` carries `packages:read` on same-repo PRs. The old master-only login step is dropped as redundant.
- New **"Reclaim buildkit store"** step after `--load`: the container driver briefly holds the ~16 GB image in both the buildkit store and dockerd, and the runner disk is tight.
- Header comment now explains *why* the paths filter includes `python/**`/`packages/**`/`cpp/**`: the image bakes the code in (`COPY` + `uv sync` + `colcon build`), it doesn't mount it — code changes are real build inputs, so narrowing the filter to the Dockerfile would ship stale images.

## Why

Runners are ephemeral and the build had **no cache backend at all**, so every PR touching `python/**` (nearly all of them) re-pulled the CUDA base, re-apt-installed ROS Jazzy, and re-resolved the full torch venv from zero — ~34 min per run, observed on #51/#52. The Dockerfile's layering already cooperates (lock files + `python/` copied before `packages/`/`cpp/`), so with a warm cache a typical PR only re-runs the layers its diff actually invalidates.

## How tested

- YAML parses; action SHAs verified via the GitHub API against upstream tags.
- This PR's own docker-build run exercises the cache-miss path (the `buildcache` ref doesn't exist yet — BuildKit warns and builds normally) plus the new driver/login/prune steps end to end.
- **Honest caveat:** the speedup itself can't be demonstrated inside this PR — the first cache *write* happens on the next master push, and the win shows on the PR after that. If this PR's build is green, the plumbing works; watch the first post-merge PR for the timing drop.

## Follow-up (not in scope)

`uv`'s `--mount=type=cache` contents aren't exported by `--cache-to` — if venv re-resolves (only when `python/**` changes) are still slow with a warm layer cache, the next lever is copying only the workspace `pyproject.toml`s before `uv sync` (needs `COPY --parents`, dockerfile syntax 1.7+).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ByRbL7CUntdRFnzuaRgk1N