### PR TITLE
fix(release): fail the job when a release stalls between merge and tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -72,15 +72,41 @@ jobs:
 
       - name: summarise
         env:
-          RELEASED: ${{ steps.release.outputs.release_created }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          RELEASED: ${{ steps.release.outputs.releases_created || steps.release.outputs.release_created }}
           TAG: ${{ steps.release.outputs.tag_name }}
           PR: ${{ steps.release.outputs.pr }}
         run: |
           set -euo pipefail
           if [ "$RELEASED" = "true" ]; then
             echo "::notice::Released $TAG. release-pypi.yml publishes the 14 packages from this tag."
-          elif [ -n "$PR" ]; then
-            echo "::notice::Release PR is open and up to date. Merge it to cut the release."
-          else
-            echo "::notice::No releasable commits since the last tag (only hidden types: docs/test/style/ci/build/chore)."
+            exit 0
           fi
+          if [ -n "$PR" ]; then
+            echo "::notice::Release PR is open and up to date. Merge it to cut the release."
+            exit 0
+          fi
+
+          # No release and no PR. That is the normal outcome when nothing
+          # releasable merged — but it is ALSO exactly what a stuck release
+          # looks like, because release-please emits no outputs when it finds a
+          # merged release PR it cannot build a release from, and then declines
+          # to open a new one ("There are untagged, merged release PRs
+          # outstanding - aborting"). v0.3.0 sat in that state across two runs
+          # while this step cheerfully reported "no releasable commits", so the
+          # tag was never created and release-pypi.yml never ran.
+          #
+          # The two cases are indistinguishable from the action's outputs, so
+          # ask the repository instead: release-please labels its PR
+          # `autorelease: pending` when it opens it and swaps it to
+          # `autorelease: tagged` once the release exists. A MERGED PR still
+          # carrying `pending` is a release that stalled between those points.
+          stuck=$(gh pr list --state merged --label 'autorelease: pending' \
+                    --json number,title --jq '.[] | "#\(.number) \(.title)"' 2>/dev/null || true)
+          if [ -n "$stuck" ]; then
+            echo "::error::release-please created no release, but a merged release PR is still pending:"
+            printf '%s\n' "$stuck" | sed 's/^/  /'
+            echo "::error::No tag was created, so release-pypi.yml will not run and nothing will publish. Read this job's log above for why the release could not be built — a component/branch mismatch is the usual cause. See docs/contributing/releasing.md."
+            exit 1
+          fi
+          echo "::notice::No releasable commits since the last tag (only hidden types: docs/test/style/ci/build/chore)."

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -99,6 +99,33 @@ Two habits keep this rare: prefer several focused PRs over one very large
 squash, and keep code snippets out of commit bodies (describe the fix in
 prose, or fence the snippet in a PR comment instead).
 
+## When a release stalls between merge and tag
+
+release-please can find a merged release PR it cannot build a release from, and
+then decline to open a new one — logging `There are untagged, merged release
+PRs outstanding - aborting`. It emits no outputs in that state, which is
+byte-for-byte what "nothing releasable merged" looks like. v0.3.0 sat stalled
+across two runs before this was noticed; no tag was created, so nothing
+published.
+
+The `summarise` step in [`release-please.yml`](https://github.com/OpenRAL/openral/blob/master/.github/workflows/release-please.yml)
+now distinguishes them by asking the repository rather than the action: a
+**merged** PR still labelled `autorelease: pending` is a release that stopped
+between merging and tagging. The job fails loudly in that case.
+
+If you see that error, the reason is in the same job's log, above the abort —
+look for a line naming what could not be built. The one that bit us was:
+
+```
+⚠ PR component: undefined does not match configured component: openral
+```
+
+`getBranchComponent()` derives a component from `package-name` and, unlike
+`getComponent()`, ignores `include-component-in-tag`; the release branch has no
+component segment, so the two could never match. Removing `package-name` fixed
+it. Once the config is right, a re-run tags the already-merged PR — the PR does
+not need to be reopened or remade.
+
 ## What you have to do
 
 Write Conventional Commits (already required — [CLAUDE.md](https://github.com/OpenRAL/openral/blob/master/CLAUDE.md) §4.2).

--- a/tests/unit/test_lockstep_versions.py
+++ b/tests/unit/test_lockstep_versions.py
@@ -194,3 +194,35 @@ def test_selective_tests_short_circuit_the_release_pr() -> None:
             f"the guard must emit {output!r} — the full-suite step is gated on "
             "full_run alone, the rest on any."
         )
+
+
+def test_release_please_reports_a_stalled_release() -> None:
+    """A release that stalls between merge and tag must fail the job, not pass.
+
+    release-please emits no outputs when it finds a merged release PR it cannot
+    build a release from, then declines to open a new one. That is byte-for-byte
+    the same output as "nothing releasable merged", so the summarise step cannot
+    tell them apart from the action alone — it has to ask the repository whether
+    a merged PR is still labelled ``autorelease: pending``. v0.3.0 sat stalled
+    across two runs while the step reported success, and no tag was ever cut.
+    """
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github/workflows/release-please.yml").read_text(encoding="utf-8")
+    )
+    steps = workflow["jobs"]["release-please"]["steps"]
+    summarise = next(s for s in steps if s.get("name") == "summarise")
+    run = summarise["run"]
+
+    assert "autorelease: pending" in run, (
+        "the stalled-release check keys off release-please's pending label"
+    )
+    assert "--state merged" in run, "only a *merged* pending PR indicates a stall"
+    assert "::error::" in run and "exit 1" in run, (
+        "a stalled release must fail the job — reporting success is what hid it"
+    )
+    # The action sets releases_created in manifest mode; release_created is the
+    # single-package name. Reading only one silently misses a real release.
+    assert "releases_created" in summarise["env"]["RELEASED"], (
+        "manifest mode reports via releases_created"
+    )
+    assert "GH_TOKEN" in summarise["env"], "the label query needs an authenticated gh"


### PR DESCRIPTION
## What

Makes `release-please.yml`'s `summarise` step distinguish "nothing to release" from "the release stalled", and fail the job for the latter. Adds a regression test and documents the failure mode.

## Why

The step treated empty action outputs as "no releasable commits since the last tag". That is one of *two* causes of empty outputs, and it reported the wrong one at the worst possible moment.

When release-please finds a merged release PR it cannot build a release from, it emits no outputs at all and then declines to open a new one:

```
⚠ There are untagged, merged release PRs outstanding - aborting
```

**v0.3.0 sat in that state across two runs while this step printed a cheerful notice and the job went green.** No tag was created, so `release-pypi.yml` never fired and nothing published. The release looked finished and wasn't — the only visible symptom was packages failing to appear on PyPI, which is a slow and indirect way to learn that a release died.

The two cases produce identical outputs, so the action cannot tell them apart. The repository can: release-please labels its PR `autorelease: pending` when it opens it and swaps it to `autorelease: tagged` once the release exists. A **merged** PR still carrying `pending` is, by definition, a release that stopped between those two points.

## How

```sh
stuck=$(gh pr list --state merged --label 'autorelease: pending' --json number,title ...)
if [ -n "$stuck" ]; then
  echo "::error::release-please created no release, but a merged release PR is still pending:"
  ...
  exit 1
fi
```

Also reads `releases_created` before falling back to `release_created`. Manifest mode reports through the plural name, so reading only the singular could miss a real release and misreport it as nothing-to-do — the same class of bug in the other direction.

## How tested

Extracted the step's script straight from the workflow YAML and ran all four paths against a stubbed `gh`:

| Case | exit | first line |
| --- | --- | --- |
| released | 0 | `::notice::Released v0.3.1…` |
| release PR open | 0 | `::notice::Release PR is open and up to date…` |
| genuinely nothing to release | 0 | `::notice::No releasable commits…` |
| **merged PR still pending** | **1** | `::error::release-please created no release, but a merged release PR is still pending:` |

`test_release_please_reports_a_stalled_release` pins the invariant; reverting the `exit 1` to a no-op makes it fail, which I verified rather than assumed.

```
pytest tests/unit/test_lockstep_versions.py   48 passed
ruff check .                                  All checks passed!
mkdocs build --strict                         built, 0 warnings
release-please.yml                            YAML parses
```

No runtime code touched — one workflow step, one test, one docs section.

## Docs

`docs/contributing/releasing.md` gains a "When a release stalls between merge and tag" section: what the error means, that the reason is always in the same job log above the abort, and the concrete instance that caused this one —

```
⚠ PR component: undefined does not match configured component: openral
```

— plus the fact that once the config is fixed, a re-run tags the already-merged PR. The PR does not need to be reopened or remade, which was not obvious at the time.

## Checklist

- [x] Conventional commit title; description has "What changed", "Why", "How tested"
- [x] Schemas: not touched
- [x] Layer boundary crossed → n/a (release infrastructure)
- [x] Tests: unit added, mutation-verified. No new mocks/stubs — the `gh` stub is a process-boundary double used only in local verification, not committed
- [x] `docs/methods/` — no public symbol changed
- [x] Docs updated in the same PR
- [x] Pre-existing errors — n/a; this misreport is mine, from #70
- [x] Repo state map — not updated; no module changed
- [x] `mypy --strict` unaffected (no package code changed)
- [x] No new safety-disabling flag; actuation path untouched
- [x] No new deps (`gh` is preinstalled on GitHub-hosted runners)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122eFA4iQJh3RRv8LzwwMG5)_