### PR TITLE
fix(safety): silence GCC 13's bogus -Wnonnull in the collision test

### DIFF
--- a/cpp/openral_safety_kernel/test/test_collision.cpp
+++ b/cpp/openral_safety_kernel/test/test_collision.cpp
@@ -8,6 +8,17 @@
 // wires this core into the live kernel. test_no_alloc-style counting proves
 // the hot path never allocates.
 
+// GCC 13 emits a bogus `-Wnonnull` from inside <vector> when this file is
+// built at -O3 (the Release build the x86 image uses): the fixtures below
+// assign brace-init-lists to `std::vector<Transform>`, and in
+// `_M_assign_aux`'s `else if (size() >= __len)` arm (bits/vector.tcc) a null
+// `_M_start` implies `size() == 0` and therefore `__len == 0`, so the flagged
+// `__builtin_memmove` sits in an unreachable block. `-Wnonnull` runs early in
+// the middle-end, before the pass that deletes that block, so it warns anyway
+// — upstream GCC PR 116851, still open, under root-cause PR 87489. Scoped to
+// the standard headers so `-Wnonnull` still covers this file's own code.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnonnull"
 #include "openral_safety_kernel/collision.hpp"
 
 #include <atomic>
@@ -15,6 +26,7 @@
 #include <cstdlib>
 #include <new>
 #include <vector>
+#pragma GCC diagnostic pop
 
 #include <gtest/gtest.h>
 

--- a/cpp/openral_safety_kernel/test/test_collision.cpp
+++ b/cpp/openral_safety_kernel/test/test_collision.cpp
@@ -582,8 +582,7 @@ TEST(BoxCapsuleDistance, DisjointAlongFaceNormalIsExact) {
   // clear), running vertically. Nearest box face is x=+0.05 → segment↔box gap
   // 0.2-0.05=0.15; minus the 0.02 capsule radius → 0.13.
   const osk::Vec3 h{0.05, 0.05, 0.05};
-  const double d =
-      osk::box_capsule_distance(identity(), h, translate(0.2, 0.0, 0.0), 0.02, 0.1);
+  const double d = osk::box_capsule_distance(identity(), h, translate(0.2, 0.0, 0.0), 0.02, 0.1);
   EXPECT_NEAR(d, 0.13, 1e-6);
 }
 
@@ -591,8 +590,7 @@ TEST(BoxCapsuleDistance, SegmentOnSurfaceGivesNegativeRadius) {
   // Capsule segment lies on the box's +x face (x=0.05) → segment↔box gap 0;
   // minus the radius → -0.02 (interpenetration by the radius).
   const osk::Vec3 h{0.05, 0.05, 0.05};
-  const double d =
-      osk::box_capsule_distance(identity(), h, translate(0.05, 0.0, 0.0), 0.02, 0.1);
+  const double d = osk::box_capsule_distance(identity(), h, translate(0.05, 0.0, 0.0), 0.02, 0.1);
   EXPECT_NEAR(d, -0.02, 1e-6);
 }
 
@@ -600,8 +598,7 @@ TEST(BoxCapsuleDistance, ClosestFeatureIsTopFace) {
   // Capsule above the top face; nearest endpoint at z=0.1 → gap 0.1-0.05=0.05,
   // minus radius 0.01 → 0.04.
   const osk::Vec3 h{0.05, 0.05, 0.05};
-  const double d =
-      osk::box_capsule_distance(identity(), h, translate(0.0, 0.0, 0.2), 0.01, 0.1);
+  const double d = osk::box_capsule_distance(identity(), h, translate(0.0, 0.0, 0.2), 0.01, 0.1);
   EXPECT_NEAR(d, 0.04, 1e-6);
 }
 
@@ -690,8 +687,7 @@ TEST(SelfCollisionBox, BoxBoxPairFiresAndClears) {
   m.origin = {identity(), identity()};
   m.axis = {{0, 0, 1}, {0, 0, 1}};
   m.box_link = {0, 1};
-  m.boxes = {osk::Obb{{0.05, 0.05, 0.05}, identity()},
-             osk::Obb{{0.05, 0.05, 0.05}, identity()}};
+  m.boxes = {osk::Obb{{0.05, 0.05, 0.05}, identity()}, osk::Obb{{0.05, 0.05, 0.05}, identity()}};
   m.allowed_pairs = {};
 
   osk::CollisionScratch s;


### PR DESCRIPTION
## What changed

Two commits on `cpp/openral_safety_kernel/test/test_collision.cpp` — test file only, no source, header, or safety behavior touched.

1. `fix(safety): clang-format the collision test file` — four pre-existing wraps violated the pinned clang-format v18 config, so pre-commit failed on any edit to the file (CLAUDE.md §1.15, separate prior commit). Pure reflow.
2. `fix(safety): silence GCC 13's bogus -Wnonnull in the collision test` — a `#pragma GCC diagnostic` pair scoped to the standard-header include block, with a comment explaining the diagnostic.

## Why

`docker/inference/Dockerfile.x86` builds the kernel with `-DCMAKE_BUILD_TYPE=Release` (`-O3`), where GCC 13 emits:

```
/usr/include/c++/13/bits/stl_algobase.h:437:30: warning: argument 1 null where non-null expected [-Wnonnull]
  437 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
```

inlined out of `std::vector<Transform>::_M_assign_aux`.

**This is not a defect in the kernel.** The fixtures assign brace-init-lists to `std::vector<Transform>` (`m.origin = {…}`, `s.link_world = {…}`). The flagged `memmove` lives in `_M_assign_aux`'s `else if (size() >= __len)` arm (`bits/vector.tcc:336`); a null `_M_start` there implies `size() == 0` and therefore `__len == 0`, so the destination is never null with a non-zero count. the flagged `memmove` sits in a block that is unreachable. `-Wnonnull` just runs early in the middle-end, before the pass that deletes it — upstream GCC **PR 116851** (open, `tree-optimization`), under root-cause **PR 87489**; upstream triage is explicit that it is a false positive, not real UB. Nothing to fix in our geometry or FK code — the only cost of leaving it is a noisy image build, and a landmine if anyone flips `-DOPENRAL_SAFETY_KERNEL_WERROR=ON` in the Release-build path.

The suppression is scoped to the standard headers rather than the whole translation unit, so `-Wnonnull` still covers the test's own code. Rewriting ~20 fixture lines to dodge a compiler artifact was the alternative and is worse: a noisy diff that someone will "clean up" back into the warning.

## How tested

- Reproduced on GCC 13.3: clean at `-O2`, warns at `-O3` — matching the image's Release build.
- After the fix, compiled `test_collision.cpp` at both `-O2` and `-O3` under the package's full warning set from `CMakeLists.txt` plus `-Werror`, with **g++ 13.3 and clang++**: all four combinations clean. (g++ `-O3 -Werror` fails to build before this commit.)
- Linked against `src/collision.cpp` and ran the suite at `-O3`: **38/38 pass**.

## Safety review

CLAUDE.md §3 requires a safety-WG reviewer for anything under `cpp/openral_safety_kernel/`, so flagging that here. No hazard-log entry applies: no collision-checking behavior, envelope, or E-stop path changes, and no safety check is disabled — `-Wnonnull` remains enabled over all first-party code in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gen2MdWggNmSQEH6NMdFpH
