### PR TITLE
fix(tests): stop the OmDet-Turbo nms probe aborting collection on pre-sm_70 GPUs

### DIFF
--- a/tests/unit/test_omdet_turbo_detector.py
+++ b/tests/unit/test_omdet_turbo_detector.py
@@ -286,6 +286,39 @@ def _omdet_runtime_present() -> bool:
     return all(importlib.util.find_spec(mod) is not None for mod in mods)
 
 
+def _cuda_arch_supported_by_torch_build() -> bool:
+    # The stock `pytorch-cu128` torch/torchvision wheels compile kernels for a
+    # fixed arch list (`sm_70` … `sm_120` for torch 2.9.1) and ship no
+    # `compute_*` PTX entry to JIT from, so on an older GPU — e.g. a Pascal
+    # GTX 1060, `sm_61` — *every* CUDA kernel launch dies with
+    # `CUDA error: no kernel image is available for execution on the device`.
+    # `torch.cuda.is_available()` is still True there, so the nms probe below
+    # would raise (as `torch.AcceleratorError`, a `RuntimeError` subclass) at
+    # *collection* time. Compare the device capability against the compiled
+    # arch list instead of discovering it by launching: a failed launch can
+    # leave the CUDA context poisoned for every later test in the session,
+    # whereas this check touches no kernel at all.
+    if importlib.util.find_spec("torch") is None:
+        return True  # handled by _omdet_runtime_present's import gate instead
+    import torch
+
+    if not torch.cuda.is_available():
+        return True  # CPU path never launches a CUDA kernel
+    major, minor = torch.cuda.get_device_capability()
+    device_arch = major * 10 + minor
+    for entry in torch.cuda.get_arch_list():
+        kind, _, num = entry.partition("_")
+        if not num.isdigit():
+            continue
+        # `sm_XX` is a cubin: it must match the device arch exactly.
+        # `compute_XX` is PTX: it JITs onto any device at or above XX.
+        if (kind == "sm" and int(num) == device_arch) or (
+            kind == "compute" and int(num) <= device_arch
+        ):
+            return True
+    return False
+
+
 def _torchvision_cuda_nms_present() -> bool:
     # pyproject.toml pins torchvision to the `pytorch-cu128` index on
     # aarch64-linux specifically because the plain PyPI aarch64 wheel is
@@ -306,12 +339,25 @@ def _torchvision_cuda_nms_present() -> bool:
 
     if not torch.cuda.is_available():
         return True  # CPU path never needs the CUDA kernel
+    if not _cuda_arch_supported_by_torch_build():
+        return True  # handled by the arch gate instead — do not launch a kernel
+    # `AcceleratorError` only exists on torch >= 2.9; on older torch the same
+    # launch failure surfaces as a plain `RuntimeError`, which it subclasses.
+    launch_error: type[BaseException] = getattr(torch, "AcceleratorError", RuntimeError)
     boxes = torch.tensor([[0.0, 0.0, 1.0, 1.0]], device="cuda")
     scores = torch.tensor([0.9], device="cuda")
     try:
         nms(boxes, scores, 0.5)
     except NotImplementedError:
         return False
+    except launch_error:
+        # Any other missing-kernel-image / launch failure the arch gate above
+        # did not predict: skip rather than abort collection.
+        return False
+    finally:
+        # Don't hold a collection-time CUDA allocation for the whole session.
+        del boxes, scores
+        torch.cuda.empty_cache()
     return True
 
 
@@ -320,6 +366,14 @@ def _torchvision_cuda_nms_present() -> bool:
     reason="needs a local GPU + the `omdet` group (torch/transformers/timm) to "
     "load omlab/omdet-turbo-swin-tiny-hf; run `just sync --group omdet` "
     "(the legitimate CI skip path, CLAUDE.md §12).",
