### PR TITLE
fix(release): drop package-name — it made release-please unable to tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -22,7 +22,6 @@
   ],
   "packages": {
     ".": {
-      "package-name": "openral",
       "extra-files": [
         "python/cli/pyproject.toml",
         "python/core/pyproject.toml",


### PR DESCRIPTION
## What

Removes `"package-name": "openral"` from `release-please-config.json`. One line; it is what prevented v0.3.0 from being tagged.

## Why

#72 merged cleanly at 14:59:59, but no `v0.3.0` tag was ever created, so `release-pypi.yml` never fired and nothing published. Every subsequent release-please run reported `There are untagged, merged release PRs outstanding - aborting`.

That abort is a symptom, not the cause — it is the guard in `createPullRequests()` refusing to open a *new* release PR while a merged, untagged one exists. The real failure is upstream, in the release-building phase:

```
✔ Building release for path: .
⚠ PR component: undefined does not match configured component: openral
```

`strategies/base.js` `buildRelease()` compares the component parsed from the release branch against `getBranchComponent()`:

- The branch is `release-please--branches--master`. It has no `--components--` segment, so its component is `undefined`, normalising to `""`.
- `getBranchComponent()` is `this.component || getDefaultComponent()`. Unlike `getComponent()`, it does **not** honour `include-component-in-tag`, so it returned `"openral"` straight from `package-name`.
- `"" !== "openral"` → `buildRelease` returns nothing → no release, no tag, for any version.

This was never going to work. It is a defect in the original config from #70, not in the title-pattern change from #74 — I checked that separately: `PullRequestTitle.parse('chore(release): v0.3.0', 'chore(release): v${version}')` returns `0.3.0` correctly, and the retitle to `chore(release): v0.3.0` worked exactly as intended.

`package-name` was only ever cosmetic here. With `include-component-in-tag: false` the tag is `vX.Y.Z` regardless of it.

## How tested

The fix follows from the source rather than from guesswork:

```js
// strategies/base.js:95
async getDefaultPackageName() { return this.packageName ?? ''; }
// strategies/base.js:99
normalizeComponent(component) { if (!component) return ''; return component; }
```

With `package-name` removed, `getDefaultComponent()` → `normalizeComponent('')` → `""`, and `getBranchComponent()` → `"" `, which equals the branch's normalised `""`. The comparison passes and the release is built.

Verified against release-please 17.11.1's own sources and schema:

```
release-please-config.json                     VALID against schemas/config.json
pytest tests/unit/test_lockstep_versions.py    47 passed
```

The end-to-end proof is the next release-please run: it should tag v0.3.0 from the already-merged #72 rather than aborting.

## Note on the current state

`master` is correct at 0.3.0 with the curated changelog; #72 is merged and still labelled `autorelease: pending`. Nothing is half-published — PyPI has no 0.3.0, so there is no partial release to clean up.

I could not create the tag from this session: `git push origin v0.3.0` returns **HTTP 403** while a branch push succeeds, so these credentials are scoped to branches only. Once this lands, a release-please run should complete the release on its own; if it does not, creating the `v0.3.0` release from the GitHub UI against `be44176` will tag it and trigger the publish.

## Checklist

- [x] Conventional commit title; description has "What changed", "Why", "How tested"
- [x] Schemas: not touched
- [x] Layer boundary crossed → n/a (release infrastructure)
- [x] Tests: covered by the existing `test_lockstep_versions.py`; the defect is in release-please's own component matching, which is not reachable from a unit test here — the verification is the next release-please run
- [x] `docs/methods/` — no public symbol changed
- [x] Docs: no user-facing procedure changes; `docs/contributing/releasing.md` stays accurate
- [x] Pre-existing errors — n/a; this defect is mine, from #70
- [x] Repo state map — not updated; no module changed
- [x] `mypy --strict` unaffected (no Python changed)
- [x] No new safety-disabling flag; actuation path untouched
- [x] No new deps

---
_Generated by [Claude Code](https://claude.ai/code/session_0122eFA4iQJh3RRv8LzwwMG5)_