### PR TITLE
chore(deps): tell dependabot to leave transformers alone

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,14 @@ updates:
     groups:
       python-deps:
         patterns: ["*"]
+    ignore:
+      # reason: the transformers ceiling is set by lerobot's own `transformers-dep`
+      # extra (`>=5.4.0,<5.6.0` on lerobot 0.6.0), so widening it here resolves to
+      # nothing. Dependabot re-raised the same no-op bump in #29/#33/#37 and also
+      # rewrote the group reason comments to assert a lerobot requirement that does
+      # not exist. Bump these pins by hand when lerobot's cap actually moves.
+      - dependency-name: "transformers"
+
   - package-ecosystem: docker
     directory: "/"
     schedule:


### PR DESCRIPTION
## What changed

One `ignore` entry in `.github/dependabot.yml` for `transformers` (bare `dependency-name`, no `versions`/`update-types` → ignores every update; grouped PRs exclude ignored deps).

## Why

The grouped `python-deps` PR keeps re-raising a transformers ceiling widening that **can never take effect** — #29 (closed), #33 (closed), #58 (open, `<5.14.0` → `<5.15.0`). `lerobot 0.6.0` declares `transformers>=5.4.0,<5.6.0` on its `transformers-dep` extra, aliased by `smolvla` / `pi` / `xvla` / `libero` / `groot` / `robometer` / …, so the resolver stays on 5.5.x regardless of the upper bound this repo states. Verified against the installed dist:

```
$ .venv/bin/python -c "import importlib.metadata as m; print([r for r in m.requires('lerobot') if 'transformers' in r][0]); print(m.version('transformers'))"
transformers<5.6.0,>=5.4.0; extra == "transformers-dep"
5.5.4
```

Dependabot additionally rewrites the per-group reason comments to assert a lerobot requirement that does not exist, making already-stale comments actively wrong. Bump the pins by hand when lerobot's own cap moves.

## How tested

`pre-commit` hooks pass (`check yaml` included); config parsed with `yaml.safe_load` to confirm the `ignore` list lands on the `pip` ecosystem entry and the `python-deps` group is untouched. No code paths affected — CI config only.

Closes #58 (closed separately as won't-do).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jzp5rBgRx8CzpqgjQdSiZJ