### PR TITLE
perf(ci): cut the docker-build PR loop from ~21 min by removing the --load tarball and fixing layer ordering

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,87 @@
+# Build-context exclusions shared by every Dockerfile built with the repo root
+# as its context: `docker/inference/Dockerfile.x86` (the open deploy image) and
+# `Dockerfile.dev` (the dev shell).
+#
+# This file was previously *gitignored* (a `# Docker` / `.dockerignore` pair in
+# `.gitignore`), so the repo shipped without one and every build sent the whole
+# working tree — including `.git` and whatever local `build/` / `install/` /
+# `.venv/` happened to be lying around. On CI that is only a 34 MB / 0.4 s
+# transfer, so this is NOT a speed fix; it is a *determinism* fix. Without it a
+# contributor's local `just docker-build-x86` hashes a different context than
+# CI does (their `.venv/` and colcon `build/` are in it, CI's are not), so the
+# two disagree about which layers are cache-valid and local builds re-run work
+# CI would have skipped.
+#
+# Everything the Dockerfiles actually COPY is deliberately NOT excluded:
+# pyproject.toml, uv.lock, python/, packages/, cpp/, robots/, rskills/,
+# benchmarks/, tools/, scenes/, docker/inference/entrypoint.sh. Verified: no
+# tracked file under any of those paths matches a pattern below.
+
+# VCS + CI metadata — never copied into an image.
+.git
+.gitignore
+.github
+
+# Docs and tests are not baked into the deploy image (it ships a runtime, not a
+# test tree). docker-build.yml bind-mounts tests/ + conftest.py + scripts/ from
+# the checkout at run time for the live-ROS suite, so excluding them from the
+# build context does not affect that.
+docs
+site
+tests
+.agents
+
+# Python build/venv artifacts.
+**/__pycache__
+**/*.py[cod]
+**/*.egg-info
+.venv
+.venv-*
+dist
+.eggs
+
+# Test/lint caches.
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.hypothesis
+htmlcov
+.coverage
+coverage.xml
+
+# colcon artifacts. The image runs its own `colcon build` into a clean
+# /workspace; a host-built tree leaking in would shadow it with binaries linked
+# against the host's ROS, not the image's.
+build
+install
+log
+build_py312
+install_py312
+.colcon-build
+
+# Agent/editor scratch.
+.claude
+.worktrees
+.impeccable
+.superpowers
+.vscode
+.idea
+*.swp
+*~
+
+# Large local-only artifacts that are never image inputs.
+example_videos
+outputs
+mjx_tmp
+unsloth_compiled_cache
+.cache
+docker/inference/deepstream/*.tbz2
+
+# Secrets — belt and braces; these are gitignored too, but a build context is
+# a second way for them to leave the host.
+*.pem
+*.key
+*.p12
+*.pfx
+*.env
+!.env.example

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,12 +8,15 @@
 <!-- Unit / integration / sim / hardware. Paste `pytest` summary. -->
 
 ## Checklist
-- [ ] Conventional commit title
-- [ ] Schemas: on-disk `schema_version` stays at `"0.1"` (pre-publish); change validated against a real fixture under `robots/` / `rskills/` / `scenes/`
-- [ ] Layer boundary: ADR added (if crossed)
-- [ ] Tests added/updated
-- [ ] Docs updated (if public surface changed)
+<!-- Mirrors CLAUDE.md §4.4 — keep the two in sync when either changes. -->
+- [ ] Conventional commit title; description has "What changed", "Why", "How tested"
+- [ ] Schemas: real fixture under `robots/` / `rskills/` / `scenes/` validates; on-disk `schema_version` bumped + migrator shipped for any backward-incompatible change (post-publish — no longer frozen at `"0.1"`)
+- [ ] Layer boundary crossed → decision recorded in the private management decision log (`OpenRAL/management`, `adr/`)
+- [ ] Tests: unit + integration + sim where applicable; HIL if a HAL changed. No new mocks/stubs/smoke tests (CLAUDE.md §1.11)
+- [ ] The matching `docs/methods/` file updated for every added/renamed/removed/moved public symbol; `tools/refresh_methods_linenos.py --check` clean
+- [ ] Docs updated in the same PR (READMEs, `docs/`, ADRs) — no follow-up deferrals
+- [ ] Pre-existing errors fixed in a separate prior `fix(...)` commit
 - [ ] Repo state map (`docs/architecture/repo-state-map.html`) updated if a module was added, renamed, removed, or its `green` / `yellow` / `blue` / `red` status flipped (CLAUDE.md §4.3)
-- [ ] No new `try/except: pass` on actuation path
-- [ ] No new safety-disabling flag
-- [ ] Licenses of new deps reviewed
+- [ ] `just lint` passes; `mypy --strict` clean; no new `# type: ignore` without `# reason: ...`; no new `try/except: pass`; no new global mutable state
+- [ ] No new safety-disabling flag; no new `try/except: pass` on the actuation path
+- [ ] Performance budgets met if relevant; no PII in fixtures/logs; new deps Apache-2.0 / MIT / BSD (no GPL without TSC review)

--- a/.github/workflows/docker-build-cache-cleanup.yml
+++ b/.github/workflows/docker-build-cache-cleanup.yml
@@ -1,0 +1,78 @@
+name: docker-build-cache-cleanup
+# Deletes the PR-scoped BuildKit layer cache that `docker-build.yml` writes.
+#
+# That workflow gives every same-repo PR its own `$IMAGE:buildcache-pr-<n>` ref
+# so successive commits on a branch reuse each other's layers instead of each
+# rebuilding against the stale master cache. Those refs are `mode=max` exports
+# of a ~16 GB image, so without this they would accumulate in GHCR one per PR,
+# forever.
+#
+# Runs on PR close (merged or not). Fork PRs never get a cache ref written —
+# their GITHUB_TOKEN is read-only — so there is simply nothing to delete and the
+# job no-ops.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  packages: write  # deleting a package version this repo owns
+
+concurrency:
+  group: docker-build-cache-cleanup-${{ github.event.number }}
+  cancel-in-progress: false
+
+jobs:
+  delete-pr-cache:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Delete the PR's buildcache ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGE: openral  # ghcr.io/openral/openral
+          TAG: buildcache-pr-${{ github.event.number }}
+        run: |
+          set -euo pipefail
+
+          # The versions endpoint differs for org- vs user-owned packages and
+          # the wrong one 404s. Try the org route, then the user route. This is
+          # an explicit two-way probe, not a silent fallback: whichever one
+          # answers is logged, and failing both is a hard error.
+          versions=""
+          for scope in orgs users; do
+            if versions=$(gh api --paginate \
+                  "/$scope/$OWNER/packages/container/$PACKAGE/versions" 2>/dev/null); then
+              echo "Package is $scope-owned ($OWNER/$PACKAGE)."
+              break
+            fi
+            versions=""
+          done
+
+          if [ -z "$versions" ]; then
+            echo "::error::Could not list versions of $OWNER/$PACKAGE via either the orgs or users endpoint."
+            exit 1
+          fi
+
+          ids=$(printf '%s' "$versions" \
+            | jq -r --arg tag "$TAG" '.[] | select(.metadata.container.tags[]? == $tag) | .id')
+
+          if [ -z "$ids" ]; then
+            echo "No cache ref tagged '$TAG' — nothing to delete."
+            echo "(Expected for fork PRs, and for PRs whose diff never triggered docker-build.)"
+            exit 0
+          fi
+
+          # A tag resolves to exactly one version in practice, but the API
+          # models it as a list and a re-tagged ref could leave more than one.
+          for id in $ids; do
+            echo "Deleting package version $id (tag '$TAG')…"
+            for scope in orgs users; do
+              if gh api --method DELETE \
+                    "/$scope/$OWNER/packages/container/$PACKAGE/versions/$id" 2>/dev/null; then
+                echo "  deleted."
+                break
+              fi
+            done
+          done

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,7 +9,9 @@ name: docker-build
 #   * push to master → build + push openral:x86 to GHCR
 # The `paths:` filter means it only runs when the image's build inputs change
 # (or the live-ROS tests it hosts), not on every commit. workflow_dispatch stays
-# for manual runs (no push).
+# for manual runs: it never pushes an image, but it DOES write a scratch layer
+# cache ref (`:buildcache-dispatch`) so the registry cache export path can be
+# exercised on demand without touching the cache master reads.
 #
 # The paths deliberately include python/**, packages/**, cpp/** and the lock
 # files: the image BAKES the code in (COPY + uv sync + colcon build), it does

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -39,6 +39,9 @@ on:
   pull_request:
     paths:
       - docker/inference/**
+      # The build context definition: excluding a path here changes what every
+      # COPY sees, so it is a real build input.
+      - .dockerignore
       - pyproject.toml
       - uv.lock
       - packages/**
@@ -54,6 +57,9 @@ on:
     branches: [master]
     paths:
       - docker/inference/**
+      # The build context definition: excluding a path here changes what every
+      # COPY sees, so it is a real build input.
+      - .dockerignore
       - pyproject.toml
       - uv.lock
       - packages/**
@@ -145,12 +151,35 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # PRs only READ the cache (a PR cannot poison it); master pushes also
-      # WRITE it. mode=max exports the builder stage's layers too — that is
-      # where the expensive apt + uv-sync work lives in the multi-stage
-      # Dockerfile, and mode=min would only cache the final stage.
+      # `mode=max` on every export: it includes the builder stage's layers, not
+      # just the final stage's, and the builder is where the expensive apt +
+      # uv-sync work lives in this multi-stage Dockerfile.
+      #
+      # PRs previously READ the master cache and wrote nothing. That meant the
+      # second commit on a branch could not reuse anything the first commit had
+      # just built — every push re-ran the same work against the same stale
+      # master cache. A PR-scoped cache ref fixes that: commit N writes it,
+      # commit N+1 reads it, and the branch converges on "only my newest diff
+      # rebuilds".
+      #
+      # It is scoped per PR rather than shared because a shared writable cache
+      # is a cross-PR trust boundary — any contributor could poison the layers
+      # every other build imports. Fork PRs get a read-only GITHUB_TOKEN and so
+      # cannot write GHCR at all; they are detected here and left reading the
+      # master cache only, exactly as before.
+      #
+      # `docker-build-cache-cleanup.yml` deletes the ref when the PR closes.
       - name: Build openral:x86 (GStreamer-free)
         run: |
+          pr_cache=""
+          if [ "${{ github.event_name }}" = "pull_request" ] \
+             && [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
+            pr_cache="$IMAGE:buildcache-pr-${{ github.event.number }}"
+          fi
+
+          # Master's cache is always readable; the PR's own cache is listed
+          # first so buildkit prefers the fresher, branch-local layers.
+          cache_from="--cache-from type=registry,ref=$IMAGE:buildcache"
           cache_to=""
           case "${{ github.event_name }}" in
             push)
@@ -163,15 +192,25 @@ jobs:
               # master, where a broken exporter would fail the publish build.
               cache_to="--cache-to type=registry,ref=$IMAGE:buildcache-dispatch,mode=max"
               ;;
+            pull_request)
+              if [ -n "$pr_cache" ]; then
+                cache_from="--cache-from type=registry,ref=$pr_cache $cache_from"
+                cache_to="--cache-to type=registry,ref=$pr_cache,mode=max"
+                echo "PR-scoped layer cache: $pr_cache"
+              else
+                echo "Fork PR — reading the master cache only, no cache write."
+              fi
+              ;;
           esac
           # `--load` is a no-op under the docker driver (the build already
           # writes into the daemon's containerd store); it is kept so the
           # command still means the same thing if the driver is ever changed
           # back.
-          # shellcheck disable=SC2086 -- intentional word-splitting of $cache_to.
+          # shellcheck disable=SC2086 -- intentional word-splitting of the
+          # $cache_from / $cache_to flag strings.
           docker buildx build --progress=plain \
             -f docker/inference/Dockerfile.x86 \
-            --cache-from type=registry,ref=$IMAGE:buildcache \
+            $cache_from \
             $cache_to \
             -t openral:x86 --load .
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,6 +17,23 @@ name: docker-build
 # down by a registry-backed BuildKit layer cache on GHCR ($IMAGE:buildcache):
 # master pushes write it, every run reads it, so a typical PR reuses the
 # CUDA/apt/venv layers and only re-runs the layers its diff invalidates.
+#
+# ── Where the time actually goes ─────────────────────────────────────
+# Forensics on run 31244132105 (a PR build, 1058.9s in `docker buildx build`)
+# found the cost was mostly NOT cache misses — apt, the uv installer and the
+# whole runtime-base stage all hit cache:
+#   474.5s (45%)  `--load` exporting the 7.9 GB image to a tarball and
+#                 replaying it into dockerd, under the docker-container driver
+#   211.7s (20%)  colcon, of which 210s was opentelemetry_cpp_vendor and the
+#                 safety kernel it serially gates
+#   154.4s (15%)  pulling 4.59 GB of GHCR cache layers on steps that HIT cache
+#   115.3s (11%)  uv sync, re-downloading 4.42 GiB of wheels
+#    69.4s  (7%)  COPY --from=builder /workspace
+# The first, second and fourth are addressed by the containerd image store
+# below and by the layer split in docker/inference/Dockerfile.x86.
+#
+# Note what is NOT on that list: pushing to GHCR. The push step is gated on
+# `github.event_name == 'push'`, so it does not run on a PR at all.
 on:
   workflow_dispatch:
   pull_request:
@@ -75,13 +92,49 @@ jobs:
           docker image prune -af || true
           df -h /
 
+      # Switch dockerd to the containerd image store. This is what lets us drop
+      # the `docker-container` buildx driver, and it is the single biggest win
+      # in this workflow.
+      #
+      # With `docker-container`, buildkit runs in its own container with its own
+      # store, so `--load` has to serialize the finished image to a tarball and
+      # replay it into dockerd. On run 31244132105 that cost 474.5s of a 1058.9s
+      # build — 45% of the total — split as `exporting layers 278.1s` +
+      # `sending tarball 196.3s`, to move 7.9 GB that buildkit had *just*
+      # finished assembling. It is paid in full on every run, including a
+      # hypothetical 100% cache hit, which is why cache tuning alone could never
+      # get this workflow under ~11 minutes.
+      #
+      # With the containerd store, the built image lands directly in the store
+      # the daemon already reads from, so there is no export and no import. The
+      # historical reason for `docker-container` — "the default docker driver
+      # cannot export a registry cache" — is exactly what the containerd store
+      # lifts, so the registry layer cache below keeps working.
+      #
+      # Restarting dockerd discards any previously pulled images; nothing has
+      # been pulled at this point, and `Free runner disk` above already pruned.
+      - name: Enable the containerd image store
+        run: |
+          sudo mkdir -p /etc/docker
+          printf '%s\n' '{ "features": { "containerd-snapshotter": true } }' \
+            | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+          # Fail loudly rather than silently falling back to the overlay2 store
+          # and the tarball round-trip this step exists to remove.
+          docker info -f '{{ .DriverStatus }}'
+          docker info -f '{{ .DriverStatus }}' | grep -q 'io.containerd.snapshotter' || {
+            echo "::error::containerd image store did not come up; refusing to build"
+            exit 1
+          }
+
       # Registry-backed layer cache: runners are ephemeral, so without this
       # every run re-pulls the CUDA base, re-apt-installs ROS Jazzy, and
-      # re-resolves the full torch venv from zero (~30+ min). The docker-
-      # container driver is required — the default docker driver cannot
-      # export a registry cache.
+      # re-resolves the full torch venv from zero (~30+ min).
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+        with:
+          # The daemon's own buildkit, writing straight to the containerd store.
+          driver: docker
 
       # Cache reads need auth on pull_request runs too (the GHCR package may
       # be private); GITHUB_TOKEN carries packages:read for same-repo PRs.
@@ -99,9 +152,22 @@ jobs:
       - name: Build openral:x86 (GStreamer-free)
         run: |
           cache_to=""
-          if [ "${{ github.event_name }}" = "push" ]; then
-            cache_to="--cache-to type=registry,ref=$IMAGE:buildcache,mode=max"
-          fi
+          case "${{ github.event_name }}" in
+            push)
+              cache_to="--cache-to type=registry,ref=$IMAGE:buildcache,mode=max"
+              ;;
+            workflow_dispatch)
+              # Exercise the registry cache EXPORT path on demand, against a
+              # scratch ref that master never reads. This is how you validate a
+              # change to the build driver or the image store before it reaches
+              # master, where a broken exporter would fail the publish build.
+              cache_to="--cache-to type=registry,ref=$IMAGE:buildcache-dispatch,mode=max"
+              ;;
+          esac
+          # `--load` is a no-op under the docker driver (the build already
+          # writes into the daemon's containerd store); it is kept so the
+          # command still means the same thing if the driver is ever changed
+          # back.
           # shellcheck disable=SC2086 -- intentional word-splitting of $cache_to.
           docker buildx build --progress=plain \
             -f docker/inference/Dockerfile.x86 \
@@ -109,12 +175,16 @@ jobs:
             $cache_to \
             -t openral:x86 --load .
 
-      # `--load` copies the image out of the buildkit container into dockerd,
-      # so both stores briefly hold it. Drop the buildkit copy before the
-      # smoke tests to keep the tight runner disk from filling.
-      - name: Reclaim buildkit store
+      # Under the docker driver there is no second copy of the image to reclaim
+      # — that was the `docker-container` tarball round-trip. What is left is
+      # buildkit's own build cache (intermediate layers, the uv cache mount),
+      # which is dead weight once the image exists and is worth dropping on a
+      # runner whose disk is this tight. The image itself lives in the
+      # containerd store and is unaffected.
+      - name: Reclaim build cache
         run: |
           docker buildx prune -af || true
+          docker image ls
           df -h /
 
       # GStreamer-free deploy smoke: gi absent; cv2 / feetech / onnxruntime /

--- a/.gitignore
+++ b/.gitignore
@@ -34,9 +34,6 @@ build/
 *.mjb
 mjx_tmp/
 
-# Docker
-.dockerignore
-
 # Editors
 .vscode/
 .idea/

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -85,6 +85,12 @@ ENV PATH="/root/.local/bin:${PATH}"
 # just
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
 
+# The uv cache lives on a BuildKit cache mount and the target venv lives in the
+# image layer — two different filesystems, so uv's default hardlink install mode
+# always fails and falls back with a warning. Mirrors
+# `docker/inference/Dockerfile.x86`.
+ENV UV_LINK_MODE=copy
+
 WORKDIR /workspace
 
 # Copy the whole Python workspace before syncing. This used to copy only

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -108,6 +108,14 @@ WORKDIR /workspace
 # over /workspace at run time, which shadows this .venv entirely, so the sync
 # exists to prove the lockfile resolves and to populate the build host's uv
 # cache — not to ship a venv.
+#
+# `docker/inference/Dockerfile.x86` DOES need that cache win (it is the CI
+# image), and it now gets it a different way: a `manifests` stage prunes
+# `python/` to the members' real `pyproject.toml` files and `uv sync
+# --no-install-workspace` installs the third-party closure against those. That
+# is the supported version of what the hand-written stub trees were reaching
+# for. It is deliberately NOT replicated here — this image's venv is shadowed
+# at run time anyway, so the extra stage would buy nothing.
 COPY pyproject.toml uv.lock* ./
 COPY python/ python/
 

--- a/docker/inference/Dockerfile.x86
+++ b/docker/inference/Dockerfile.x86
@@ -236,9 +236,42 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         --group sim --group omdet --group lingbot \
     && uv pip install --python /workspace/.venv/bin/python onnxruntime opencv-python
 
-# Copy the colcon-buildable trees AFTER the venv resolve so a packages/ tweak
-# doesn't bust the (much larger) Python dep layer. `cpp/` carries the C++ safety
-# kernel + the opentelemetry_cpp_vendor package the kernel links against.
+# ── opentelemetry_cpp_vendor, on its own cache line ──────────────────
+#
+# This package clones and builds opentelemetry-cpp from source via
+# `ExternalProject_Add`, and it is the single most expensive thing in the image
+# after the Python deps: 154s of the 211.7s colcon step, measured on run
+# 31244132105. Worse, it is a *serial gate* — `openral_safety_kernel` links its
+# CMake targets and cannot start until it finishes, so the vendor build and the
+# kernel together accounted for 210 of those 211.7 seconds while the other 14
+# packages finished in parallel by t=92s.
+#
+# It is also the most stable thing in the image: `cpp/opentelemetry_cpp_vendor/`
+# is two files, and `cpp/` as a whole changed in 3 of the last 60 commits.
+# Copying it alone and building it alone gives it a cache key that a `packages/`
+# or `python/` diff cannot invalidate, which takes it off the critical path for
+# essentially every PR.
+#
+# It has no in-repo dependencies (`package.xml`: ament_cmake + curl), so it is
+# safe to build before any other tree is present. The kernel is NOT built here:
+# it also depends on `openral_msgs`, which lives under `packages/`.
+COPY cpp/opentelemetry_cpp_vendor/ cpp/opentelemetry_cpp_vendor/
+
+RUN bash -lc 'set -eo pipefail \
+    && source /opt/ros/${ROS_DISTRO}/setup.bash \
+    && set -u \
+    && colcon build --merge-install \
+        --base-paths cpp \
+        --packages-select opentelemetry_cpp_vendor \
+        --cmake-args -DCMAKE_C_COMPILER=/usr/bin/gcc \
+                     -DCMAKE_CXX_COMPILER=/usr/bin/g++ \
+                     -DCMAKE_BUILD_TYPE=Release \
+    && rm -rf build log'
+
+# The remaining colcon-buildable trees. Copied AFTER the venv resolve so a
+# packages/ tweak doesn't bust the (much larger) Python dep layer. `cpp/` carries
+# the C++ safety kernel (and re-lands the vendor sources copied above, which is
+# a no-op for the already-installed vendor prefix).
 COPY packages/ packages/
 COPY cpp/ cpp/
 
@@ -252,11 +285,19 @@ COPY benchmarks/ benchmarks/
 COPY tools/ tools/
 COPY scenes/ scenes/
 
-# Build every ROS 2 + C++ package the deploy image needs in one shot. The set
-# mirrors `just ros2-build` so the on-host dev loop and the image stay aligned —
-# including openral_perception_ros (the gstreamer-free ros_image_detector_node +
+# Build the remaining ROS 2 + C++ packages the deploy image needs. Together with
+# the opentelemetry_cpp_vendor build above this is 16 packages: the
+# deploy-relevant subset of `just ros2-build` (which additionally builds the
+# HALs and bringup packages for robots this image does not target), kept aligned
+# with it so the on-host dev loop and the image agree on the shared packages.
+# Includes openral_perception_ros (the gstreamer-free ros_image_detector_node +
 # reward_monitor_node) and the C++ safety kernel (binary lands at
 # /workspace/install/lib/openral_safety_kernel/safety_kernel_node).
+#
+# `source /workspace/install/setup.bash` overlays the vendor prefix built in the
+# earlier layer so `openral_safety_kernel` finds its opentelemetry-cpp CMake
+# targets. It is sourced BEFORE `set -u` because colcon's generated setup
+# scripts reference unbound variables.
 #
 # `Python3_EXECUTABLE=/workspace/.venv/bin/python` is essential so the
 # ament-python packages resolve openral_* + structlog against the venv, not the
@@ -265,11 +306,11 @@ COPY scenes/ scenes/
 # runtime stage copies install/ over and cross-tree symlinks would dangle.
 RUN bash -lc 'set -eo pipefail \
     && source /opt/ros/${ROS_DISTRO}/setup.bash \
+    && source /workspace/install/setup.bash \
     && set -u \
     && colcon build --merge-install \
         --base-paths packages cpp \
         --packages-select openral_msgs \
-                          opentelemetry_cpp_vendor \
                           openral_hal_so100 \
                           openral_hal_galaxea_a1 \
                           openral_hal_openarm \

--- a/docker/inference/Dockerfile.x86
+++ b/docker/inference/Dockerfile.x86
@@ -139,6 +139,15 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin s
 # moves cold-start skill loads back to seconds.
 ENV UV_COMPILE_BYTECODE=1
 
+# The uv cache lives on a BuildKit cache mount and the target venv lives in the
+# image layer — two different filesystems, so uv's default hardlink install
+# mode always fails and falls back, printing:
+#   warning: Failed to hardlink files; falling back to full copy.
+# Naming the copy mode up front skips the failed-hardlink probe on every one of
+# the ~229 installed packages and silences a warning that has been in every
+# build log to date.
+ENV UV_LINK_MODE=copy
+
 WORKDIR /workspace
 
 # Copy workspace metadata + lockfile first so dep resolution is layer-cacheable.

--- a/docker/inference/Dockerfile.x86
+++ b/docker/inference/Dockerfile.x86
@@ -50,6 +50,30 @@
 # `--network host` is recommended so the host can share the DDS bus. ROS 2
 # Jazzy + the local colcon overlay are sourced by the entrypoint.
 
+# ── Stage 0: workspace manifests ─────────────────────────────────────
+#
+# Prunes `python/` down to just the workspace members' `pyproject.toml` files.
+# The builder installs the third-party dependency set against THIS tree, not the
+# real one, so editing Python source no longer invalidates the dependency layer.
+#
+# Why a pruning stage instead of listing the manifests by hand: the uv workspace
+# is `members = ["python/*"]`, so a hand-written `COPY python/core/pyproject.toml
+# …` list silently drifts the moment a 15th package lands under `python/`. The
+# glob cannot drift.
+#
+# This stage re-runs on every `python/` edit (it takes ~3 s), but it emits a
+# byte-identical tree whenever no `pyproject.toml` changed. BuildKit keys the
+# downstream `COPY --from=manifests` on the *content* of what it copies, so the
+# expensive `uv sync` below stays cached across ordinary source edits.
+#
+# The base is the same CUDA image the builder uses, purely so this stage costs
+# no extra registry pull — nothing from the base is used beyond GNU find.
+FROM nvidia/cuda:13.0.0-cudnn-runtime-ubuntu24.04 AS manifests
+
+COPY python/ /manifests/python/
+RUN find /manifests/python -type f ! -name pyproject.toml -delete \
+    && find /manifests/python -depth -type d -empty -delete
+
 # ── Stage 1: builder ─────────────────────────────────────────────────
 
 FROM nvidia/cuda:13.0.0-cudnn-runtime-ubuntu24.04 AS builder
@@ -152,10 +176,34 @@ WORKDIR /workspace
 
 # Copy workspace metadata + lockfile first so dep resolution is layer-cacheable.
 COPY pyproject.toml uv.lock ./
-COPY python/ python/
 
-# Workspace install. Groups needed for a real VLA deploy with the perception
-# legs, all gstreamer-free:
+# The manifests-only view of `python/` (see stage 0). This is what the
+# third-party install below resolves against.
+COPY --from=manifests /manifests/python/ python/
+
+# ── Phase 1: third-party dependencies ────────────────────────────────
+#
+# `--no-install-workspace` installs the 215-package third-party closure (torch
+# 2.9.1, the whole nvidia-cu12 stack, transformers, lerobot, mujoco, …) and
+# skips every `openral-*` workspace member. Those members need no source tree to
+# be *excluded*, which is the entire point: this layer's cache key is
+# `pyproject.toml` + `uv.lock` + the 14 member manifests, and nothing else.
+#
+# Before this split, `COPY python/ python/` sat directly above the sync, so a
+# one-line edit to any Python source file — the most-churned tree in the repo,
+# 33 of the last 60 commits — re-downloaded 4.42 GiB of wheels (torch 858 MiB,
+# cudnn 674 MiB, cublas 567 MiB, …) and re-ran the whole builder stage. The uv
+# cache mount does NOT save you here: BuildKit cache mounts are not exported by
+# the registry cache exporter, so on an ephemeral CI runner it is always cold.
+#
+# An earlier attempt at this split (see Dockerfile.dev's comment) hand-wrote
+# *fake* stub src trees and failed — uv rejected them with "references a
+# workspace ... but is not a workspace member". Real manifests plus
+# `--no-install-workspace` is the supported path: uv never builds the members,
+# so it never looks for their sources.
+#
+# Groups needed for a real VLA deploy with the perception legs, all
+# gstreamer-free:
 #   sim   — the lerobot / transformers / accelerate / bitsandbytes stack the VLA
 #           policy adapters AND the in-process Robometer reward monitor import at
 #           load time (needed on REAL hardware too).
@@ -163,6 +211,18 @@ COPY python/ python/
 #           the ros_image_detector_node runs when enable_object_detector is on.
 #   lingbot — the msgpack + synchronous-websocket protocol dependencies used by
 #           the out-of-process LingBot policy adapters, including Galaxea A1.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --all-packages \
+        --group sim --group omdet --group lingbot \
+        --no-install-workspace
+
+# ── Phase 2: the workspace members themselves ────────────────────────
+#
+# Now the real source tree. This layer DOES rebuild on every Python edit, but
+# all it does is install the 14 local packages into the venv phase 1 already
+# populated — seconds, not minutes, and no network.
+COPY python/ python/
+
 # The `opencv_thread` camera path needs cv2 (opencv-python). It is a per-member
 # EXTRA (openral-runner `opencv`), NOT pulled by `uv sync --all-packages`, so it
 # is installed explicitly post-sync alongside onnxruntime (which lives only in

--- a/docker/inference/README.md
+++ b/docker/inference/README.md
@@ -174,6 +174,51 @@ onnxruntime / omdet present, `deploy run --dry-run` resolves) but does **not**
 push. On merge to `master` it builds and pushes `openral:x86` to GHCR. The image
 is ~16 GB, so the workflow frees runner disk before building.
 
+### Build caching
+
+The image is large and its code is baked in, not mounted, so a naive rebuild is
+~30 minutes. Four mechanisms keep an incremental PR build far below that. If you
+change the Dockerfile's layer order, keep them in mind — they are easy to defeat
+by accident.
+
+1. **Containerd image store, `docker` buildx driver.** The build writes straight
+   into the store dockerd reads from. Under the older `docker-container` driver,
+   `--load` had to serialize the finished 7.9 GB image to a tarball and replay it
+   into the daemon — 45% of total build time, paid on every run no matter how
+   good the cache was. The workflow asserts the snapshotter is active and fails
+   the job if it is not.
+
+2. **Registry-backed layer cache on GHCR.** `master` pushes write
+   `$IMAGE:buildcache` (`mode=max`, so the builder stage's layers are cached
+   too, not just the final stage); every run reads it.
+
+3. **Per-PR layer cache.** Same-repo PRs additionally read and write
+   `$IMAGE:buildcache-pr-<n>`, so the second commit on a branch reuses what the
+   first one built instead of starting again from the master cache. Fork PRs
+   have a read-only token and are detected and skipped. The ref is deleted when
+   the PR closes, by `docker-build-cache-cleanup.yml`.
+
+4. **Layer ordering that isolates the two expensive steps.** Two rules:
+   - **The dependency sync must not depend on Python source.** A `manifests`
+     stage prunes `python/` to the workspace members' `pyproject.toml` files, and
+     `uv sync --no-install-workspace` installs the 215-package third-party
+     closure against *that*. The real `python/` is copied afterwards and a second
+     sync adds the 14 local packages in ~2s. Copying `python/` before the sync —
+     the obvious-looking arrangement — makes every one-line source edit
+     re-download ~4.4 GiB of wheels. Note the BuildKit cache mount on
+     `/root/.cache/uv` does **not** save you: cache mounts are not exported by
+     the registry cache exporter, so on a fresh runner it is always cold.
+   - **`opentelemetry_cpp_vendor` gets its own layer.** It builds
+     opentelemetry-cpp from source and serially gates `openral_safety_kernel`,
+     together ~210s of the colcon step. It is copied and built before
+     `packages/` lands so that a `packages/` or `python/` diff cannot invalidate
+     it.
+
+To validate a change to the build driver or image store before it reaches
+`master`, run the workflow via **workflow_dispatch**: dispatch runs exercise the
+registry cache *export* path against a scratch `:buildcache-dispatch` ref that
+`master` never reads.
+
 ## Image sizes
 
 | Image | Size |


### PR DESCRIPTION
## What

Five commits that attack the four largest costs in `docker-build.yml`, measured from a real run rather than guessed: the `--load` tarball round-trip, the colcon critical path, the dependency layer's cache key, and the absence of any PR-scoped cache. Plus two `docs(ci)` commits correcting stale claims.

## Results (measured on this PR)

| | Build step | Total job |
|---|---|---|
| Baseline — old system, typical PR ([31244132105](https://github.com/OpenRAL/openral/actions/runs/31244132105)) | 1058.9s | 20m50s |
| This branch, cold rebuild ([31247284018](https://github.com/OpenRAL/openral/actions/runs/31247284018)) | 1269s | 24m07s |
| **This branch, warm cache ([31250800566](https://github.com/OpenRAL/openral/actions/runs/31250800566))** | **264s** | **7m06s** |

**Build step −75%, whole job −66%.** The warm run had **30 of 30 buildkit steps `CACHED`** — nothing in the Dockerfile executed.

## Why

`docker-build` took ~17m39s of build on every PR commit and re-ran that work for one-line diffs. Forensics showed the cost was mostly **not** cache misses — apt, the uv installer and the whole `runtime-base` stage already hit cache. Where the 1058.9s went:

| Phase | Time | Share |
|---|---|---|
| `--load` export to tarball + import into dockerd | 474.5s | 45% |
| `colcon build` | 211.7s | 20% |
| Pulling 4.59 GB of GHCR cache layers on steps that **hit** cache | 154.4s | 15% |
| `uv sync`, re-downloading 4.42 GiB of wheels | 115.3s | 11% |
| `COPY --from=builder /workspace` | 69.4s | 7% |

Two root causes of "every little commit rebuilds":

1. **`COPY python/ python/` sat directly above `uv sync`.** BuildKit named it the first cache-missing vertex; everything downstream re-ran. `python/` is the most-churned tree in the repo (33 of the last 60 commits) while `uv.lock` moved 6 times in 40.
2. **PR builds never wrote cache.** `cache_to` was gated on `push`, so commit N+1 could not reuse anything commit N built.

Worth stating since it was the initial suspicion: **the GHCR push is not implicated.** It is gated on `github.event_name == 'push'` and does not run on a PR.

## Verification

Confirmed from the warm run's build log:

- **Cache export works under the `docker` driver + containerd store** — the one item that could not be checked without a runner. `#43 exporting cache to registry … preparing build cache for export 11.8s done … DONE 11.8s`, no warnings, no errors. Both refs import cleanly, and `:buildcache-pr-68` comes back as an `image.index.v1+json` — i.e. written by the new exporter and read back successfully.
- **Tarball round-trip is gone** — `exporting to docker image format`, `sending tarball`, `importing to docker` have zero occurrences. Replaced by `exporting to image` → `unpacking`.
- **containerd store active** — `driver-type: io.containerd.snapshotter.v1`.
- **All four target layers CACHED** — `uv sync --no-install-workspace`, the `opentelemetry_cpp_vendor` colcon build, the 15-package colcon build, and the `manifests` stage.
- **`warning: Failed to hardlink files` is absent.**
- Functionally equivalent: both smoke tests pass and the live-ROS suite reports `42 passed in 50.81s`.

The two-phase `uv sync` was also validated locally against the real workspace before pushing: phase 1 installs the 215-package third-party closure with **zero** `openral-*` packages present; phase 2 over that venv takes **2.0s**, installs exactly the 14 members with no network, and all 14 import.

## Known remaining cost, and what I'd attack next

A 100% cache-hit build still costs 4m24s, and it is now ~97% image materialization rather than building:

- `#42 exporting to image` **249.5s**, of which `unpacking to docker.io/library/openral:x86` is **249.3s**
- `#41` lazy cache-import blob pull of ~8 GB from GHCR, **137.7s** (overlaps #42)

The final image is **25.2 GB**. (An earlier revision of this description said 7.9 GB — that was the compressed tarball layer sum from the old driver's log, not the image size. Corrected.) The job materializes all 25.2 GB to run three short `docker run` smoke checks. Shrinking the image, or decoupling the smoke checks from a full local materialization, is the next lever — deliberately **not** in this PR.

## Reviewer notes

**The first `master` build after merge will be slow (~1269s), once.** Master's `:buildcache` still holds old-Dockerfile layers, so the merge commit rebuilds them before writing the new cache. Every master build after that should be fast. This is the same one-time cost this branch's first run paid.

## Checklist
- [x] Conventional commit title; description has "What changed", "Why", "How tested"
- [ ] ~~Schemas~~ — N/A, no schema touched
- [ ] ~~Layer boundary~~ — N/A, no layer boundary crossed (build tooling only)
- [x] Tests: the two-phase sync validated against the real workspace; the image's own smoke + live-ROS suites pass on this PR's runs. No new mocks/stubs
- [x] Docs updated in the same PR — `docker/inference/README.md` gains a "Build caching" section covering all four mechanisms and the layer-ordering rules that are easy to defeat by accident
- [x] Pre-existing errors fixed in a separate prior `fix(...)` commit
- [ ] ~~Repo state map~~ — N/A, no module added, renamed, removed, or status-flipped
- [x] `just lint` unaffected — no Python changed
- [x] No new safety-disabling flag; no new `try/except: pass`
- [x] New deps: none. No new third-party Actions — the containerd store is enabled with a plain `run:` step against the runner's own docker