### PR TITLE
fix(release): stop the version bump stopping at pyproject.toml (uv.lock + __version__)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,6 +52,18 @@ jobs:
       contents: write        # create the release commit, tag and GitHub release
       pull-requests: write   # open / update the release PR
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # Needed by the uv.lock step below, which pushes to the release
+          # branch. The default GITHUB_TOKEN can push, but its commits do not
+          # re-trigger the required checks — same reason the tag needs the app.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
       - name: check token
         env:
           HAS_APP_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN != '' }}
@@ -69,6 +81,40 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # release-please rewrites the 15 pyprojects and knows nothing about
+      # uv.lock — which records every workspace member's version too. Left
+      # alone, the lock keeps the *previous* release's numbers: master carried
+      # 0.3.1 pyprojects against a lock still saying 0.2.0, so every
+      # `uv sync --frozen` installed metadata a release behind, and every
+      # feature branch that touched dependencies re-locked 15 unrelated lines.
+      #
+      # release-please cannot do this itself: `extra-files` is a text
+      # substituter driven by `x-release-please-*` comments, and uv.lock is
+      # generated — the annotations would not survive the next `uv lock`. So
+      # regenerate it here and push it into the release PR, where the version
+      # bump belongs. `uv lock` without `--upgrade` rewrites only what the
+      # pyprojects changed; third-party pins keep their resolved versions.
+      - name: refresh uv.lock on the release PR
+        if: steps.release.outputs.pr
+        env:
+          PR: ${{ steps.release.outputs.pr }}
+        run: |
+          set -euo pipefail
+          branch=$(jq -r .headBranchName <<<"$PR")
+          git fetch --depth 1 origin "$branch"
+          git checkout "$branch"
+          uv lock
+          if git diff --quiet uv.lock; then
+            echo "::notice::uv.lock on $branch already matches the release version."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          # -s because DCO is a required check on the release PR too.
+          git commit -s -m 'chore(release): refresh uv.lock for the version bump' uv.lock
+          git push origin "HEAD:$branch"
+          echo "::notice::Pushed a refreshed uv.lock to $branch."
 
       - name: summarise
         env:

--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ The `openral` CLI lives in `.venv/bin/openral`. Run via `uv run openral ...` or 
 
 `uv run openral doctor` output on a working machine:
 
