### PR TITLE
fix(sim): quote the failing install step's own output in the raised error

### DIFF
--- a/docs/reference/sim-environments.md
+++ b/docs/reference/sim-environments.md
@@ -21,6 +21,16 @@ conflicting robosuite versions, so swap groups per task. Full recipe →
 [Managing the Python environment & dependency
 groups](../contributing/toolchain.md#managing-the-python-environment-dependency-groups).
 
+An install step's output streams to your terminal as it runs, and the tail of
+it is quoted back inside the `ROSConfigError` if the step fails — so when a
+backend or sidecar won't provision, read the quoted lines rather than the exit
+code. That matters most when the step ran *inside a ROS node*, where the raw
+output is scattered through the launch log: the reasoner reports the failure as
+`goal_rejected`, and the quoted tail is the only place the cause travels with
+it. A sidecar pinned to wheels that don't exist for your platform (aarch64 is
+the common case) shows up there as a `uv` "no source distribution or wheel for
+the current platform" line naming the offending package.
+
 ## Quick CLI
 
 ```bash

--- a/python/sim/src/openral_sim/_deps.py
+++ b/python/sim/src/openral_sim/_deps.py
@@ -455,6 +455,93 @@ def _refresh_editable_finders() -> None:
             break
 
 
+_STEP_TAIL_BYTES = 8192
+"""How much trailing step output is retained to explain a failure."""
+
+_STEP_TAIL_LINES = 25
+"""How many of those trailing lines are quoted in the raised error."""
+
+
+def _run_install_step(step: InstallStep, env: dict[str, str]) -> None:
+    """Run one install step, streaming its output *and* keeping the tail.
+
+    The step's stdout+stderr are merged and echoed to this process's stderr
+    byte-for-byte as they arrive, so `uv`'s carriage-return progress bars and a
+    multi-GB download's throughput line render live exactly as they would if the
+    child owned the terminal. The last :data:`_STEP_TAIL_BYTES` are retained so
+    :func:`_step_failure_detail` can quote *why* a step failed.
+
+    The retention is the point. ``subprocess.run(..., check=True)`` raises a
+    ``CalledProcessError`` whose message is only ``Command [...] returned
+    non-zero exit status 2``. That string is what reaches the ``ROSConfigError``,
+    and from there the rSkill runner's ``goal_rejected`` and the reasoner's
+    replanning ladder — so an operator watching the reasoner sees an exit code
+    and no cause. The child's real diagnostic did reach the launch log, but
+    detached from the error and buried among unrelated node output. Observed on
+    a GB10 (aarch64) host, where the whole explanation was one `uv` line:
+    ``Distribution `torchcodec==0.4.0` can't be installed because it doesn't
+    have a source distribution or wheel for the current platform``.
+
+    Raises:
+        subprocess.CalledProcessError: The step exited non-zero. ``output``
+            carries the retained tail.
+        OSError: The executable could not be spawned (e.g. ``FileNotFoundError``
+            when ``argv[0]`` is missing).
+    """
+    proc = subprocess.Popen(  # reason: argv is plan-controlled, shell=False
+        step.argv,
+        env=env,
+        cwd=str(step.cwd) if step.cwd else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    tail = bytearray()
+    sink = getattr(sys.stderr, "buffer", None)
+    stream = proc.stdout
+    if stream is not None:
+        with stream:
+            while True:
+                chunk = stream.read(4096)
+                if not chunk:
+                    break
+                if sink is not None:
+                    sink.write(chunk)
+                    sink.flush()
+                else:
+                    sys.stderr.write(chunk.decode("utf-8", "replace"))
+                    sys.stderr.flush()
+                tail.extend(chunk)
+                if len(tail) > _STEP_TAIL_BYTES:
+                    del tail[:-_STEP_TAIL_BYTES]
+    returncode = proc.wait()
+    if returncode != 0:
+        raise subprocess.CalledProcessError(returncode, step.argv, output=bytes(tail))
+
+
+def _step_failure_detail(exc: BaseException) -> str:
+    """Render a failed step's exception plus its captured tail, ready to embed.
+
+    Always ends with a newline (or a space) so the caller can append
+    ``"Finish manually:"`` without gluing words together. Returns just the
+    exception text when nothing was captured — a spawn failure
+    (``FileNotFoundError``) produces no output at all.
+    """
+    # CalledProcessError already ends in a period; OSError does not.
+    summary = str(exc).rstrip(". ")
+    output = getattr(exc, "output", None)
+    if not isinstance(output, bytes | str):
+        return f"{summary}. "
+    text = output.decode("utf-8", "replace") if isinstance(output, bytes) else output
+    # Progress bars overwrite one line with \r; treat each rewrite as its own
+    # line so the tail is the *final* state, not one long unreadable run.
+    lines = [ln.rstrip() for ln in text.replace("\r", "\n").splitlines()]
+    kept = [ln for ln in lines if ln.strip()][-_STEP_TAIL_LINES:]
+    if not kept:
+        return f"{summary}. "
+    quoted = "\n".join(f"    {ln}" for ln in kept)
+    return f"{summary}.\n  Last {len(kept)} line(s) of step output:\n{quoted}\n  "
+
+
 def _uv() -> str:
     """Return the path to the ``uv`` executable or raise ROSConfigError."""
     found = shutil.which("uv")
@@ -1936,16 +2023,12 @@ def ensure_backend_deps(backend_id: str) -> None:
         for step in plan.steps:
             run_env = {**os.environ, **step.env}
             try:
-                subprocess.run(
-                    step.argv,
-                    env=run_env,
-                    cwd=str(step.cwd) if step.cwd else None,
-                    check=True,
-                )
-            except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+                _run_install_step(step, run_env)
+            except (subprocess.CalledProcessError, OSError) as exc:
                 raise ROSConfigError(
                     f"{plan.backend_id} install failed at step "
-                    f"{step.description!r}: {exc}. Finish manually:\n  " + plan.manual_hint
+                    f"{step.description!r}: {_step_failure_detail(exc)}Finish manually:\n  "
+                    + plan.manual_hint
                 ) from exc
 
         # Some packages need importlib's caches invalidated for newly-installed

--- a/tests/unit/test_deps_install_plans.py
+++ b/tests/unit/test_deps_install_plans.py
@@ -22,6 +22,7 @@ verification happened on the GPU host.
 from __future__ import annotations
 
 import importlib.metadata
+import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -866,8 +867,8 @@ def test_live_dependency_swap_is_refused_before_the_venv_is_mutated(monkeypatch)
     )
     monkeypatch.setattr(_deps, "get_plan", lambda _bid: plan)
     monkeypatch.setattr(
-        _deps.subprocess,
-        "run",
+        _deps,
+        "_run_install_step",
         lambda *a, **k: ran.append("ran"),  # must never fire
     )
     monkeypatch.setitem(sys.modules, "robosuite", SimpleNamespace(__version__="1.5.2"))
@@ -911,3 +912,92 @@ def test_every_robosuite_swapping_plan_declares_the_repin() -> None:
     """
     for backend_id in ("libero", "robocasa_kitchen", "robocasa_gr1", "openarm_robosuite"):
         assert "robosuite" in _deps.get_plan(backend_id).repins, backend_id
+
+
+# ── Install-step output capture ───────────────────────────────────────────
+#
+# A failing step used to surface as bare "returned non-zero exit status 2":
+# `subprocess.run(..., check=True)` puts nothing but the exit code in the
+# CalledProcessError, and that string is what `ensure_backend_deps` embeds in
+# its ROSConfigError — which the rSkill runner then reports as `goal_rejected`
+# and the reasoner replans against. The child's real diagnostic reached the
+# launch log but was detached from the error and buried among other nodes'
+# output. Observed on a GB10 (aarch64) host, where the entire explanation was
+# one `uv` line about `torchcodec` having no aarch64 wheel.
+#
+# These drive REAL subprocesses (no mocks, CLAUDE.md §1.11) — the child is a
+# `sys.executable -c` one-liner that writes known text and exits non-zero.
+
+
+def _echoing_step(stdout_text: str, stderr_text: str, code: int) -> _deps.InstallStep:
+    """An InstallStep whose child writes known text to both streams, then exits."""
+    prog = (
+        "import sys;"
+        f"sys.stdout.write({stdout_text!r});"
+        f"sys.stderr.write({stderr_text!r});"
+        f"sys.exit({code})"
+    )
+    return _deps.InstallStep(description="probe step", argv=[sys.executable, "-c", prog])
+
+
+def test_failing_install_step_surfaces_the_child_stderr(monkeypatch, capsysbinary) -> None:
+    """The raised ROSConfigError quotes what the child actually said."""
+    real_uv_error = (
+        "error: Distribution `torchcodec==0.4.0` can't be installed because it "
+        "doesn't have a source distribution or wheel for the current platform\n"
+    )
+    plan = _deps.BackendInstallPlan(
+        backend_id="rldx_sidecar_setup",
+        display_name="RLDX sidecar",
+        license_note="test",
+        probe=lambda: False,
+        steps=(_echoing_step("Resolved 210 packages\n", real_uv_error, 2),),
+        manual_hint="git clone ... && uv sync",
+    )
+    monkeypatch.setattr(_deps, "get_plan", lambda _bid: plan)
+    monkeypatch.setenv("OPENRAL_AUTO_INSTALL_DEPS", "1")
+
+    with pytest.raises(ROSConfigError) as excinfo:
+        _deps.ensure_backend_deps("rldx_sidecar_setup")
+
+    message = str(excinfo.value)
+    assert "torchcodec==0.4.0" in message, (
+        "the child's own diagnostic must reach the typed error; got:\n" + message
+    )
+    assert "exit status 2" in message, "the exit code is still useful context"
+    assert "git clone ... && uv sync" in message, "the manual hint must survive"
+    # Streamed live as well as captured — an 11 GB download must stay watchable.
+    assert b"Resolved 210 packages" in capsysbinary.readouterr().err
+
+
+def test_install_step_streams_output_while_it_runs(capsysbinary) -> None:
+    """A succeeding step writes through to stderr and raises nothing."""
+    step = _echoing_step("to stdout\n", "to stderr\n", 0)
+    _deps._run_install_step(step, dict(os.environ))
+    streamed = capsysbinary.readouterr().err
+    assert b"to stdout" in streamed and b"to stderr" in streamed
+
+
+def test_install_step_tail_keeps_the_end_of_a_long_log(capsysbinary) -> None:
+    """Only the tail is quoted, so a chatty build cannot bury its own error."""
+    noise = "".join(f"compiling module_{i}\n" for i in range(4000))
+    step = _echoing_step(noise, "error: the last line is the real one\n", 1)
+    with pytest.raises(_deps.subprocess.CalledProcessError) as excinfo:
+        _deps._run_install_step(step, dict(os.environ))
+
+    detail = _deps._step_failure_detail(excinfo.value)
+    assert "error: the last line is the real one" in detail
+    assert "compiling module_0\n" not in detail, "the head of a long log must be dropped"
+    quoted = [ln for ln in detail.splitlines() if ln.startswith("    ")]
+    assert len(quoted) <= _deps._STEP_TAIL_LINES
+    capsysbinary.readouterr()  # drain the 4000 streamed lines
+
+
+def test_step_failure_detail_handles_a_spawn_failure() -> None:
+    """A missing executable yields no output; the detail must still read cleanly."""
+    step = _deps.InstallStep(description="missing", argv=["openral-does-not-exist-xyz"])
+    with pytest.raises(OSError) as excinfo:
+        _deps._run_install_step(step, dict(os.environ))
+    detail = _deps._step_failure_detail(excinfo.value)
+    assert "line(s) of step output" not in detail
+    assert detail.endswith(". ")


### PR DESCRIPTION
## What changed

A failing backend/sidecar install step now quotes its own output inside the `ROSConfigError` it raises, while still streaming that output live to the terminal.

## Why

`ensure_backend_deps` ran each step through `subprocess.run(..., check=True)`. The resulting `CalledProcessError` stringifies to nothing but:

```
Command '['uv', 'sync']' returned non-zero exit status 2.
```

That string is what gets embedded in the `ROSConfigError` — which the rSkill runner reports as `goal_rejected`, and which the reasoner replans against. An operator watching a failed skill dispatch saw an exit code and no cause.

The child's diagnostic was not *lost*: without `capture_output`, stderr goes to the parent's stderr and lands in the launch log. But it arrives **detached from the error** and interleaved with every other node's output — on a `deploy sim` run, thousands of lines of nav2 TF chatter between the message and the failure it explains.

Observed live on a GB10 / DGX Spark (aarch64), ROS 2 Jazzy. The RLDX sidecar's `uv sync` failed during `openral deploy sim`, and the entire explanation was two lines buried 300 lines away from the error:

```
error: Distribution `torchcodec==0.4.0 @ registry+https://pypi.org/simple` can't be installed
  because it doesn't have a source distribution or wheel for the current platform
