### PR TITLE
docs(rskill): price π0.5 int8 honestly, and fix every VRAM number

### DIFF
--- a/docs/reference/rskills.md
+++ b/docs/reference/rskills.md
@@ -49,7 +49,7 @@ All entries are published under `OpenRAL/rskill-*` on HuggingFace Hub and exerci
 | [`act-so101-pen`](https://github.com/OpenRAL/openral/tree/master/rskills/act-so101-pen/) | ACT pen checkpoint | `so101_follower` | Apache-2.0 |
 | [`molmoact2-libero-nf4`](https://github.com/OpenRAL/openral/tree/master/rskills/molmoact2-libero-nf4/) | MolmoAct2 NF4 (Molmo2-ER VLM + flow-matching, ~5.5 B) | `franka_panda` | Apache-2.0 |
 | [`molmoact2-so101-nf4`](https://github.com/OpenRAL/openral/tree/master/rskills/molmoact2-so101-nf4/) | MolmoAct2 NF4 SO-101 checkpoint | `so101_follower` | Apache-2.0 |
-| [`pi05-libero-int8`](https://github.com/OpenRAL/openral/tree/master/rskills/pi05-libero-int8/) | π0.5 NF4 | `franka_panda` | Permissive research (weights non-Apache) |
+| [`pi05-libero-int8`](https://github.com/OpenRAL/openral/tree/master/rskills/pi05-libero-int8/) | π0.5 LLM.int8 — fits 8 GB, but costs task success vs bf16 (see the rSkill README) | `franka_panda` | Permissive research (weights non-Apache) |
 | [`act-aloha`](https://github.com/OpenRAL/openral/tree/master/rskills/act-aloha/) | ACT (Action Chunking Transformer) | `aloha_bimanual` | MIT |
 | [`act-aloha-insertion`](https://github.com/OpenRAL/openral/tree/master/rskills/act-aloha-insertion/) | ACT insertion checkpoint — *custom example* | `aloha_bimanual` | MIT |
 | [`diffusion-pusht`](https://github.com/OpenRAL/openral/tree/master/rskills/diffusion-pusht/) | Diffusion Policy | `pusht_2d` | Apache-2.0 |

--- a/rskills/pi05-libero-int8/README.md
+++ b/rskills/pi05-libero-int8/README.md
@@ -42,13 +42,54 @@ base_model_relation: quantized
 
 ## Why int8 (and not NF4)
 
-π0.5's 3.4 B backbone is **too large to run bf16 on 8 GB** (~13.6 GiB peak → OOM),
-but **NF4 4-bit is too lossy for it** — 4-bit quantization scores **0/5** on
-`libero_spatial` because it destroys the policy. **LLM.int8**
-(bitsandbytes `Linear8bitLt` on every Linear ≥ 4 M weight elements) is the sweet
-spot: it both fits 8 GB *and* preserves competence — **~0.5–0.7 success** on
-`libero_spatial` across 10-episode runs on an RTX 4070 (`eval/scene_libero_spatial.json`
-records 0.5). Quantization runs at load from the bf16 checkpoint (no prequantized pack).
+π0.5's 3.4 B backbone **does not fit bf16 on an 8 GB card** — bf16 peaks at
+**8.06 GB** of device memory, and an 8 GB GPU has less than that free once the
+driver takes its cut. **NF4 4-bit** fits but is too lossy for this backbone: it
+scores **0/5** on `libero_spatial`, destroying the policy outright. **LLM.int8**
+(bitsandbytes `Linear8bitLt` on every Linear ≥ 4 M weight elements) fits at
+**6.35 GB** and keeps the policy working. Quantization runs at load from the
+bf16 checkpoint (no prequantized pack).
+
+### …but int8 is not free — prefer bf16 if it fits
+
+int8 is a *memory* fit. It costs accuracy and speed, and neither cost was
+recorded here before. Measured on a GB10 — `libero_spatial` tasks 0/1/2, seed
+42, `max_steps=220`, **n=50 per task per arm (300 episodes)**, same episodes and
+protocol, the only difference being `quantization.dtype`:
+
+| dtype | task 0 | task 1 | task 2 | **Total** | Mean step latency | Peak device memory |
+|---|---|---|---|---|---|---|
+| **bf16** | 98% | 94% | 94% | **143/150 = 95%** | **9.6 ms** | 8.06 GB |
+| int8 | 76% | **22%** | 82% | 93/150 = 62% | 24.8 ms | **6.35 GB** |
+
+int8 costs **~33 points of task success** (Fisher exact **p = 4e-13**) and runs
+**~2.6× slower per step** — LLM.int8's mixed-precision decomposition is slower
+than a plain bf16 GEMM.
+
+**Read the per-task columns, not just the total.** bf16 is steady (98/94/94);
+int8 swings between 22% and 82%. The damage is *task-dependent*, so a
+single-task spot-check can land on 82% and look acceptable while task 1 is
+nearly non-functional. That variance is the real hazard — more than the average.
+
+What int8 buys is **1.7 GB**, and on an 8 GB card that is decisive: bf16 will
+not load at all, and 62% beats not running.
+
+**On any host with ≳9 GB of VRAM, use bf16.** No manifest edit is needed:
+
+```bash
+openral sim run --config scenes/sim/libero_spatial.yaml \
+    --rskill rskills/pi05-libero-int8 --vla-extra dtype=bf16
+```
+
+Faster still on NVIDIA hardware with TensorRT: an FP8 engine reaches **78.9 ms**
+per policy call against bf16 eager's 190 ms and scores **49/50 — identical to
+bf16**, so FP8 costs no task success at all. See the `openral-pro` TensorRT
+runtime (`OPENRAL_PI05_TRT=1`, `OPENRAL_PI05_TRT_PRECISION=fp8_bf16_attn`).
+
+Scope: one task of LIBERO-Spatial's ten, so treat 98%/76% as a like-for-like
+*comparison* rather than a suite score. The older "0.5–0.7 across 10-episode
+runs" figure is not contradicted so much as too noisy to use — at n=10 the
+binomial SD is ~0.16, wide enough to cover both arms above.
 
 ## Quick start
 
@@ -116,7 +157,15 @@ Full schema: `openral_core.RSkillManifest`.
 
 `eval/scene_libero_spatial.json` holds the locally-reproduced result:
 **`libero_spatial` = 0.50 (5/10 episodes)**, int8, RTX 4070 8 GB (a separate
-10-episode run scored 0.70; the policy sits around 0.5–0.7). Re-run with:
+10-episode run scored 0.70; the policy sits around 0.5–0.7).
+
+⚠️ **n=10 is too small to compare anything with.** Its binomial SD is ~0.16, so
+that 0.50 and the 0.76 measured at n=50 above are the same result, not a
+regression or an improvement. Prefer the n=50 numbers in [Why int8](#why-int8-and-not-nf4)
+when deciding a dtype, and treat the recorded 0.50 as provenance for the
+committed eval artifact rather than as this policy's success rate.
+
+Re-run with:
 
 ```bash
 PYTORCH_ALLOC_CONF=expandable_segments:True OPENRAL_ALLOW_NONCOMMERCIAL=1 \

--- a/rskills/pi05-libero-int8/SKILL.md
+++ b/rskills/pi05-libero-int8/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pi05-libero-int8
 description: >-
-  S1 Vision-Language-Action policy. Capabilities: pick, place, open, close on bowl, cup, drawer, object. π0.5 fine-tuned on LIBERO (v0.44), loaded from the upstream LeRobot checkpoint and LLM.int8-packed at runtime so 8 GB GPUs can run the rollout without the NF4 competence regression (NF4 scored 0/5 on libero_spatial; int8 scores ~0.5–0.7). π0.5 uses a PaliGemma 3B backbone with a flow-matching head. Weights are PI permissive-research — commercial use needs a vendor agreement. See eval/scene_libero_spatial.json for the locally-reproduced result. Discovery view of an OpenRAL rSkill — NOT directly runnable by an agent harness; it runs via rSkill.from_pretrained + the robot HAL.
+  S1 Vision-Language-Action policy. Capabilities: pick, place, open, close on bowl, cup, drawer, object. π0.5 (PaliGemma 3B + flow-matching) fine-tuned on LIBERO v0.44, LLM.int8-packed at load so 8 GB GPUs can run it at all — bf16 peaks at 8.1 GB and will not load there. int8 is a memory fit, not a free one: over 300 LIBERO-Spatial episodes it scores 62% vs bf16's 95%, task-dependent (22-82%), and is ~2.6x slower per step. With >9 GB prefer `--vla-extra dtype=bf16`, or openral-pro's TensorRT FP8; see the README. PI permissive-research weights: commercial use needs a vendor agreement. Discovery view of an OpenRAL rSkill — NOT directly runnable by an agent harness; it runs via rSkill.from_pretrained + the robot HAL.
 metadata:
   openral_rskill: true            # generated discovery view of an rSkill
   schema_version: 0.1
@@ -20,7 +20,7 @@ metadata:
   action_representation: delta_ee_6d_plus_gripper
   runtime: pytorch
   quantization: int8/pytorch
-  min_vram_gb: {fp32: 14.0, bf16: 7.0, int8: 6.0}
+  min_vram_gb: {fp32: 16.1, bf16: 8.1, int8: 6.4}
   chunk_size: 50
   n_action_steps: 25
   latency_budget: {per_chunk_ms: 200.0}
@@ -41,7 +41,7 @@ metadata:
 
 ## What it is
 
-An OpenRAL **Vision-Language-Action policy** (`role: s1`, `kind: vla`). π0.5 fine-tuned on LIBERO (v0.44), loaded from the upstream LeRobot checkpoint and LLM.int8-packed at runtime so 8 GB GPUs can run the rollout without the NF4 competence regression (NF4 scored 0/5 on libero_spatial; int8 scores ~0.5–0.7). π0.5 uses a PaliGemma 3B backbone with a flow-matching head. Weights are PI permissive-research — commercial use needs a vendor agreement. See eval/scene_libero_spatial.json for the locally-reproduced result.
+An OpenRAL **Vision-Language-Action policy** (`role: s1`, `kind: vla`). π0.5 (PaliGemma 3B + flow-matching) fine-tuned on LIBERO v0.44, LLM.int8-packed at load so 8 GB GPUs can run it at all — bf16 peaks at 8.1 GB and will not load there. int8 is a memory fit, not a free one: over 300 LIBERO-Spatial episodes it scores 62% vs bf16's 95%, task-dependent (22-82%), and is ~2.6x slower per step. With >9 GB prefer `--vla-extra dtype=bf16`, or openral-pro's TensorRT FP8; see the README. PI permissive-research weights: commercial use needs a vendor agreement.
 
 ## Capabilities
 

--- a/rskills/pi05-libero-int8/rskill.yaml
+++ b/rskills/pi05-libero-int8/rskill.yaml
@@ -2,15 +2,43 @@
 # Wraps: lerobot/pi05_libero_finetuned_v044 with int8 runtime packing.
 # Base:  lerobot/pi05_base (Physical Intelligence π0.5)
 #
-# Why int8 (not NF4): bf16 π0.5 (~7 GB, ~13.6 GiB peak) OOMs on an 8 GB
-# consumer GPU. NF4 4-bit fits but is *too lossy* for the 3.4 B π0.5
-# backbone — it destroys competence (0/5 on libero_spatial with NF4
-# 4-bit). LLM.int8 (bitsandbytes Linear8bitLt on every
-# Linear ≥4M elements) restores the policy AND fits 8 GB: measured
-# 0.5–0.7 on libero_spatial across 10-episode runs (RTX 4070 8 GB;
-# eval/scene_libero_spatial.json records 0.5). The pi05 adapter loads the
-# bf16 source, rewraps Linears to Linear8bitLt, then packs to int8 on the
-# device move (accelerate-free meta-init fast path).
+# Why int8 (not NF4): bf16 π0.5 peaks at 8.06 GB of device memory, which does
+# not fit an 8 GB consumer GPU once the driver takes its cut. NF4 4-bit fits
+# but is *too lossy* for the 3.4 B π0.5 backbone — it destroys competence
+# (0/5 on libero_spatial with NF4 4-bit). LLM.int8 (bitsandbytes Linear8bitLt
+# on every Linear ≥4M elements) restores the policy AND fits, at 6.35 GB. The
+# pi05 adapter loads the bf16 source, rewraps Linears to Linear8bitLt, then
+# packs to int8 on the device move (accelerate-free meta-init fast path).
+#
+# ⚠️ int8 is a *memory* fit, not a free one. Measured on a GB10 — LIBERO-Spatial
+# tasks 0/1/2, seed 42, max_steps 220, n=50 per task per arm (300 episodes
+# total). Same episodes, same protocol; the only difference is
+# quantization.dtype:
+#
+#            task 0    task 1    task 2    total
+#     bf16     98%       94%       94%     143/150 = 95%   9.6 ms/step
+#     int8     76%       22%       82%      93/150 = 62%  24.8 ms/step
+#
+# int8 costs ~33 points of task success overall (Fisher exact p=4e-13) *and*
+# runs ~2.6x slower per step — LLM.int8's mixed-precision decomposition is
+# slower than a plain bf16 GEMM.
+#
+# Read the per-task row, not just the total. bf16 is steady (98/94/94) while
+# int8 swings 22–82%. The damage is **task-dependent**, so a single-task
+# spot-check can easily land on 82% and look acceptable; task 1 is where this
+# policy nearly stops working. That variance is the real hazard, more than the
+# average.
+#
+# What int8 buys is 1.7 GB, and that is the whole reason it exists: on an 8 GB
+# card bf16 will not load at all, and 62% beats not running. **On any host with
+# ≳9 GB, prefer bf16** — no manifest edit needed, just `--vla-extra dtype=bf16`.
+# With TensorRT an FP8 engine is better again: 78.9 ms/call vs bf16 eager's
+# 190 ms, at bf16-identical task success (openral-pro, OPENRAL_PI05_TRT=1,
+# OPENRAL_PI05_TRT_PRECISION=fp8_bf16_attn).
+#
+# The older "0.5–0.7 across 10-episode runs" figure is not wrong so much as
+# unusable: at n=10 the binomial SD is ~0.16, wide enough to cover most of the
+# spread above. eval/scene_libero_spatial.json still records that n=10 run.
 #
 # LICENSE WARNING (CLAUDE.md §7.4):
 #   Code: Apache-2.0
@@ -68,13 +96,32 @@ quantization:
   dtype: "int8"
   backend: "pytorch"
 # Informational VRAM ceilings, used by `ral skill check` / `openral doctor`.
-# int8-packed weights are ~4–5 GiB and fit under the 8 GiB consumer-GPU
-# ceiling (measured live on RTX 4070). CLAUDE.md §11 still forbids silent
-# downcast — the actually-applied dtype stays pinned by quantization.dtype.
+# CLAUDE.md §11 still forbids silent downcast — the actually-applied dtype
+# stays pinned by quantization.dtype.
+#
+# These are **peak device memory for a full rollout**, measured on a GB10
+# (torch `max_memory_reserved`, i.e. what the caching allocator took from the
+# driver — the number that decides whether a load OOMs), not weight size:
+#
+#     int8    6.35 GB   (5.90 allocated)
+#     bf16    8.06 GB   (7.91 allocated)
+#     fp32   16.10 GB   (15.76 allocated)
+#
+# All three previous figures were **understated** — by 0.4, 1.1 and 2.1 GB
+# respectively. The bf16 one is what made this manifest look self-contradictory:
+# 7.0 reads as "fits an 8 GB card", while the header says bf16 OOMs there. The
+# header is right. bf16 peaks at 8.06 GB and an 8 GB GPU has less than that free
+# once the driver takes its cut; int8's 1.7 GB saving is what buys the headroom.
+#
+# Do not confuse these with **host** RSS during load, which reaches ~13 GiB
+# while the checkpoint is materialized on CPU before the device move. That is
+# host RAM, not VRAM, and it is the same order of magnitude for every dtype
+# here — which is exactly how "~13.6 GiB peak" ended up being read as a bf16
+# *VRAM* figure.
 min_vram_gb:
-  fp32: 14.0
-  bf16: 7.0
-  int8: 6.0
+  fp32: 16.1
+  bf16: 8.1
+  int8: 6.4
 weights_uri: "hf://lerobot/pi05_libero_finetuned_v044"
 
 # ── Preprocessing (all knobs needed to interpret IO) ───────────────────────
@@ -123,13 +170,13 @@ paper_url: "https://arxiv.org/abs/2410.24164"
 source_repo: "hf://lerobot/pi05_libero_finetuned_v044"
 
 description: >
-  π0.5 fine-tuned on LIBERO (v0.44), loaded from the upstream LeRobot
-  checkpoint and LLM.int8-packed at runtime so 8 GB GPUs can run the rollout
-  without the NF4 competence regression (NF4 scored 0/5 on libero_spatial;
-  int8 scores ~0.5–0.7). π0.5 uses a PaliGemma 3B backbone with a
-  flow-matching head. Weights are PI permissive-research — commercial use
-  needs a vendor agreement. See eval/scene_libero_spatial.json for the
-  locally-reproduced result.
+  π0.5 (PaliGemma 3B + flow-matching) fine-tuned on LIBERO v0.44,
+  LLM.int8-packed at load so 8 GB GPUs can run it at all — bf16 peaks at
+  8.1 GB and will not load there. int8 is a memory fit, not a free one: over
+  300 LIBERO-Spatial episodes it scores 62% vs bf16's 95%, task-dependent
+  (22-82%), and is ~2.6x slower per step. With >9 GB prefer
+  `--vla-extra dtype=bf16`, or openral-pro's TensorRT FP8; see the README. PI
+  permissive-research weights: commercial use needs a vendor agreement.
 
 # Action vocabulary surfaced to the reasoner LLM tool
 # palette so it can pick this skill by what it does (action verb +


### PR DESCRIPTION
## The tradeoff was never written down

`pi05-libero-int8` documented int8 as *restoring* competence (against NF4's 0/5) but never as *costing* it (against bf16). Measured on a GB10 — LIBERO-Spatial tasks 0/1/2, seed 42, `max_steps=220`, **n=50 per task per arm (300 episodes)**, same episodes and protocol, only `quantization.dtype` differing:

| dtype | task 0 | task 1 | task 2 | **Total** | Step latency |
|---|---|---|---|---|---|
| **bf16** | 98% | 94% | 94% | **143/150 = 95%** | 9.6 ms |
| int8 | 76% | **22%** | 82% | 93/150 = 62% | 24.8 ms |

int8 costs **~33 points** (Fisher exact **p = 4e-13**) and is **~2.6× slower per step**.

**The per-task row matters more than the total.** bf16 is steady (98/94/94); int8 swings 22–82%. The damage is task-dependent, so a single-task spot-check can land on 82% and look fine while task 1 is nearly non-functional. Measuring only task 0 would have understated the penalty threefold.

**None of this makes int8 wrong.** It buys 1.7 GB, and that is decisive on an 8 GB card where bf16 does not load at all — 62% beats not running. What was wrong was shipping the memory win without the accuracy bill, so a user on a 24 GB GPU pays it silently. Both README and manifest now say so and point at `--vla-extra dtype=bf16` (no manifest edit needed) or the TensorRT FP8 engine.

## Every `min_vram_gb` entry was understated

Peak device memory over a full rollout (`torch.cuda.max_memory_reserved` — what the allocator actually took from the driver):

| dtype | was | measured |
|---|---|---|
| fp32 | 14.0 | **16.1** |
| bf16 | 7.0 | **8.1** |
| int8 | 6.0 | **6.4** |

bf16's was the harmful one: 7.0 reads as "fits an 8 GB card" while the header says bf16 OOMs there — the manifest contradicted itself, and the wrong half was the machine-readable one `ral skill check` consumes.

The header's "~13.6 GiB peak" turns out to be **host RSS during load**, ~13 GiB for every dtype here. That is how it came to be read as a bf16 *VRAM* figure; called out inline so the next reader doesn't repeat it.

## Also

- `docs/reference/rskills.md` described this rSkill as "π0.5 NF4". It is int8 — NF4 is the variant that scored 0/5.
- Flags the committed n=10 eval as too noisy to compare dtypes with (binomial SD ~0.16 covers most of the spread above); left in place as provenance rather than overwritten.
- `SKILL.md` regenerated from the manifest; `generate_rskill_skillmd.py --check` clean.

## Testing

`tests/unit`: **4525 passed, 92 skipped**.

Measurements came out of validating the openral-pro π0.5 TensorRT work, which needed an honest unquantized baseline. The HF mirror (`OpenRAL/rskill-pi05-franka_panda-libero_spatial-int8`) is being updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7vfhWmKBxfsJqADfUMyJ4