### PR TITLE
docs(ci): record the GHCR dedup the 3s push depends on, and correct the image size

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -42,6 +42,12 @@ on:
   pull_request:
     paths:
       - docker/inference/**
+      # ...but README.md is NOT a build input: it is never COPYed into the
+      # image and cannot change a layer. Without this negation a docs-only edit
+      # in this directory triggers a full image build (~7 min even on a total
+      # cache hit, because the image still has to be materialized). Negations
+      # must come AFTER the pattern they narrow — later patterns win.
+      - '!docker/inference/README.md'
       # The build context definition: excluding a path here changes what every
       # COPY sees, so it is a real build input.
       - .dockerignore
@@ -60,6 +66,12 @@ on:
     branches: [master]
     paths:
       - docker/inference/**
+      # ...but README.md is NOT a build input: it is never COPYed into the
+      # image and cannot change a layer. Without this negation a docs-only edit
+      # in this directory triggers a full image build (~7 min even on a total
+      # cache hit, because the image still has to be materialized). Negations
+      # must come AFTER the pattern they narrow — later patterns win.
+      - '!docker/inference/README.md'
       # The build context definition: excluding a path here changes what every
       # COPY sees, so it is a real build input.
       - .dockerignore
@@ -111,9 +123,8 @@ jobs:
       # build — 45% of the total — split as `exporting layers 278.1s` +
       # `sending tarball 196.3s`, to move 7.9 GB of compressed layers that
       # buildkit had *just* finished assembling. It is paid in full on every
-      # run, including a
-      # hypothetical 100% cache hit, which is why cache tuning alone could never
-      # get this workflow under ~11 minutes.
+      # run, including a hypothetical 100% cache hit, which is why cache tuning
+      # alone could never get this workflow under ~11 minutes.
       #
       # With the containerd store, the built image lands directly in the store
       # the daemon already reads from, so there is no export and no import. The

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,8 +24,9 @@ name: docker-build
 # Forensics on run 31244132105 (a PR build, 1058.9s in `docker buildx build`)
 # found the cost was mostly NOT cache misses — apt, the uv installer and the
 # whole runtime-base stage all hit cache:
-#   474.5s (45%)  `--load` exporting the 7.9 GB image to a tarball and
-#                 replaying it into dockerd, under the docker-container driver
+#   474.5s (45%)  `--load` exporting the image to a tarball (7.9 GB of
+#                 compressed layers; the image itself is 25.2 GB) and replaying
+#                 it into dockerd, under the docker-container driver
 #   211.7s (20%)  colcon, of which 210s was opentelemetry_cpp_vendor and the
 #                 safety kernel it serially gates
 #   154.4s (15%)  pulling 4.59 GB of GHCR cache layers on steps that HIT cache
@@ -90,7 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      # The image is ~16 GB (CUDA 13 + ROS Jazzy + colcon build). GitHub-hosted
+      # The image is ~25 GB (CUDA 13 + ROS Jazzy + colcon build). GitHub-hosted
       # runners ship ~14 GB free on /, so reclaim the big preinstalled toolchains
       # we don't need before building.
       - name: Free runner disk
@@ -108,8 +109,9 @@ jobs:
       # store, so `--load` has to serialize the finished image to a tarball and
       # replay it into dockerd. On run 31244132105 that cost 474.5s of a 1058.9s
       # build — 45% of the total — split as `exporting layers 278.1s` +
-      # `sending tarball 196.3s`, to move 7.9 GB that buildkit had *just*
-      # finished assembling. It is paid in full on every run, including a
+      # `sending tarball 196.3s`, to move 7.9 GB of compressed layers that
+      # buildkit had *just* finished assembling. It is paid in full on every
+      # run, including a
       # hypothetical 100% cache hit, which is why cache tuning alone could never
       # get this workflow under ~11 minutes.
       #

--- a/docker/inference/README.md
+++ b/docker/inference/README.md
@@ -172,7 +172,7 @@ change** (`docker/inference/**`, `pyproject.toml`, `uv.lock`, `packages/**`,
 `docker-smoke-x86-deploy` smoke (asserts `gi` absent, cv2 / feetech /
 onnxruntime / omdet present, `deploy run --dry-run` resolves) but does **not**
 push. On merge to `master` it builds and pushes `openral:x86` to GHCR. The image
-is ~16 GB, so the workflow frees runner disk before building.
+is ~25 GB, so the workflow frees runner disk before building.
 
 ### Build caching
 
@@ -223,5 +223,5 @@ registry cache *export* path against a scratch `:buildcache-dispatch` ref that
 
 | Image | Size |
 |---|---|
-| `openral:x86` (gstreamer-free) | ~16 GB |
+| `openral:x86` (gstreamer-free) | 25.2 GB |
 | `openral:x86-deepstream-latest` (built by openral-pro) | larger (adds the media stack) |

--- a/docker/inference/README.md
+++ b/docker/inference/README.md
@@ -219,6 +219,46 @@ To validate a change to the build driver or image store before it reaches
 registry cache *export* path against a scratch `:buildcache-dispatch` ref that
 `master` never reads.
 
+### Do not move the buildcache to another repository
+
+`$IMAGE:buildcache` deliberately lives in **the same GHCR repository as the
+image** (`ghcr.io/openral/openral`). Splitting it out to something like
+`ghcr.io/openral/openral-cache:buildcache` looks tidier and would silently cost
+several minutes per `master` build.
+
+GHCR deduplicates blobs per repository. Because `--cache-to
+type=registry,mode=max` writes every layer into `ghcr.io/openral/openral`, by
+the time `Tag + push to GHCR` runs, all of the image's layers are already there.
+Measured on master run 31253732623, the push is **16 × `Layer already exists`
+and 1 × `Pushed`** — the single new blob is the attestation manifest, which the
+cache export does not carry — so the whole step takes **3.3s**. Before the cache
+and the image shared a repository's dedup domain, that same step took **6m27s**.
+
+Two consequences worth internalising:
+
+- **The upload cost did not vanish, it moved.** The master cache export is
+  ~426s, against the ~387s the push used to cost. The publish path is roughly a
+  wash on its own; the win comes from the tarball round-trip disappearing
+  (build + push together: 1705s → 1353s). Do not read the 3.3s push as free.
+- **A separate cache repo breaks the dedup**, and the push reverts to uploading
+  the full image. Nothing will fail — CI stays green — the publish step just
+  quietly gets minutes slower. There is no test that catches this.
+
+### Where the remaining time goes
+
+After the above, neither a warm nor a cold build is dominated by compiling
+anything. Measured:
+
+| | Warm PR build (264s) | Cold master build (1350s) |
+|---|---|---|
+| Actual compilation | ~0s (30/30 steps `CACHED`) | 322s (uv sync 113s, vendor 104s, 15 pkgs 105s) |
+| Export / unpack / cache export | ~250s unpacking + 138s blob pull | 810s (60%) |
+
+So the lever for further speedup is **image size**, or decoupling the smoke
+checks from a full local image materialization — not more caching and not
+colcon. A 25.2 GB image is materialized in full to run three short
+`docker run` checks.
+
 ## Image sizes
 
 | Image | Size |


### PR DESCRIPTION
## What

Follow-up to #68, capturing two facts that only became visible once that PR's changes ran on real infrastructure, plus a small trigger-path fix.

## Why

**1. The `Tag + push to GHCR` step is now 3.3s where it was 6m27s, and nothing in the repo explains why.**

`--cache-to type=registry,mode=max` writes every layer into `ghcr.io/openral/openral` — the same repository the image is pushed to — and GHCR deduplicates blobs per repository. By the time the push runs, the layers are already there. Master run [31253732623](https://github.com/OpenRAL/openral/actions/runs/31253732623) shows:

```
16 × Layer already exists
 1 × Pushed          (the attestation manifest, which the cache export does not carry)
 0 × Mounted from
```

The failure mode this documents is silent. Moving the buildcache to a separate repo — `ghcr.io/openral/openral-cache:buildcache` is the obvious tidy-up someone will eventually propose — breaks the dedup and the push reverts to uploading the full 25.2 GB image. **CI stays green.** The publish step just quietly gets minutes slower, and there is no test that catches it.

The README now also records two things that are easy to misread from the timings:

- **The upload cost moved, it did not vanish.** The master cache export is ~426s against the ~387s push it displaced — the publish path is roughly a wash on its own. The real win is the tarball round-trip disappearing: build + push together, 1705s → 1353s. A reader seeing "3.3s push" would otherwise draw the wrong conclusion about where the budget went.
- **Neither a warm nor a cold build is compile-bound any more.** Compilation is 322s of a 1350s cold build; export/unpack is 810s (60%). On a warm build 30/30 steps are `CACHED` and essentially all 264s is materialization. The next lever is image size, not caching and not colcon.

**2. The image size was wrong in three places.** `docker image ls` on the master run reports `openral x86 f350d8544a4c 13 minutes ago 25.2GB`, against a documented `~16 GB`. That figure is load-bearing — it is the stated justification for the `Free runner disk` step, which reclaims space on a runner shipping ~14 GB free, so anyone assessing whether that step is still sufficient was working from a number ~9 GB too low.

Separately, the `7.9 GB` in the workflow header described the compressed layer blobs the old driver pushed through its tarball, not the image. Both numbers are real; the comments now say which is which.

**3. Docs-only edits under `docker/inference/` triggered a full image build.** `docker/inference/**` catches `README.md`, which is not a build input — never COPYed, cannot change a layer. Because the image must still be materialized into the containerd store even on a total cache hit, a documentation typo cost ~7 minutes of CI. Now excluded via `!docker/inference/README.md`, placed after the pattern it narrows (GitHub's `paths` negations are order-sensitive — later patterns win).

Scoped to `README.md` only, deliberately: `docker-compose.yaml` and `smoke_reasoner.py` in the same directory are also not baked into the image, but they are referenced by `just` targets and CI smoke steps, so excluding them is a judgement call rather than an obvious one.

## How tested

No build input is altered by any of the three commits. Every figure is quoted from the two runs named in the text ([31250800566](https://github.com/OpenRAL/openral/actions/runs/31250800566) warm PR, [31253732623](https://github.com/OpenRAL/openral/actions/runs/31253732623) master), read out of their build logs. The workflow parses as YAML and both `paths:` lists were verified to carry the negation in the correct position.

This PR still runs `docker-build`, because it also edits `.github/workflows/docker-build.yml`, which remains a trigger path — so the change is exercised rather than merged blind. The exclusion takes effect for future docs-only edits.

## Checklist
- [x] Conventional commit title; description has "What changed", "Why", "How tested"
- [ ] ~~Schemas~~ — N/A
- [ ] ~~Layer boundary~~ — N/A
- [ ] ~~Tests~~ — N/A; the figures come from CI runs, and the trigger-path change is exercised by this PR's own run
- [x] Docs updated in the same PR
- [x] Pre-existing errors fixed in a separate prior commit — the `~16 GB` correction is its own commit ahead of the new material
- [ ] ~~Repo state map~~ — N/A
- [x] `just lint` unaffected — no Python changed
- [x] No new safety-disabling flag
- [x] New deps: none