+)
+@pytest.mark.skipif(
+    not _cuda_arch_supported_by_torch_build(),
+    reason="the local GPU's compute capability is outside the arch list this "
+    "torch/torchvision build ships kernels for (pre-sm_70 Pascal and older "
+    "against the cu128 wheels), so OmDet-Turbo's CUDA `batched_nms` fails with "
+    "`no kernel image is available for execution on the device`; needs an "
+    "sm_70+ GPU or a torch built for this arch.",
 )
 @pytest.mark.skipif(
     not _torchvision_cuda_nms_present(),


### PR DESCRIPTION
## What changed

`tests/unit/test_omdet_turbo_detector.py` gains a
`_cuda_arch_supported_by_torch_build()` gate that compares the local GPU's
compute capability against `torch.cuda.get_arch_list()`. The e2e test skips
on a mismatch, `_torchvision_cuda_nms_present()` returns early instead of
launching a kernel, and its probe additionally catches the launch failure
(`torch.AcceleratorError` on torch >= 2.9, plain `RuntimeError` before it —
which `AcceleratorError` subclasses) and frees its CUDA tensors in a
`finally`. The stale-CPU-only-torchvision skip from #109 is untouched: the
`NotImplementedError` branch and its reason string still fire exactly as
before, on the aarch64 hosts they were written for.

## Why

`_torchvision_cuda_nms_present()` (added in b999138, #109) probes CUDA nms by
launching it, and catches only `NotImplementedError`. Both skipif conditions
are evaluated at import, so on a host where the probe raises anything else
the exception escapes during **pytest collection** and takes down the entire
unit suite — not one test, all of them:

```
E   torch.AcceleratorError: CUDA error: no kernel image is available for
    execution on the device
ERROR tests/unit/test_omdet_turbo_detector.py
!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!
no tests collected, 1 error in 2.56s
```

That is exactly what happens on a Pascal-class dev host (GTX 1060, `sm_61`).
Note this is a *different* root cause from the one #109 fixed, and the fix it
prescribes does not apply: the torchvision here is already the correct CUDA
build (`0.24.1+cu128`, alongside `torch 2.9.1+cu128`), so reinstalling it
changes nothing. The stock cu128 wheels compile cubins for
`['sm_70', 'sm_75', 'sm_80', 'sm_86', 'sm_90', 'sm_100', 'sm_120']` and ship
no `compute_*` PTX entry to JIT from, so a `sm_61` device has no runnable
kernel image for `torchvision::nms` — or for any other CUDA kernel. Yet
`torch.cuda.is_available()` is still True, so the probe sails past the
existing CPU guard and launches.

Detecting this by launching a kernel is the wrong instrument regardless of
the exception caught: a failed CUDA launch can leave the context poisoned for
every later test in the session. So the new gate compares the device
capability against the compiled arch list and touches no kernel at all —
matching a `sm_XX` cubin exactly, or any `compute_XX` PTX at or below the
device arch, which is how the CUDA loader itself resolves one. The broadened
`except` remains as a backstop for a missing kernel image the arch list does
not predict, and is a two-type tuple rather than a blanket handler, resolved
through `getattr` so it introduces no `AttributeError` on a torch without
`AcceleratorError`.

## How tested

Host: x86_64, GTX 1060 6GB (`sm_61`), torch 2.9.1+cu128, torchvision
0.24.1+cu128, default `just sync` venv.

Before, the whole unit suite is unrunnable:

```
$ uv run pytest tests/unit/test_omdet_turbo_detector.py --collect-only -q
ERROR tests/unit/test_omdet_turbo_detector.py - torch.AcceleratorError: CUDA ...
!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!
no tests collected, 1 error in 2.56s
```

After, the file collects and the e2e skips with a reason that names the
actual blocker:

```
$ uv run pytest tests/unit/test_omdet_turbo_detector.py -q
SKIPPED [1] tests/unit/test_omdet_turbo_detector.py:364: the local GPU's
compute capability is outside the arch list this torch/torchvision build
ships kernels for ...
15 passed, 1 skipped, 3 warnings in 2.44s
```

Full unit suite, same host, after: `4516 passed, 103 skipped` in 127.78s
(0 failed, 0 errors) — versus zero tests collected before.

`ruff check` / `ruff format --check` on the touched file: clean. `mypy` on
the file reports the same 3 pre-existing errors before and after this change
(2 `union-attr`, 1 untyped `torchvision.ops` import); `just lint`'s mypy pass
covers `-p openral_*` and `tools/`, not `tests/`, so none of them are in the
lint gate. `grep -rn _torchvision_cuda_nms_present docs/methods/` is empty —
both helpers are file-local test gates, not public symbols, so no
`docs/methods/` entry is due. No package, schema, or layer surface changed,
so the repo state map is unaffected.

Signed-off-by: Adrian Llopart <adrianllopart@gmail.com>
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YUhD1uz93qMFJQsNxyTEM5