### PR TITLE
fix(tests): skip the OmDet-Turbo e2e test on a stale CPU-only torchvision

### DIFF
--- a/tests/unit/test_omdet_turbo_detector.py
+++ b/tests/unit/test_omdet_turbo_detector.py
@@ -286,11 +286,47 @@ def _omdet_runtime_present() -> bool:
     return all(importlib.util.find_spec(mod) is not None for mod in mods)
 
 
+def _torchvision_cuda_nms_present() -> bool:
+    # pyproject.toml pins torchvision to the `pytorch-cu128` index on
+    # aarch64-linux specifically because the plain PyPI aarch64 wheel is
+    # CPU-only: its `_C.so` never registers a CUDA kernel for
+    # `torchvision::nms`, so the (CPU-registered, CUDA-absent) op raises
+    # `NotImplementedError` the moment OmDet-Turbo's post-processing calls
+    # `batched_nms` on GPU boxes. Both wheels report the same `0.24.1` version
+    # string (no `+cu128` local tag), so an aarch64 venv provisioned *before*
+    # this pin landed satisfies `uv sync` without reinstalling torchvision —
+    # `uv sync --frozen --reinstall-package torchvision` is required to pick up
+    # the CUDA build (see docs/reference/aarch64-support.md). Detect that stale
+    # state directly rather than let the e2e test crash on it: skip only when
+    # the installed torchvision genuinely cannot run CUDA nms.
+    if importlib.util.find_spec("torchvision") is None:
+        return True  # handled by _omdet_runtime_present's import gate instead
+    import torch
+    from torchvision.ops import nms
+
+    if not torch.cuda.is_available():
+        return True  # CPU path never needs the CUDA kernel
+    boxes = torch.tensor([[0.0, 0.0, 1.0, 1.0]], device="cuda")
+    scores = torch.tensor([0.9], device="cuda")
+    try:
+        nms(boxes, scores, 0.5)
+    except NotImplementedError:
+        return False
+    return True
+
+
 @pytest.mark.skipif(
     not (_gpu_present() and _omdet_runtime_present()),
     reason="needs a local GPU + the `omdet` group (torch/transformers/timm) to "
     "load omlab/omdet-turbo-swin-tiny-hf; run `just sync --group omdet` "
     "(the legitimate CI skip path, CLAUDE.md §12).",
+)
+@pytest.mark.skipif(
+    not _torchvision_cuda_nms_present(),
+    reason="installed torchvision has no CUDA `nms` kernel (CPU-only aarch64 "
+    "wheel, satisfying the `0.24.1` version pin without the `+cu128` build); "
+    "run `uv sync --frozen --reinstall-package torchvision` "
+    "(docs/reference/aarch64-support.md).",
 )
 def test_e2e_detects_indoor_objects_on_coco_sample() -> None:
     # coco_sample.jpg is the canonical COCO image of two cats and two remotes on

--- a/tools/test_selection.toml
+++ b/tools/test_selection.toml
@@ -81,6 +81,12 @@ isolate_globs = [
   # skip; isolated files intentionally permit that partial skip.
   "tests/unit/test_locateanything_detector.py",
   "tests/unit/test_qwen_scene_vlm.py",
+  # Same shape: 15 CPU contract tests plus one real-model e2e needing a local
+  # GPU (omlab/omdet-turbo-swin-tiny-hf, and a CUDA torchvision for its
+  # `batched_nms` post-processing). The batched `omdet` lane only runs when a
+  # PR touches this file, so its strictness stayed latent until one did — the
+  # e2e has always skipped on the GPU-less hosted runner.
+  "tests/unit/test_omdet_turbo_detector.py",
 ]
 
 # Non-code paths (fixtures, manifests, scenes) that no `import openral_*`


### PR DESCRIPTION
## Summary

- `test_e2e_detects_indoor_objects_on_coco_sample` was hard-failing on master with `NotImplementedError: Could not run 'torchvision::nms' with arguments from the 'CUDA' backend` — not the GPU-absent / deps-missing skip the file already had.
- Root cause is the exact operational trap `c906303` already documented: the plain PyPI aarch64 torchvision wheel is CPU-only, and both the CPU and CUDA (`pytorch-cu128`) torchvision builds report the identical `0.24.1` version string (no `+cu128` local tag). A venv provisioned before that pin landed satisfies `uv sync` without ever reinstalling torchvision, so it silently keeps running the CPU-only wheel even though `pyproject.toml`/`uv.lock` on this branch correctly pin the CUDA build.
- Neither the detector code nor the test's assertions are wrong — installing the pinned CUDA wheel makes all 16 tests in the file pass, including the e2e one (verified by shadowing a fetched `pytorch-cu128` torchvision wheel ahead of the stale one). So the honest fix is a precise `pytest.skip`, matching the style of the file's other two gates, not a loosened assertion.
- Added `_torchvision_cuda_nms_present()`: probes a real CUDA `nms` call and skips with a reason pointing straight at the fix (`uv sync --frozen --reinstall-package torchvision`, `docs/reference/aarch64-support.md`) when it's unavailable.

## Test plan

- [x] `tests/unit/test_omdet_turbo_detector.py` — before: 1 failed (the `torchvision::nms` `NotImplementedError`), 15 passed. After: 15 passed, 1 skipped with the precise reason above.
- [x] Confirmed the gate doesn't over-skip: shadowing a correct CUDA torchvision wheel ahead of the stale one makes all 16 tests pass, including the e2e one.
- [x] Full `tests/unit`, same environment, apples-to-apples (unmodified master test file vs. this fix, nothing else changed): before `1 failed, 4526 passed, 90 skipped`; after `4526 passed, 91 skipped` (0 failed).
- [x] `ruff check` / `ruff format --check` on the touched file: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7vfhWmKBxfsJqADfUMyJ4