### PR TITLE
fix(deps): correct the PR references in the dependabot transformers ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
     ignore:
       # reason: the transformers ceiling is set by lerobot's own `transformers-dep`
       # extra (`>=5.4.0,<5.6.0` on lerobot 0.6.0), so widening it here resolves to
-      # nothing. Dependabot re-raised the same no-op bump in #29/#33/#37 and also
+      # nothing. Dependabot re-raised the same no-op bump in #18/#29/#33/#58 and also
       # rewrote the group reason comments to assert a lerobot requirement that does
       # not exist. Bump these pins by hand when lerobot's cap actually moves.
       - dependency-name: "transformers"


### PR DESCRIPTION
## What changed

One-word fix to the comment added in #60: `#29/#33/#37` → `#18/#29/#33/#58`.

## Why

`#37` is not a `python-deps` PR. The recurring no-op transformers bumps were #18, #29, #33 and #58 (`gh pr list --state all --search "python-deps in:title"`). A wrong reference in a permanent comment sends the next reader to an unrelated PR.

## How tested

Comment-only change to `.github/dependabot.yml`; `pre-commit`'s `check yaml` passes. No behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jzp5rBgRx8CzpqgjQdSiZJ