### PR TITLE
fix(sim): wire π0.5's TensorRT attach hook — it was never called

### DIFF
--- a/python/sim/src/openral_sim/policies/pi05.py
+++ b/python/sim/src/openral_sim/policies/pi05.py
@@ -43,6 +43,7 @@ from openral_rskill._vla_core import (
     resolve_state_dim,
     to_numpy_action,
 )
+from openral_rskill.backend_registry import maybe_attach_pro_hooks
 
 # π0.5 nf4 quantization + prequantized state load both live in the
 # adapter-agnostic helper module so smolvla / xvla / future-pi06 can
@@ -951,6 +952,19 @@ def _build_pi05(env_cfg: Any) -> _PI05Adapter:  # noqa: PLR0915  # reason: load-
     state_dim = resolve_state_dim(manifest, spec.extra)
     scene_cameras = getattr(env_cfg.scene, "cameras", None)
     cam_keys = resolve_camera_keys(manifest, spec.extra, scene_cameras=scene_cameras)
+
+    # Opt-in TensorRT runtime: swaps sample_actions for the split-ONNX TRT
+    # engines, exactly as SmolVLA and ACT do (see openral_sim.policies.smolvla).
+    # The hook itself ships in the private openral-pro-trt package and is
+    # looked up by name — a host without it falls straight through to the
+    # torch path unwired above. No torch.compile fallback to skip here: π0.5's
+    # `compile_model` is already forced off (see the comment at
+    # `pi05_cfg.compile_model = False` above), independent of whether TRT
+    # attaches.
+    if maybe_attach_pro_hooks(
+        "pi05", policy, repo_id=repo_id, device=device, n_cameras=len(cam_keys)
+    ):
+        _log.info("pi05.runtime_tensorrt", repo_id=repo_id, n_cameras=len(cam_keys))
 
     adapter = _PI05Adapter(
         spec=spec,


### PR DESCRIPTION
## What changed

SmolVLA and ACT both call `maybe_attach_pro_hooks` from their sim adapters;
`openral_sim/policies/pi05.py` never did. `openral_pro_trt.hooks.attach_pi05`
has existed and been env-gated (`OPENRAL_PI05_TRT`) since the hook seam was
built, but nothing on the open side ever reached it — a LIBERO rollout with the
pi05 rSkill always ran pure PyTorch regardless of the env var.

Found while trying to run a LIBERO success-rate benchmark against the π0.5
TensorRT engine landed in `openral-pro`'s Phase B work (`fp8_bf16_attn`:
78.9 ms vs a 190 ms eager baseline, 2.41x, cosine 0.997891) — the benchmark
harness already exists (`openral benchmark scene`), the rSkill already exists
(`pi05-libero-int8`), and the only gap was this one call.

Wired identically to `smolvla.py`'s pattern: right after `cam_keys` is
resolved (the engine must be exported for exactly the cameras this robot
supplies), calling `maybe_attach_pro_hooks("pi05", policy, repo_id=repo_id,
device=device, n_cameras=len(cam_keys))`. No `elif`/`else` branch to add —
unlike SmolVLA, π0.5's `torch.compile` is already unconditionally disabled
(`pi05_cfg.compile_model = False`), so there's no compile path to skip in
favor of TRT.

## Test plan

- `uv run mypy --strict -p openral_sim` — clean.
- `ruff check` / `ruff format --check` — clean.
- Manual: `OPENRAL_PI05_TRT=1 OPENRAL_PI05_TRT_PRECISION=fp8_bf16_attn openral
  benchmark scene --config scenes/benchmark/libero_spatial.yaml --rskill
  rskill://rskills/pi05-libero-int8 --n-episodes 20` — pending a venv sync to
  the `libero` group (currently on `robocasa`) on the box this was developed
  on; this PR is the code-side prerequisite for that run, not the run itself.