+<!-- Snapshot of a real run at v0.3.1. Every row is that machine's — the GPU,
+     the ROS paths and the openral-core version all move; nothing reads this. -->
+
 ```
          openral doctor
 ┏━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -188,7 +191,7 @@ The `openral` CLI lives in `.venv/bin/openral`. Run via `uv run openral ...` or 
 ┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
 │ Python             │ ok      │ 3.12.9                         │
 │ Platform           │ info    │ Linux 6.14.0                   │
-│ openral-core       │ ok      │ 0.2.0                          │
+│ openral-core       │ ok      │ 0.3.1                          │
 │ ROS 2 binary       │ ok      │ /opt/ros/jazzy/bin/ros2        │
 │ ROS 2 distro       │ ok      │ jazzy                          │
 │ RMW                │ info    │ rmw_fastrtps_cpp (default)     │

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A VLA alone is not an agent — OpenRAL wraps it in the loop it needs. It is a t
 
 We compose ROS 2, tf2, MoveIt 2 (with optional CUDA-accelerated **cuMotion** planning), Nav2, NVIDIA Isaac ROS (**cuVSLAM + nvblox** vision SLAM), and `ros2_control` — we don't reinvent them.
 
-**Shipped today** (all workspace packages at `0.2.0`):
+**Shipped today** (every workspace package ships at one lockstep version — see the PyPI badge):
 - `openral_core` schemas + the `openral` CLI (bare `openral` drops into a REPL)
 - HAL adapters for [15+ robot platforms](docs/reference/robots.md) — manipulators, mobile manipulators, bimanual arms, humanoids
 - [Sensor catalog](docs/reference/sensors_landscape.md) — RGB-D, F/T, and USB-UVC adapters

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -152,6 +152,13 @@ are rewritten by release-please via the `x-release-please-version` /
 `x-release-please-start-version` annotations in each `pyproject.toml`; editing
 around them puts the manifest and the tree out of sync.
 
+Nothing under `src/` carries a version either. Every package's `__version__`
+reads `importlib.metadata` for its own distribution, so it follows the
+pyproject release-please just rewrote. Hardcoded literals used to sit in
+eleven `__init__.py` files and nothing bumped them — the runtime announced
+0.2.0 out of a 0.3.1 wheel until this was fixed. `test_lockstep_versions.py`
+rejects a literal reintroduced there.
+
 ## Adding a package
 
 A new `python/<name>` package needs three edits, all enforced by

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -37,6 +37,17 @@ merge PRs to master  →  release-please computes the bump  →  release PR
    Review the number and the notes there — the changelog body is editable, so
    curate it in the PR if a release deserves a narrative.
 
+   It also carries a second commit, `chore(release): refresh uv.lock for the
+   version bump`, pushed by the same workflow. release-please only substitutes
+   text in the files `extra-files` names, and `uv.lock` is generated — it
+   records every workspace member's version, so a bump that stops at the
+   pyprojects leaves the lock a release behind (v0.3.0 and v0.3.1 both did:
+   master ran 0.3.1 pyprojects against a lock still saying 0.2.0, and
+   `uv sync --frozen` installed that stale metadata). The step runs `uv lock`
+   on the release branch; without `--upgrade` it rewrites only the 15 version
+   lines and leaves third-party pins alone. `test_lockstep_versions.py` fails
+   if the lock and the tree ever disagree again.
+
    Its CI is deliberately thin. `test-selective` short-circuits on the
    `release-please--*` branch and selects nothing: rewriting all 15 pyprojects
    matches the `pyproject.toml` full-run glob *and* marks every package

--- a/docs/reference/schemas/all.json
+++ b/docs/reference/schemas/all.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "openral_core",
-  "version": "0.3.1",
   "schemas": {
     "EmbodimentKind": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/python/cli/src/openral_cli/__init__.py
+++ b/python/cli/src/openral_cli/__init__.py
@@ -1,6 +1,8 @@
 """openral CLI — the `ros` command entry point."""
 
-__version__ = "0.2.0"
-__all__ = ["app"]
+from importlib.metadata import version as _pkg_version
 
 from openral_cli.main import app
+
+__all__ = ["app"]
+__version__ = _pkg_version("openral-cli")

--- a/python/detect/src/openral_detect/__init__.py
+++ b/python/detect/src/openral_detect/__init__.py
@@ -1,6 +1,6 @@
 """openral auto-provisioning — `openral detect` machinery."""
 
-__version__ = "0.2.0"
+from importlib.metadata import version as _pkg_version
 
 from openral_detect.assemble import assemble_robot_description, build_compute_spec
 from openral_detect.compatibility import (
@@ -57,3 +57,4 @@ __all__ = [
     "check_single_rskill",
     "detect_hardware",
 ]
+__version__ = _pkg_version("openral-detect")

--- a/python/reasoner/src/openral_reasoner/__init__.py
+++ b/python/reasoner/src/openral_reasoner/__init__.py
@@ -13,6 +13,8 @@ subscriptions and dispatch plumbing.
 
 from __future__ import annotations
 
+from importlib.metadata import version as _pkg_version
+
 from openral_reasoner.active_search import (
     SearchBudget,
     SearchCandidate,
@@ -125,4 +127,4 @@ __all__ = [
     "save_ladder_state",
     "should_rebuild_mission",
 ]
-__version__ = "0.2.0"
+__version__ = _pkg_version("openral-reasoner")

--- a/python/rskill/src/openral_rskill/__init__.py
+++ b/python/rskill/src/openral_rskill/__init__.py
@@ -29,6 +29,8 @@ TensorRT/NVMM fast path is a private OpenRAL Pro plugin); resolve it via
 ``resolve_runtime_backend("tensorrt")`` when ``openral-pro-trt`` is installed.
 """
 
+from importlib.metadata import version as _pkg_version
+
 from openral_rskill.backend_registry import maybe_attach_pro_hooks, resolve_runtime_backend
 from openral_rskill.base import rSkillBase
 from openral_rskill.engine_cache import DEFAULT_CACHE_DIR, EngineCache
@@ -56,4 +58,4 @@ __all__ = [
     "rSkillBase",
     "resolve_runtime_backend",
 ]
-__version__ = "0.2.0"
+__version__ = _pkg_version("openral-rskill")

--- a/python/runner/src/openral_runner/__init__.py
+++ b/python/runner/src/openral_runner/__init__.py
@@ -41,6 +41,7 @@ modules at import, and the resulting ``glib`` state conflicts with
 
 from __future__ import annotations
 
+from importlib.metadata import version as _pkg_version
 from typing import TYPE_CHECKING, Any
 
 # Light imports — no torch, no gi, no rclpy in any of these.
@@ -72,7 +73,7 @@ __all__ = [
     "precise_sleep",
     "sleep_until",
 ]
-__version__ = "0.2.0"
+__version__ = _pkg_version("openral-runner")
 
 
 _LAZY_ATTRS: dict[str, tuple[str, str]] = {

--- a/python/sensors/src/openral_sensors/__init__.py
+++ b/python/sensors/src/openral_sensors/__init__.py
@@ -17,6 +17,8 @@ Public surface:
 # Import every vendor module so the global CATALOG is populated on
 # `import openral_sensors`.  Order does not matter; each module registers
 # its own entries with replace=True.
+from importlib.metadata import version as _pkg_version
+
 from openral_sensors import (  # reason: side-effect import populates CATALOG
     force_torque,
     luxonis,
@@ -53,4 +55,4 @@ __all__ = [
     "realsense_d435_bundle",
     "realsense_d435i_bundle",
 ]
-__version__ = "0.2.0"
+__version__ = _pkg_version("openral-sensors")

--- a/python/sim/src/openral_sim/__init__.py
+++ b/python/sim/src/openral_sim/__init__.py
@@ -36,6 +36,8 @@ so installing this package never pulls heavyweight ML deps.
 
 from __future__ import annotations
 
+from importlib.metadata import version as _pkg_version
+
 # Trigger built-in policy + backend registration (LIBERO, MetaWorld, mock,
 # smolvla, …). Importing the two subpackages runs their `_register_*`
 # side effects.
@@ -64,4 +66,4 @@ __all__ = [
     "save_episode_mp4",
 ]
 
-__version__ = "0.2.0"
+__version__ = _pkg_version("openral-sim")

--- a/python/state_adapter/src/openral_state_adapter/__init__.py
+++ b/python/state_adapter/src/openral_state_adapter/__init__.py
@@ -5,6 +5,8 @@ Consumers (skill_runner, reasoner palette filter) call
 :func:`assemble_state` / :func:`registered_layouts`.
 """
 
+from importlib.metadata import version as _pkg_version
+
 from openral_state_adapter import (
     layouts as _layouts,  # reason: side-effect import — registers every shipped layout
 )
@@ -23,4 +25,4 @@ __all__ = [
     "register",
     "registered_layouts",
 ]
-__version__ = "0.2.0"
+__version__ = _pkg_version("openral-state-adapter")

--- a/python/wam/src/openral_wam/__init__.py
+++ b/python/wam/src/openral_wam/__init__.py
@@ -24,6 +24,8 @@ Layer 5 for what's planned next.
 
 from __future__ import annotations
 
+from importlib.metadata import version as _pkg_version
+
 from openral_wam.null_wam import NullWorldModel
 from openral_wam.protocol import WorldModel
 from openral_wam.rollout import Rollout
@@ -33,4 +35,4 @@ __all__ = [
     "Rollout",
     "WorldModel",
 ]
-__version__ = "0.2.0"
+__version__ = _pkg_version("openral-wam")

--- a/python/world_state/src/openral_world_state/__init__.py
+++ b/python/world_state/src/openral_world_state/__init__.py
@@ -22,6 +22,8 @@ Public surface:
   lift 2D detections to 3D object centres and remember them with IoU gating.
 """
 
+from importlib.metadata import version as _pkg_version
+
 from openral_world_state.aggregator import (
     DEFAULT_POLICY_STATE_STALENESS_S,
     DEFAULT_RATE_HZ,
@@ -101,4 +103,4 @@ __all__ = [
     "rotation_to_quat_wxyz",
     "scene_objects_payload",
 ]
-__version__ = "0.2.0"
+__version__ = _pkg_version("openral-world-state")

--- a/tests/unit/test_deps_install_plans.py
+++ b/tests/unit/test_deps_install_plans.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import importlib.metadata
 import sys
-import sysconfig
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -44,7 +43,44 @@ from openral_sim._deps import (
     get_plan,
 )
 
+# `uv pip` targets the venv it discovers from the *working directory*, which is
+# not necessarily the interpreter running pytest — from a git worktree it is a
+# different environment entirely, and an editable installed there never becomes
+# importable here. Every uv call these tests make is about their own process, so
+# say so explicitly.
+_UV_PIP_INSTALL = ["uv", "pip", "install", "--python", sys.executable]
+_UV_PIP_UNINSTALL = ["uv", "pip", "uninstall", "--python", sys.executable]
+
 # ─── Fix #1+2: shadow dir cleanup ─────────────────────────────────────────
+
+
+def _step_site_packages() -> Path:
+    """Where ``_remove_editable_shadow_step`` will actually look.
+
+    The step runs ``uv run python``, which resolves the *project* venv — not
+    necessarily the interpreter running pytest. Those differ whenever the suite
+    runs from a git worktree, or against a venv reached via ``PYTHONPATH``, and
+    planting the shadow under the wrong ``site-packages`` made the removal test
+    fail while the preservation test passed vacuously (the step reports "no
+    shadow to clean" both when the dir is protected and when it was never
+    there). Ask the step's own interpreter instead.
+    """
+    import subprocess
+
+    probe = subprocess.run(
+        [
+            _deps._uv(),
+            "run",
+            "--no-sync",  # a unit test must not trigger a workspace sync
+            "python",
+            "-c",
+            "import sysconfig; print(sysconfig.get_paths()['purelib'])",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(probe.stdout.strip())
 
 
 class TestRemoveEditableShadow:
@@ -68,7 +104,7 @@ class TestRemoveEditableShadow:
 
         # Build a fake shadow directly in the real site-packages, then
         # run the step and confirm it's gone.
-        sp = Path(sysconfig.get_paths()["purelib"])
+        sp = _step_site_packages()
         shadow_name = "shadow_test_pkg_xyz_42"
         shadow = sp / shadow_name
         shadow.mkdir()
@@ -94,7 +130,7 @@ class TestRemoveEditableShadow:
         """A site-packages dir WITH __init__.py is a real install — do not touch."""
         import subprocess
 
-        sp = Path(sysconfig.get_paths()["purelib"])
+        sp = _step_site_packages()
         pkg_name = "real_pkg_test_xyz_42"
         pkg_dir = sp / pkg_name
         pkg_dir.mkdir()
@@ -508,7 +544,7 @@ class TestRefreshEditableFinders:
         try:
             # First install: find_spec returns None until we refresh.
             subprocess.run(
-                ["uv", "pip", "install", "--no-deps", "-e", str(a)],
+                [*_UV_PIP_INSTALL, "--no-deps", "-e", str(a)],
                 check=True,
                 capture_output=True,
             )
@@ -526,7 +562,7 @@ class TestRefreshEditableFinders:
 
             # Swap to B: without refresh, find_spec sticks to A; with refresh, follows B.
             subprocess.run(
-                ["uv", "pip", "install", "--force-reinstall", "--no-deps", "-e", str(b)],
+                [*_UV_PIP_INSTALL, "--force-reinstall", "--no-deps", "-e", str(b)],
                 check=True,
                 capture_output=True,
             )
@@ -544,7 +580,7 @@ class TestRefreshEditableFinders:
             assert spec_fresh is not None and spec_fresh.origin is not None
             assert str(tmp_path / "b") in spec_fresh.origin, spec_fresh.origin
         finally:
-            subprocess.run(["uv", "pip", "uninstall", pkg], capture_output=True, check=False)
+            subprocess.run([*_UV_PIP_UNINSTALL, pkg], capture_output=True, check=False)
             # Drop any meta_path finder we might have registered for this pkg.
             for finder in list(sys.meta_path):
                 mod_name = getattr(finder, "__module__", "")

--- a/tests/unit/test_lockstep_versions.py
+++ b/tests/unit/test_lockstep_versions.py
@@ -26,6 +26,7 @@ Coverage
 - Every ``python/*`` package is listed in ``release-please-config.json`` and
   carries the annotations release-please needs.
 - The manifest agrees with the tree about the current version.
+- ``uv.lock`` records that same version for every workspace member.
 """
 
 from __future__ import annotations
@@ -157,6 +158,33 @@ def test_manifest_matches_the_tree() -> None:
     assert manifest["."] == _root_version(), (
         f"manifest says {manifest['.']}, root pyproject says {_root_version()}. "
         "release-please computes the next bump from the manifest — they must agree."
+    )
+
+
+def test_uv_lock_records_the_lockstep_version() -> None:
+    """``uv.lock`` pins every workspace member at the tree's version.
+
+    release-please rewrites pyprojects textually and cannot regenerate a lock
+    file, so the two drifted for two releases: master shipped 0.3.1 pyprojects
+    against a lock still naming 0.2.0, and `uv sync --frozen` happily installed
+    the stale metadata. release-please.yml now runs `uv lock` on the release
+    branch; this test is what fails if that step is dropped or silently stops
+    working.
+    """
+    lock = (REPO_ROOT / "uv.lock").read_text(encoding="utf-8")
+    # Each workspace member is a `[[package]]` whose source is the local tree.
+    members = re.findall(
+        r'^name = "(openral[a-z-]*)"\nversion = "([^"]+)"\nsource = \{ (?:editable|virtual)',
+        lock,
+        re.M,
+    )
+    assert len(members) >= len(PACKAGE_DIRS), (
+        f"expected every workspace member in uv.lock, found {members}"
+    )
+    stale = {name: version for name, version in members if version != _root_version()}
+    assert not stale, (
+        f"uv.lock is a release behind for {stale}; the tree is at {_root_version()}. "
+        "Run `uv lock` and commit the result."
     )
 
 

--- a/tests/unit/test_lockstep_versions.py
+++ b/tests/unit/test_lockstep_versions.py
@@ -27,6 +27,8 @@ Coverage
   carries the annotations release-please needs.
 - The manifest agrees with the tree about the current version.
 - ``uv.lock`` records that same version for every workspace member.
+- No package hardcodes ``__version__`` — release-please only rewrites
+  ``pyproject.toml``, so source has to derive it.
 """
 
 from __future__ import annotations
@@ -186,6 +188,28 @@ def test_uv_lock_records_the_lockstep_version() -> None:
         f"uv.lock is a release behind for {stale}; the tree is at {_root_version()}. "
         "Run `uv lock` and commit the result."
     )
+
+
+@pytest.mark.parametrize("pkg_dir", PACKAGE_DIRS, ids=lambda p: p.name)
+def test_dunder_version_is_derived_not_hardcoded(pkg_dir: Path) -> None:
+    """``__version__`` reads ``importlib.metadata``, never a literal.
+
+    release-please rewrites `pyproject.toml`, not source. Eleven packages
+    carried a hand-written ``__version__ = "0.2.0"`` that nothing bumped, so
+    two releases later the runtime still announced 0.2.0 while the wheel said
+    0.3.1 — and ``test_smoke.py``'s metadata comparison failed on master. A
+    literal here is a second source of truth; there is only one.
+    """
+    src = pkg_dir / "src"
+    for init in src.glob("*/__init__.py"):
+        for line in init.read_text(encoding="utf-8").split("\n"):
+            if not line.startswith("__version__"):
+                continue
+            assert not re.match(r'^__version__\s*=\s*["\']', line), (
+                f"{init.relative_to(REPO_ROOT)}: {line!r} hardcodes the version. "
+                'Use `_pkg_version("<dist-name>")` from importlib.metadata — '
+                "release-please only rewrites pyproject.toml."
+            )
 
 
 def test_selective_tests_short_circuit_the_release_pr() -> None:

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -10,8 +10,10 @@ checks):
 - It uses **only the public ``import openral_core as core`` surface**,
   catching regressions in the package re-exports without touching
   internal modules.
-- It pins the package version string so a botched release bump is caught
-  before tests/build/publish run.
+- It checks that ``__version__`` agrees with the installed distribution — the
+  package derives it from ``importlib.metadata``, so a failure here means the
+  install itself is broken, not that someone forgot a bump.
+  ``tests/unit/test_lockstep_versions.py`` owns the release-bump contract.
 
 Per the audit (``tests/README.md`` §4-A.7), this docstring documents the
 file's role so future readers don't fold its assertions into the fuzz

--- a/tools/schema_export.py
+++ b/tools/schema_export.py
@@ -6,6 +6,12 @@ Run with:
 Writes to docs/reference/schemas/<ModelName>.json and docs/reference/schemas/all.json.
 CI compares the output of this script against committed files; any drift fails the build.
 
+``all.json`` deliberately carries no package version. Stamping one made every
+release bump this generated file — a 1-line diff in 6k lines that CI's drift
+check turns into a hard failure on the release PR unless someone remembers to
+regenerate. The schemas' own compatibility contract is each model's
+``schema_version`` field; the release that produced a given file is in git.
+
 Schema versioning rules (pre-1.0):
   - Breaking change (field removed, type narrowed, required added) → bump MINOR.
   - Additive change (optional field added, enum value added) → bump PATCH.
@@ -23,8 +29,7 @@ from typing import Any
 # ── Ensure the workspace packages are importable when run from repo root ──────
 sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "core" / "src"))
 
-import openral_core  # reason: path manipulation above
-from openral_core.schemas import (
+from openral_core.schemas import (  # reason: path manipulation above
     Action,
     ActionRepresentation,
     ActionSpec,
@@ -166,7 +171,6 @@ def export_schemas(out_dir: Path = _OUT_DIR) -> dict[str, Any]:
     all_schemas: dict[str, Any] = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "openral_core",
-        "version": openral_core.__version__,
         "schemas": {},
     }
 


### PR DESCRIPTION
Four commits. Two fix the version bump stopping at `pyproject.toml`; two clean up what that exposed.

## 1. `uv.lock` recorded 0.2.0 while the tree ran 0.3.1

- **`uv.lock` regenerated** — it named `0.2.0` for all 15 workspace members, two releases stale.
- **`release-please.yml`** gains a step that runs `uv lock` on the release branch and pushes `chore(release): refresh uv.lock for the version bump` into the release PR (plus the `actions/checkout` + `setup-uv` steps it needs).
- **`test_lockstep_versions.py`** asserts every `openral-*` package in `uv.lock` carries the tree's version.

## 2. Eleven packages hardcoded `__version__ = "0.2.0"`

Nothing bumped them, so the runtime announced 0.2.0 out of a 0.3.1 wheel and `openral doctor` printed the wrong version. `tests/unit/test_smoke.py::test_version_is_set` compares `__version__` against the installed distribution — **it has been failing on master since v0.3.0.**

- Each now reads `importlib.metadata.version("<dist>")`, so it follows the pyproject release-please just rewrote.
- `tools/schema_export.py` stops stamping the package version into `docs/reference/schemas/all.json`. That stamp made every release rewrite a generated 6k-line file for one line — and once `__version__` tracks reality, CI's drift check would have failed the release PR itself.
- `test_lockstep_versions.py` rejects a literal reintroduced under `src/`; README drops its hardcoded "all workspace packages at `0.2.0`" prose.

## 3. The install-plan tests assumed `uv` and pytest shared a venv

`uv` picks its environment from the working directory, not `sys.executable`. Where those differ (a git worktree, a venv reached via PYTHONPATH), `TestRefreshEditableFinders` installed its fixture into one venv and probed another, and `TestRemoveEditableShadow` planted its shadow dir under a site-packages the step never looks at — failing on removal and passing **vacuously** on preservation, since "no shadow to clean" is also what you get when the directory was never there. Now both ask the step's own interpreter, and the `uv pip` calls pass `--python sys.executable`.

## 4. The `openral doctor` sample in README

Bumped to 0.3.1, with an HTML comment (invisible when rendered) marking the block as one machine's snapshot. Nothing can automate it — the same block contains `3.12.9` and `Linux 6.14.0`, which a release-please version block would rewrite too.

## Is this something release-please should do?

For `uv.lock`, it can't. release-please substitutes text in the files `extra-files` names, driven by `x-release-please-*` comments, and `uv.lock` is generated — the markers wouldn't survive the next `uv lock`. There is no uv lockfile updater. So the job that opens the PR completes the bump: `uv lock` without `--upgrade` rewrites only the 15 version lines, no dependency churn.

For `__version__`, it could (11 more `extra-files` entries + 11 annotations to forget), but deriving from metadata deletes the failure mode instead of scheduling it. Same for the schema stamp.

## How tested

- `uv lock` on master: `Resolved 342 packages in 307ms`, diff is exactly the 15 member versions `0.2.0 → 0.3.1`, no third-party pin moved.
- Installed `python/core` from this tree (0.3.1) into a clean venv: `metadata: 0.3.1 | __version__: 0.3.1` — the literal said 0.2.0. All 11 packages import cleanly from source.
- Both new tests falsification-checked: they fail against the pre-fix lock (`assert not {'openral-cli': '0.2.0', ...}`) and against a restored literal (`hardcodes the version` on wam).
- `test_deps_install_plans.py` goes 34 passed / 1 failed → 35 passed when run from a worktree.
- **Full `tests/unit`: 4499 passed, 57 skipped, 0 failed.** `tools/schema_export.py --check`: no drift.
- `ruff check` + `format --check` clean across 943 files; `mypy --strict` clean on `openral_core` + `openral_cli` with `MYPYPATH` pointed at this tree.

## Notes

- The workflow step is idempotent: release-please force-pushes its branch on every master push and drops the lock commit; the step re-adds it in the same run. It signs off as `github-actions[bot]` because DCO is a required check on the release PR too.
- Skipped: `uv lock --check` in `quality.yml`. The unit test covers the drift that actually happened, offline. Add it if a PR ever lands a stale lock for a *dependency* change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJZG9buhvyS8LYfsWCgcQr