### PR TITLE
fix(release): corrections the first live release run exposed

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -27,14 +27,14 @@ name: release-pypi
 #   - PyPI (https://pypi.org): WORKING. 0.1.0 and 0.2.0 are published for all
 #     14 packages; the v0.2.0 tag push (run 30795961650) exchanged its OIDC
 #     token successfully.
-#   - TestPyPI (https://test.pypi.org): NOT REGISTERED for this owner/repo.
-#     Every `target=testpypi` dispatch fails the token exchange with
-#     `invalid-publisher: valid token, but no corresponding publisher`, most
-#     recently run 31258658584 on 2026-08-08 and three runs on 2026-07-09.
-#     The 0.1.0 files on TestPyPI predate the move into the OpenRAL org, so
-#     the publisher is presumably still bound to the old owner. Register one
-#     with the claims above to restore the trial-release path; until then
-#     `target=testpypi` is dead and the only working route is a v*.*.* tag.
+#   - TestPyPI (https://test.pypi.org): WORKING since 2026-08-08. 0.1.0 and
+#     0.2.0 are published for all 14 packages. It was broken up to that point
+#     — the publisher was still bound to the pre-org-move owner, so every
+#     `target=testpypi` dispatch died at the token exchange with
+#     `invalid-publisher: valid token, but no corresponding publisher`
+#     (run 31258658584, plus three on 2026-07-09). Re-registering the 14
+#     projects against the claims above fixed it. If that symptom returns,
+#     this is the first thing to check.
 #
 # Trusted publishing matches on the *ref*, so a claim set is not portable
 # between triggers: a tag push presents `ref: refs/tags/vX.Y.Z` while a

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -24,10 +24,24 @@ name: release-pypi
 # repo + this workflow file. Pending publishers cover names that don't exist
 # yet and need no org approval (https://docs.pypi.org/trusted-publishers/):
 #   owner: OpenRAL · repo: openral · workflow: release-pypi.yml · env: (none)
-#   - TestPyPI (https://test.pypi.org): already registered.
-#   - PyPI (https://pypi.org): register a pending publisher per project under
-#     the individual account, then dispatch target=pypi (or push a v*.*.* tag).
-#     Projects transfer into the OpenRAL org later with no re-publish.
+#   - PyPI (https://pypi.org): WORKING. 0.1.0 and 0.2.0 are published for all
+#     14 packages; the v0.2.0 tag push (run 30795961650) exchanged its OIDC
+#     token successfully.
+#   - TestPyPI (https://test.pypi.org): NOT REGISTERED for this owner/repo.
+#     Every `target=testpypi` dispatch fails the token exchange with
+#     `invalid-publisher: valid token, but no corresponding publisher`, most
+#     recently run 31258658584 on 2026-08-08 and three runs on 2026-07-09.
+#     The 0.1.0 files on TestPyPI predate the move into the OpenRAL org, so
+#     the publisher is presumably still bound to the old owner. Register one
+#     with the claims above to restore the trial-release path; until then
+#     `target=testpypi` is dead and the only working route is a v*.*.* tag.
+#
+# Trusted publishing matches on the *ref*, so a claim set is not portable
+# between triggers: a tag push presents `ref: refs/tags/vX.Y.Z` while a
+# workflow_dispatch off master presents `ref: refs/heads/master`. A publisher
+# registered without a ref restriction accepts both; one restricted to tags
+# rejects the dispatch. That difference is why the tag path can be green while
+# a dispatch is not.
 #
 # Every workspace package shares one lockstep version, and every `openral-*`
 # dependency pins it exactly — nothing here bumps it. `release-please.yml`

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -56,22 +56,25 @@ merge PRs to master  →  release-please computes the bump  →  release PR
 
 ## Check the release PR against `git log`
 
-release-please parses each commit message with a conventional-commits grammar.
-A message it cannot parse is **skipped silently** — no error, no entry in the
-changelog, no contribution to the bump. Large squash-merges are the usual
-casualty: GitHub composes the squash body from every sub-commit, and one
-prose line containing source syntax is enough to fail the whole message.
+release-please expands a squash-merge body: GitHub composes it from every
+sub-commit, and each `* type(scope): subject` line is parsed as its own
+entry. When the body fails the conventional-commits grammar — one prose line
+containing source syntax is enough — the expansion is **dropped silently**.
+The commit's own subject still lands, so the failure looks like a normal
+one-line entry rather than an error.
 