hint: You're on Linux (`manylinux_2_39_aarch64`), but `torchcodec` (v0.4.0) only has wheels for
  the following platforms: `manylinux_2_28_x86_64`, `macosx_11_0_arm64`
```

## How

**`_run_install_step(step, env)`** drives the step through `Popen` with stdout+stderr merged, echoes the bytes to this process's stderr as they arrive, and retains the last 8 KB.

Streaming **byte-for-byte rather than line-by-line is deliberate**: `uv`'s carriage-return progress bars and a multi-GB asset download's throughput line have to keep rendering live. Line-buffered iteration would hold each progress frame until a newline that never comes, turning a watchable download into a frozen terminal. That is why this isn't simply `capture_output=True`.

**`_step_failure_detail(exc)`** renders the tail into the error message:
- Treats each `\r` rewrite as its own line, so a progress bar contributes its *final* state instead of one unreadable run.
- Quotes at most the last 25 non-empty lines, so a chatty source build cannot bury its own error.
- Falls back to the bare exception when nothing was captured — a spawn failure (`FileNotFoundError`) produces no output at all.

The step loop's `except` widens from `(CalledProcessError, FileNotFoundError)` to `(CalledProcessError, OSError)`, since `Popen` can fail to spawn in more ways than a missing file (`PermissionError`, `NotADirectoryError` on a bad `cwd`).

Result, as `goal_rejected` would now report it:

```
rldx_sidecar_setup install failed at step 'uv sync in ~/.cache/openral/rldx-sidecar/source':
Command '['uv', 'sync']' returned non-zero exit status 2.
  Last 3 line(s) of step output:
    error: Distribution `torchcodec==0.4.0 @ registry+https://pypi.org/simple` can't be installed
      because it doesn't have a source distribution or wheel for the current platform
    hint: You're on Linux (`manylinux_2_39_aarch64`), but `torchcodec` (v0.4.0) only has wheels
      for the following platforms: `manylinux_2_28_x86_64`, `macosx_11_0_arm64`
    Resolved 210 packages in 1.94s
  Finish manually:
  git clone https://github.com/RLWRLD/RLDX-1.git ... && uv sync