-A real example on this repo — `cc6182a` (PR #43), a 3658-line squash of ~150
-sub-commits, fails to parse on the body line:
+A real example on this repo: `cc6182a` (PR #43) is a 3658-line squash of ~150
+sub-commits whose body fails to parse on the line
 
 ```
 isinstance(x, (int, float)) admits bool
 ```
 
-Everything in that PR is therefore missing from the generated changelog,
-including a `refactor(reasoner)!` sub-commit with a `BREAKING CHANGE:` footer.
-Nothing warns you.
+In the 0.3.0 changelog it appears as a single line under **Changed** — its
+own subject, `perf(sensors): 9x faster skill load…`. The ~150 sub-commits are
+absent, and so is the `refactor(reasoner)!` sub-commit's `BREAKING CHANGE:`
+footer: 0.3.0 has no "⚠ BREAKING CHANGES" section even though the release
+removes the `OPENRAL_REASONER_LLM_*` contract. Nothing warns you.
 
 So before merging a release PR, diff its changelog against the range it
 covers:
@@ -82,8 +85,15 @@ git log --no-merges --format='%s' v<last>..origin/master
 
 Anything in that list with a user-facing type (`feat`, `fix`, `refactor`,
 `perf`) that is absent from the PR's changelog was dropped — add it by hand.
-The changelog body is editable, and editing it is the intended fix; the merged
-commit message cannot be corrected without rewriting `master`.
+Check large squashes line by line, and check for a missing "⚠ BREAKING
+CHANGES" section against `git log --grep='BREAKING CHANGE'`. The changelog
+body is editable, and editing it is the intended fix; the merged commit
+message cannot be corrected without rewriting `master`.
+
+A merge commit needs the same care in the other direction: keep its message
+free of any `type(scope): subject` line, or release-please parses the merge
+*and* the branch commit and the entry appears twice. The 0.3.0 changelog
+carries exactly that duplicate for `feat(release)` (`f1d1b1f` and `5ba709a`).
 
 Two habits keep this rare: prefer several focused PRs over one very large
 squash, and keep code snippets out of commit bodies (describe the fix in

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -142,33 +142,42 @@ Without the secret the job still runs and says so with a `::warning::`. Recover
 a stranded tag by dispatching `release-pypi.yml` manually with `target=pypi`,
 `confirm=YES`.
 
-## Trial runs — currently unavailable
+## Trial runs
 
 `release-pypi.yml` accepts a `workflow_dispatch` with `target=testpypi` (the
-default), which is meant to publish to TestPyPI without confirmation so you can
-validate packaging without burning a version number.
+default), which publishes to TestPyPI without confirmation. Use it to validate
+packaging without burning a version number — `skip-existing` means re-running
+it against an already-published version is a no-op, so it costs nothing.
 
-**It does not work today.** TestPyPI has no trusted publisher matching
-`OpenRAL/openral` + `release-pypi.yml`, so the OIDC exchange fails before
-anything is uploaded:
+It is worth doing before any release that changes packaging metadata, because
+it is the only way to see what installers will actually read. After it runs,
+check the published requirements rather than the source:
 
+```sh
+curl -s https://test.pypi.org/pypi/openral-cli/<version>/json \
+  | python3 -c "import sys,json;[print(r) for r in json.load(sys.stdin)['info']['requires_dist']]"
 ```
-invalid-publisher: valid token, but no corresponding publisher
-  sub: repo:OpenRAL/openral:ref:refs/heads/master
-  workflow_ref: OpenRAL/openral/.github/workflows/release-pypi.yml@refs/heads/master
-```
 
-Every `target=testpypi` dispatch has failed this way (run 31258658584 on
-2026-08-08; three more on 2026-07-09). The 0.1.0 files sitting on TestPyPI
-predate the move into the OpenRAL org, which is the likely reason the
-publisher no longer matches. Registering one with the claims in the
-`release-pypi.yml` header restores the path.
+The 0.2.0 trial confirmed every `openral-*` sibling carries its `==` pin, with
+extras and markers intact (`openral-observability[dashboard]==0.2.0`,
+`pygobject>=3.42; extra == "gstreamer"`). Neither `uv lock --check` nor the
+unit tests can show that — they read source, and `[tool.uv.sources]` is
+stripped at build time.
 
-Real PyPI is unaffected: its publisher works, and 0.1.0 and 0.2.0 are
-published for all 14 packages. Note that trusted publishing matches on the
-ref, so a tag push (`refs/tags/vX.Y.Z`) and a dispatch off master
-(`refs/heads/master`) present different claims — a green tag release does not
-imply a green dispatch.
+### When the token exchange fails
+
+A `invalid-publisher: valid token, but no corresponding publisher` error means
+the OIDC claims do not match any registered trusted publisher — nothing is
+uploaded. Register one per project with `owner: OpenRAL`, `repo: openral`,
+`workflow: release-pypi.yml`, and **no** environment name (the workflow
+declares none, so the claim is `environment: MISSING` and a publisher that
+expects one will never match).
+
+Trusted publishing also matches on the ref, so claims are not portable between
+triggers: a tag push presents `refs/tags/vX.Y.Z`, a dispatch off master
+presents `refs/heads/master`. A publisher with no ref restriction accepts
+both; one restricted to tags rejects the dispatch. A green tag release
+therefore does not imply a green dispatch, and vice versa.
 
 ## What is *not* versioned by this
 

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -142,11 +142,33 @@ Without the secret the job still runs and says so with a `::warning::`. Recover
 a stranded tag by dispatching `release-pypi.yml` manually with `target=pypi`,
 `confirm=YES`.
 
-## Trial runs
+## Trial runs — currently unavailable
 
-`release-pypi.yml` also accepts a `workflow_dispatch` with `target=testpypi`
-(the default), which publishes to TestPyPI without any confirmation. Use it to
-validate packaging changes without burning a version number.
+`release-pypi.yml` accepts a `workflow_dispatch` with `target=testpypi` (the
+default), which is meant to publish to TestPyPI without confirmation so you can
+validate packaging without burning a version number.
+
+**It does not work today.** TestPyPI has no trusted publisher matching
+`OpenRAL/openral` + `release-pypi.yml`, so the OIDC exchange fails before
+anything is uploaded:
+
+```
+invalid-publisher: valid token, but no corresponding publisher
+  sub: repo:OpenRAL/openral:ref:refs/heads/master
+  workflow_ref: OpenRAL/openral/.github/workflows/release-pypi.yml@refs/heads/master
+```
+
+Every `target=testpypi` dispatch has failed this way (run 31258658584 on
+2026-08-08; three more on 2026-07-09). The 0.1.0 files sitting on TestPyPI
+predate the move into the OpenRAL org, which is the likely reason the
+publisher no longer matches. Registering one with the claims in the
+`release-pypi.yml` header restores the path.
+
+Real PyPI is unaffected: its publisher works, and 0.1.0 and 0.2.0 are
+published for all 14 packages. Note that trusted publishing matches on the
+ref, so a tag push (`refs/tags/vX.Y.Z`) and a dispatch off master
+(`refs/heads/master`) present different claims — a green tag release does not
+imply a green dispatch.
 
 ## What is *not* versioned by this
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
   "pull-request-title-pattern": "chore(release): v${version}",
+  "group-pull-request-title-pattern": "chore(release): v${version}",
   "signoff": "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>",
   "changelog-sections": [
     { "type": "feat", "section": "Added" },


### PR DESCRIPTION
## What

Four corrections to the release automation from #70, each found by actually running it: the release PR title now names the version, and three documentation claims that turned out to be wrong are fixed against observed behaviour.

## Why

#70 was verified against release-please's updaters in isolation. Running it for real — PR #72 (`v0.3.0`) and two TestPyPI dispatches — surfaced things that offline verification could not.

**1. The release PR title ignored its pattern.** #72 came out as `chore: release master`, not `chore(release): v0.3.0`. A manifest release with `separate-pull-requests: false` is titled by the merge plugin, which reads `group-pull-request-title-pattern`; `pull-request-title-pattern` alone never applies to it. The merge plugin does pass the root release's version through (`plugins/merge.js` → `PullRequestTitle.ofComponentTargetBranchVersion`), so `${version}` resolves — verified rendering `chore(release): v0.3.0`. Config still validates against release-please's own JSON schema.

**2. The squash-hazard note overstated the loss.** `docs/contributing/releasing.md` claimed an unparseable squash body means "everything in that PR is missing from the generated changelog". The real pipeline is narrower: the commit's own subject still lands. `cc6182a` (PR #43) appears in 0.3.0 under **Changed** as `perf(sensors): 9x faster skill load…`; only the sub-commit expansion is dropped. That is still a real loss — ~150 sub-commits, and the `refactor(reasoner)!` `BREAKING CHANGE:` footer, so 0.3.0 has no "⚠ BREAKING CHANGES" section despite removing the `OPENRAL_REASONER_LLM_*` contract — but it fails as a plausible one-line entry rather than a visible gap, which makes the pre-merge diff against `git log` more important, not less. Adds a `git log --grep='BREAKING CHANGE'` cross-check.

Also documents the mirror-image trap the merge of #70 demonstrated: a merge commit whose message repeats a `type(scope): subject` line is parsed alongside the branch commit, so 0.3.0 lists `feat(release)` twice (`f1d1b1f` and `5ba709a`).

**3. TestPyPI was not registered, and the header said it was.** `release-pypi.yml` asserted "TestPyPI: already registered". Every `target=testpypi` dispatch had been failing the OIDC exchange with `invalid-publisher: valid token, but no corresponding publisher` — run `31258658584` plus three on 2026-07-09 — because the publisher was still bound to the pre-org-move owner. That stale comment is what made the trial-release path look available.

**4. …and then it was fixed, so that correction needed correcting too.** The 14 projects were re-registered on 2026-08-08 and 0.2.0 published to TestPyPI for all of them. The final state of this branch describes a working procedure, not an outage; the middle commit is kept so the history shows what was true when.

## How tested

The TestPyPI trial is the substantive test, and it validated the packaging fix from #70 in artifacts an installer actually reads:

```
openral-cli 0.2.0     → openral-core==0.2.0; openral-detect==0.2.0;
                        openral-observability[dashboard]==0.2.0; openral-rskill==0.2.0;
                        openral-sensors==0.2.0; openral-sim==0.2.0
openral-runner 0.2.0  → openral-core==0.2.0; openral-hal==0.2.0;
                        openral-observability==0.2.0; openral-rskill==0.2.0;
                        openral-world-state==0.2.0
openral-sim 0.2.0     → openral-core==0.2.0; openral-dataset==0.2.0;
                        openral-observability==0.2.0; openral-rskill==0.2.0;
                        openral-runner==0.2.0; openral-world-state==0.2.0
openral-sensors 0.2.0 → openral-core==0.2.0
```

Extras and environment markers survive the pin (`openral-observability[dashboard]==0.2.0`, `pygobject>=3.42; extra == "gstreamer"`), and third-party specifiers are untouched. Corroborated independently by building `openral-cli` locally and reading the wheel's `dist-info/METADATA` — same result, which also confirms `[tool.uv.sources]` is stripped at build time.

Config change verified by rendering the title pattern through release-please 17.11.1's own `PullRequestTitle`, and re-validating `release-please-config.json` against its published JSON schema.

Local gate:

```
ruff check .                              All checks passed!
mkdocs build --strict                     built, 0 warnings
pytest tests/unit/test_lockstep_versions.py   47 passed
release-pypi.yml                          YAML parses
```

No runtime code touched — workflow comments, one config key, and docs.

## Checklist

- [x] Conventional commit title; description has "What changed", "Why", "How tested"
- [x] Schemas: not touched
- [x] Layer boundary crossed → n/a (release infrastructure). The ADR flagged on #70 still applies and is still a maintainer action
- [x] Tests: existing `test_lockstep_versions.py` covers the config; no new behaviour to test — the changes are one config key and documentation. No new mocks/stubs
- [x] `docs/methods/` — no public symbol added, renamed, removed or moved
- [x] Docs updated in the same PR (that is most of the diff): `docs/contributing/releasing.md`, `release-pypi.yml` header
- [x] Pre-existing errors — n/a; every claim corrected here was introduced by #70 (mine), not pre-existing
- [x] Repo state map — not updated; no module added, renamed, removed or status-flipped
- [x] `mypy --strict` unaffected (no Python changed); no new `# type: ignore`, no new `try/except: pass`, no new global mutable state
- [x] No new safety-disabling flag; actuation path untouched
- [x] No new deps

## Note for #72

Merging #72 publishes 0.3.0 to real PyPI, where a version can be yanked but never replaced. Before merging, hand-edit its changelog to add PR #43's contents, add a ⚠ BREAKING CHANGES entry for the `OPENRAL_REASONER_LLM_*` removal, and drop the duplicate `feat(release)` line. Landing this PR first also means #72 gets retitled `chore(release): v0.3.0` on release-please's next run.

---
_Generated by [Claude Code](https://claude.ai/code/session_0122eFA4iQJh3RRv8LzwwMG5)_