```

## Scope note — what this does *not* fix

The RLDX sidecar still does not provision on aarch64. That is an upstream RLDX-1 packaging gap, three deep, each blocker revealed only by clearing the previous one:

1. `torchcodec==0.4.0` — no `linux-aarch64` wheel on PyPI (first appears in 0.11.0).
2. Bump it, and `flash-attn` fails: it has no prebuilt wheel on any platform, always source-builds, and PyPI's default aarch64 `torch==2.7.0` is CPU-only → `CUDA_HOME not set`.
3. Point torch at PyTorch's `cu128` aarch64 index (which does carry a real aarch64 wheel), and torch 2.7.0's metadata pins `triton==3.3.0`, no aarch64 wheel until 3.5.0.

Upstream has a documented Blackwell path in `pixi.toml`, but it is hard-pinned `platforms = ["linux-64"]`. Each workaround was tried by hand and traded one wheel gap for the next, so no verified fix exists on this host. **This PR only makes the machine say so.**

## How tested

Four new cases in `tests/unit/test_deps_install_plans.py`, driving **real subprocesses** — the child is a `sys.executable -c` one-liner writing known text and exiting non-zero (a real process boundary, not a mock; CLAUDE.md §1.11):

1. A failing step's stderr reaches the typed error (asserts the real `torchcodec` text lands in the `ROSConfigError`) **and** was streamed live — the exit code and manual hint both survive.
2. A succeeding step streams both channels through to stderr and raises nothing.
3. A 4000-line log is truncated to its tail: the last line survives, the first is dropped, and the quote is capped at `_STEP_TAIL_LINES`.
4. A spawn failure (missing executable) produces no output and still renders a clean message.

Also **repoints the live-swap guard's sentinel** in `test_live_swap_guard_refuses_a_repin_after_import` from `_deps.subprocess.run` to `_deps._run_install_step`. The step loop no longer calls `subprocess.run`, so that `ran == []` assertion would have silently gone vacuous — it exists to prove the guard fires *before* the venv is mutated, and it has to keep meaning that.

- `tests/unit/test_deps_install_plans.py` — 39 passed.
- `tests/unit` — **4522 passed, 44 skipped** (skips are pre-existing environment gates).
- `mypy --strict -p openral_sim` clean (68 files); `ruff check` + `ruff format --check` clean.
- `tools/refresh_methods_linenos.py --check` exits 0.

## Checklist

- [x] Conventional commit title; description has "What changed", "Why", "How tested"
- [x] Schemas — *n/a, none touched*
- [x] Layer boundary crossed → decision recorded — *n/a, entirely inside `openral_sim._deps`*
- [x] Tests: unit added; no new mocks/stubs/smoke tests
- [x] `docs/methods/` — *n/a: `_deps.py` is a `_private` module and is not in the inventory (CLAUDE.md §2, "`_private` modules are not API"); no public symbol added, renamed, or removed*
- [x] Docs updated in the same PR — `docs/reference/sim-environments.md` now tells operators to read the quoted tail rather than the exit code
- [x] Pre-existing errors fixed in a separate prior `fix(...)` commit — *none needed*
- [x] Repo state map updated if a module was added/renamed/removed/status-flipped — *n/a*
- [x] `just lint` passes; `mypy --strict` clean; no new `# type: ignore`; no new `try/except: pass`; no new global mutable state
- [x] No safety-disabling flag; nothing on the actuation path
- [x] No new dependencies

## Notes for review

One commit, signed off, based on `36cf937`.

Worth a reviewer's eye: stdout and stderr are now **merged into one stream**, so their relative ordering in the terminal follows actual flush order rather than being two independent channels. For install steps that is what you want (a `uv` error should appear where it happened), but it is a visible change, and a caller that wanted to redirect the two separately no longer can.

The `# noqa: S603` on the `Popen` call is the same posture the file already takes for `subprocess.run`: `argv` is plan-controlled and `shell=False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ricid9s3VKGgEF63ERJqaa
