### PR TITLE
fix(cli): let OPENRAL_REPO_ROOT override the launcher's baked-in checkout

### DIFF
--- a/docs/contributing/toolchain.md
+++ b/docs/contributing/toolchain.md
@@ -215,6 +215,28 @@ just install-cli
 
 The wrapper sources the ROS 2 distro overlay and the colcon workspace overlay before delegating to `.venv/bin/openral`, so ROS 2 node/topic/action commands work transparently. Pure-Python commands (`openral doctor`, `openral detect`, etc.) still work even if ROS 2 is not yet built.
 
+### Which checkout does `openral` run? (`OPENRAL_REPO_ROOT`)
+
+The wrapper bakes in the checkout that generated it. That is the right default for a single clone, but it is a **provenance hazard** the moment you have two — a git worktree used for validation, say. Without an override the wrapper would exec the *generating* checkout's venv, colcon overlay and `robots/` manifests no matter where you invoked it from, so a run could be attributed to the wrong branch with nothing in the log to show it (this happened for real on a DGX Spark).
+
+`OPENRAL_REPO_ROOT` is the escape hatch, and the behaviour is:
+
+| Situation | What runs | What you see |
+| --- | --- | --- |
+| `OPENRAL_REPO_ROOT` unset, cwd anywhere in one checkout | the baked-in checkout | nothing (unchanged) |
+| `OPENRAL_REPO_ROOT=/path/to/checkout` | that checkout | `openral: repo root /path/to/checkout (OPENRAL_REPO_ROOT override; installed default …)` on stderr |
+| `OPENRAL_REPO_ROOT` points at a tree with no executable `.venv/bin/openral` | nothing — exit 1 | an error naming the tree; it never falls back to the baked one |
+| `OPENRAL_REPO_ROOT` unset, but cwd is inside a *different* checkout that has its own `.venv/bin/openral` | still the baked-in checkout | `WARNING: cwd is inside the OpenRAL checkout …, but this launcher is baked to …` on stderr |
+
+So when you validate from a worktree, either export the override:
+
+```bash
+export OPENRAL_REPO_ROOT=$(git rev-parse --show-toplevel)
+openral deploy sim --config …          # stderr records the root that ran
+```
+
+…or re-run `just install-cli` from that worktree to re-bake the default. The stderr line is deliberate: it means a captured run log always names the tree that produced it.
+
 Bare `openral` (no args) drops into an interactive REPL where subcommands run without the prefix (`sim run --config …`); pass a subcommand for one-shot mode in scripts/CI.
 
 ```bash
@@ -238,6 +260,7 @@ openral sim run --config FILE    # run a SimScene YAML end-to-end
 ## Tooling self-help
 
 - **`openral` prints `AMENT_TRACE_SETUP_FILES: unbound variable` and exits?** Your `~/.local/bin/openral` predates the fix that sources the (not-`set -u`-safe) ROS 2 overlays with nounset disabled. Re-run `just install-cli` to regenerate it.
+- **`openral` seems to run the wrong branch / wrong `robots/` manifests?** You are almost certainly in a second checkout while `~/.local/bin/openral` is baked to the first. Recent wrappers print a `WARNING: cwd is inside the OpenRAL checkout …` line for exactly this; fix it with `export OPENRAL_REPO_ROOT=$(git rev-parse --show-toplevel)` or by re-running `just install-cli` from the checkout you mean. If you see no warning at all, your wrapper predates the fix — regenerate it with `just install-cli`.
 - **Python import unclear?** `uv run python -c 'import openral_<pkg>; print(openral_<pkg>.__file__)'`.
 - **ROS 2 topic missing?** `ros2 topic list -t` in a `source install/setup.bash`-ed shell.
 - **Schema diff?** `just schema-export` and check `git diff python/openral_core/schemas/`.

--- a/scripts/install_cli.py
+++ b/scripts/install_cli.py
@@ -5,11 +5,28 @@ Called by `just install-cli` (and transitively by `just quickstart`).
 Idempotent — safe to re-run after moving the repo or upgrading Python.
 
 The generated wrapper:
-  1. Sources the ROS 2 distro overlay (/opt/ros/*/setup.bash) if present.
-  2. Sources the colcon workspace overlay (<repo>/install/setup.bash) if built.
-  3. exec-replaces itself with .venv/bin/openral, forwarding all args.
+  1. Resolves which checkout to drive (see below).
+  2. Sources the ROS 2 distro overlay (/opt/ros/*/setup.bash) if present.
+  3. Sources the colcon workspace overlay (<repo>/install/setup.bash) if built.
+  4. exec-replaces itself with .venv/bin/openral, forwarding all args.
      So `openral` (no args) drops into the REPL and `openral <cmd>` is
      one-shot, matching the behaviour `just openral` used to provide.
+
+Repo-root resolution is a *provenance* control, not a convenience. The wrapper
+bakes in the checkout that generated it, so running `openral` from a second
+checkout (a git worktree used for validation) used to silently execute the
+first checkout's venv, colcon overlay and ``robots/`` manifests — a validation
+run on a DGX Spark was attributed to the wrong branch with nothing in the log
+to show it. The generated wrapper therefore:
+
+  * honours ``OPENRAL_REPO_ROOT`` as an explicit override, validating that the
+    named tree really has an executable ``.venv/bin/openral`` before exec'ing
+    it (hard error otherwise — never a silent fall back to the baked path), and
+    printing the root it settled on to stderr so every log records it;
+  * warns (non-fatally) when the cwd sits inside a *different* OpenRAL checkout
+    than the baked-in one, which is the shape of the Spark incident.
+
+The single-checkout default is unchanged and stays silent.
 """
 
 from __future__ import annotations
@@ -47,9 +64,50 @@ _PATH_SNIPPET = f'\n{_PATH_MARKER}\nexport PATH="$HOME/.local/bin:$PATH"\n'
 _WRAPPER_TEMPLATE = r"""#!/usr/bin/env bash
 # OpenRAL CLI launcher — written by `just install-cli` / `just quickstart`.
 # Re-run `just install-cli` if you move the repo.
+#
+# Which checkout does this run? In order:
+#   1. $OPENRAL_REPO_ROOT, when set — validated, announced on stderr.
+#   2. The baked-in checkout below (the one that generated this file).
+# A cwd inside a DIFFERENT OpenRAL checkout is warned about, not overridden:
+# a launcher must never quietly execute a tree the caller didn't mean.
 set -euo pipefail
 
 _OPENRAL_DIR="__REPO__"
+_OPENRAL_BAKED_DIR="$_OPENRAL_DIR"
+
+if [ -n "${OPENRAL_REPO_ROOT:-}" ]; then
+    _OPENRAL_OVERRIDE="$OPENRAL_REPO_ROOT"
+    # Normalise so the announced root is absolute and symlink-free.
+    if [ -d "$_OPENRAL_OVERRIDE" ]; then
+        _OPENRAL_OVERRIDE=$(cd "$_OPENRAL_OVERRIDE" && pwd -P)
+    fi
+    if [ ! -x "$_OPENRAL_OVERRIDE/.venv/bin/openral" ]; then
+        echo "ERROR: OPENRAL_REPO_ROOT=$OPENRAL_REPO_ROOT has no executable .venv/bin/openral." >&2
+        echo "       Run \`just sync --all-packages\` inside that checkout, or unset" >&2
+        echo "       OPENRAL_REPO_ROOT to use the installed default ($_OPENRAL_BAKED_DIR)." >&2
+        exit 1
+    fi
+    _OPENRAL_DIR="$_OPENRAL_OVERRIDE"
+    # One line, so a captured log always names the tree that actually ran.
+    echo "openral: repo root $_OPENRAL_DIR" \
+         "(OPENRAL_REPO_ROOT override; installed default $_OPENRAL_BAKED_DIR)" >&2
+else
+    # Provenance guard: is the cwd inside a different OpenRAL checkout? If so
+    # the baked-in tree still wins (unchanged behaviour) but we say so loudly,
+    # because that mismatch silently misattributes validation runs.
+    _OPENRAL_CWD_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+    if [ -n "$_OPENRAL_CWD_ROOT" ] && [ -d "$_OPENRAL_CWD_ROOT" ]; then
+        _OPENRAL_CWD_ROOT=$(cd "$_OPENRAL_CWD_ROOT" && pwd -P)
+        if [ "$_OPENRAL_CWD_ROOT" != "$_OPENRAL_DIR" ] \
+           && [ -x "$_OPENRAL_CWD_ROOT/.venv/bin/openral" ]; then
+            echo "WARNING: cwd is inside the OpenRAL checkout $_OPENRAL_CWD_ROOT," >&2
+            echo "         but this launcher is baked to $_OPENRAL_DIR — running the latter's" >&2
+            echo "         venv, overlay and robots/ manifests. To run THIS checkout instead:" >&2
+            echo "           export OPENRAL_REPO_ROOT=$_OPENRAL_CWD_ROOT" >&2
+            echo "         (or re-run \`just install-cli\` from it to re-bake the default)." >&2
+        fi
+    fi
+fi
 
 # Source an ament-generated overlay that is not `set -u`/`set -e` safe.
 # Disable nounset+errexit only around the `source`, then restore them.
@@ -90,8 +148,12 @@ exec "$_VENV_BIN" "$@"
 def render_wrapper(repo: Path) -> str:
     """Return the ``openral`` launcher bash with ``repo`` baked in as the repo dir.
 
+    ``repo`` is the *default* checkout only: the rendered wrapper lets
+    ``OPENRAL_REPO_ROOT`` override it at run time (see the module docstring).
+
     Args:
-        repo: Absolute path to the OpenRAL checkout the wrapper should drive.
+        repo: Absolute path to the OpenRAL checkout the wrapper should drive
+            unless ``OPENRAL_REPO_ROOT`` says otherwise.
 
     Returns:
         The complete bash source of the wrapper, ready to write to disk.
@@ -102,6 +164,8 @@ def render_wrapper(repo: Path) -> str:
         >>> "set -euo pipefail" in script
         True
         >>> '_OPENRAL_DIR="/opt/openral"' in script
+        True
+        >>> "OPENRAL_REPO_ROOT" in script  # run-time override honoured
         True
         >>> "__REPO__" in script  # token fully substituted
         False

--- a/tests/unit/test_install_cli.py
+++ b/tests/unit/test_install_cli.py
@@ -14,6 +14,16 @@ shape under ``tmp_path`` (no mocks / no monkey-patching — CLAUDE.md §1.11),
 including a deliberately nounset-unsafe ``install/setup.bash`` overlay and a
 stub ``.venv/bin/openral``, render the wrapper against it, run it with real
 bash, and assert it sources the unsafe overlay and still reaches ``exec``.
+
+The second family of tests covers *provenance*. The wrapper bakes in the
+checkout that generated it, so running ``openral`` from a second checkout used
+to silently execute the first one's venv, overlay and ``robots/`` manifests —
+which is how a DGX Spark validation run got attributed to the wrong branch.
+Those tests build two real checkouts under ``tmp_path`` (one of them a real
+``git init`` repo, because the mismatch guard probes ``git rev-parse``) and
+pin down the three-way behaviour matrix: baked default runs silently,
+``OPENRAL_REPO_ROOT`` redirects and announces itself, and a cwd inside a
+different checkout warns without changing which tree runs.
 """
 
 from __future__ import annotations
@@ -39,21 +49,33 @@ def _load_install_cli() -> ModuleType:
     return module
 
 
-def _make_fake_repo(tmp_path: Path, *, with_venv: bool = True) -> Path:
+def _make_fake_repo(
+    tmp_path: Path,
+    *,
+    with_venv: bool = True,
+    name: str = "openral",
+    git_init: bool = False,
+) -> Path:
     """Build a throwaway OpenRAL checkout shape that the wrapper can drive.
 
     The ``install/setup.bash`` overlay is intentionally nounset-unsafe — it
     reproduces the exact ament idiom (``[ -n "$AMENT_TRACE_SETUP_FILES" ]``)
-    that aborts the wrapper under ``set -u``. The stub ``.venv/bin/openral``
-    prints a sentinel and echoes its args so the test can prove ``exec`` ran.
+    that aborts the wrapper under ``set -u``. Both the overlay and the stub
+    ``.venv/bin/openral`` stamp their own checkout path into the output, so a
+    test can prove *which* tree supplied the overlay and which supplied the
+    CLI — that is exactly what the repo-root override has to get right.
+
+    ``git_init`` makes the checkout a real git repository, which is what the
+    wrapper's cwd-mismatch guard probes with ``git rev-parse --show-toplevel``.
     """
-    repo = tmp_path / "openral"
+    repo = (tmp_path / name).resolve()
     install = repo / "install"
     install.mkdir(parents=True)
     (install / "setup.bash").write_text(
         "# ament-style overlay: NOT nounset-safe (reads an unset var).\n"
         'if [ -n "$AMENT_TRACE_SETUP_FILES" ]; then echo trace; fi\n'
         "export OPENRAL_OVERLAY_SOURCED=1\n"
+        f'export OPENRAL_OVERLAY_FROM="{repo}"\n'
     )
     if with_venv:
         venv_bin = repo / ".venv" / "bin"
@@ -62,8 +84,16 @@ def _make_fake_repo(tmp_path: Path, *, with_venv: bool = True) -> Path:
         cli.write_text(
             "#!/usr/bin/env bash\n"
             'echo "REACHED_EXEC overlay=${OPENRAL_OVERLAY_SOURCED:-unset} args=$*"\n'
+            f'echo "EXEC_REPO={repo}"\n'
+            'echo "OVERLAY_REPO=${OPENRAL_OVERLAY_FROM:-unset}"\n'
         )
         cli.chmod(cli.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    if git_init:
+        subprocess.run(  # reason: a real git repo is what the wrapper's guard probes
+            ["git", "init", "-q", str(repo)],
+            check=True,
+            capture_output=True,
+        )
     return repo
 
 
@@ -75,12 +105,30 @@ def _write_rendered_wrapper(install_cli: ModuleType, repo: Path, dest: Path) -> 
     return dest
 
 
-def _run_wrapper(wrapper: Path, *args: str) -> subprocess.CompletedProcess[str]:
+def _run_wrapper(
+    wrapper: Path,
+    *args: str,
+    cwd: Path,
+    repo_root_env: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the generated launcher from ``cwd`` with a controlled environment.
+
+    ``cwd`` is always explicit because the wrapper now inspects it (the
+    different-checkout guard), and ``OPENRAL_REPO_ROOT`` is always set or
+    explicitly cleared so an exported value in the developer's shell cannot
+    leak into the run.
+    """
+    env = {**os.environ}
+    env.pop("OPENRAL_REPO_ROOT", None)
+    if repo_root_env is not None:
+        env["OPENRAL_REPO_ROOT"] = repo_root_env
     return subprocess.run(  # reason: running our own generated bash launcher
         [str(wrapper), *args],
         capture_output=True,
         text=True,
         check=False,
+        cwd=str(cwd),
+        env=env,
     )
 
 
@@ -95,7 +143,7 @@ def test_wrapper_sources_nounset_unsafe_overlay_and_reaches_exec(tmp_path: Path)
     repo = _make_fake_repo(tmp_path)
     wrapper = _write_rendered_wrapper(install_cli, repo, tmp_path / "bin" / "openral")
 
-    proc = _run_wrapper(wrapper, "doctor", "--flag")
+    proc = _run_wrapper(wrapper, "doctor", "--flag", cwd=tmp_path)
 
     assert proc.returncode == 0, proc.stderr
     assert "AMENT_TRACE_SETUP_FILES: unbound variable" not in proc.stderr
@@ -120,7 +168,7 @@ def test_wrapper_errors_clearly_when_venv_cli_missing(tmp_path: Path) -> None:
     repo = _make_fake_repo(tmp_path, with_venv=False)
     wrapper = _write_rendered_wrapper(install_cli, repo, tmp_path / "bin" / "openral")
 
-    proc = _run_wrapper(wrapper)
+    proc = _run_wrapper(wrapper, cwd=tmp_path)
 
     assert proc.returncode == 1
     assert ".venv/bin/openral not found" in proc.stderr
@@ -134,6 +182,91 @@ def test_render_wrapper_substitutes_repo_token(tmp_path: Path) -> None:
     script = install_cli.render_wrapper(repo)
     assert "__REPO__" not in script
     assert f'_OPENRAL_DIR="{repo}"' in script
+
+
+def test_repo_root_override_redirects_venv_and_overlay_and_announces_it(tmp_path: Path) -> None:
+    """``OPENRAL_REPO_ROOT`` wins over the baked-in checkout, visibly.
+
+    Provenance regression: on a DGX Spark a validation run launched from a git
+    worktree silently executed the *parent* checkout's venv, overlay and
+    ``robots/`` manifests, so the result was attributed to the wrong branch.
+    The override must redirect BOTH the colcon overlay and the exec'd CLI, and
+    must name the root it chose on stderr so the run log records which tree ran.
+    """
+    install_cli = _load_install_cli()
+    baked = _make_fake_repo(tmp_path, name="openral-main")
+    other = _make_fake_repo(tmp_path, name="openral-worktree")
+    wrapper = _write_rendered_wrapper(install_cli, baked, tmp_path / "bin" / "openral")
+
+    proc = _run_wrapper(wrapper, "doctor", cwd=tmp_path, repo_root_env=str(other))
+
+    assert proc.returncode == 0, proc.stderr
+    assert f"EXEC_REPO={other}" in proc.stdout
+    assert f"OVERLAY_REPO={other}" in proc.stdout
+    assert f"EXEC_REPO={baked}" not in proc.stdout
+    # One stderr line names the root actually used (and the default it replaced).
+    assert f"openral: repo root {other}" in proc.stderr
+    assert "OPENRAL_REPO_ROOT override" in proc.stderr
+    assert str(baked) in proc.stderr
+
+
+def test_repo_root_override_without_a_venv_cli_fails_instead_of_falling_back(
+    tmp_path: Path,
+) -> None:
+    """A bogus override is a hard error — never a silent fall back to the baked tree.
+
+    Falling back would recreate the exact hazard the override exists to close:
+    the caller asks for checkout B and gets checkout A's code with no signal.
+    """
+    install_cli = _load_install_cli()
+    baked = _make_fake_repo(tmp_path, name="openral-main")
+    unsynced = _make_fake_repo(tmp_path, name="openral-unsynced", with_venv=False)
+    wrapper = _write_rendered_wrapper(install_cli, baked, tmp_path / "bin" / "openral")
+
+    proc = _run_wrapper(wrapper, cwd=tmp_path, repo_root_env=str(unsynced))
+
+    assert proc.returncode == 1
+    assert "REACHED_EXEC" not in proc.stdout  # the baked CLI must NOT have run
+    assert f"OPENRAL_REPO_ROOT={unsynced}" in proc.stderr
+    assert "no executable .venv/bin/openral" in proc.stderr
+    assert "just sync --all-packages" in proc.stderr
+
+
+def test_warns_when_cwd_is_a_different_openral_checkout(tmp_path: Path) -> None:
+    """cwd in another usable checkout → WARNING on stderr, baked tree still runs.
+
+    This is the Spark footgun made visible. It stays a warning, not an error:
+    the baked default must keep working, and the launcher must not silently
+    *switch* trees either — it only tells the operator what it is about to do.
+    """
+    install_cli = _load_install_cli()
+    baked = _make_fake_repo(tmp_path, name="openral-main")
+    worktree = _make_fake_repo(tmp_path, name="openral-worktree", git_init=True)
+    wrapper = _write_rendered_wrapper(install_cli, baked, tmp_path / "bin" / "openral")
+
+    proc = _run_wrapper(wrapper, "deploy", cwd=worktree)
+
+    assert proc.returncode == 0, proc.stderr
+    assert "WARNING: cwd is inside the OpenRAL checkout" in proc.stderr
+    assert str(worktree) in proc.stderr
+    assert f"baked to {baked}" in proc.stderr
+    assert f"export OPENRAL_REPO_ROOT={worktree}" in proc.stderr
+    # Behaviour is unchanged: the baked checkout is what actually executes.
+    assert f"EXEC_REPO={baked}" in proc.stdout
+
+
+def test_no_mismatch_warning_for_the_normal_single_checkout_case(tmp_path: Path) -> None:
+    """cwd inside the baked checkout itself → silent, exactly as before."""
+    install_cli = _load_install_cli()
+    baked = _make_fake_repo(tmp_path, name="openral-main", git_init=True)
+    wrapper = _write_rendered_wrapper(install_cli, baked, tmp_path / "bin" / "openral")
+
+    proc = _run_wrapper(wrapper, cwd=baked)
+
+    assert proc.returncode == 0, proc.stderr
+    assert "WARNING: cwd is inside" not in proc.stderr
+    assert "OPENRAL_REPO_ROOT override" not in proc.stderr
+    assert f"EXEC_REPO={baked}" in proc.stdout
 
 
 def test_bin_dir_env_override_targets_custom_dir(tmp_path: Path) -> None:


### PR DESCRIPTION
## What changed

`scripts/install_cli.py` (the generator behind `just install-cli` / `just quickstart`) now renders a launcher that resolves its repo root explicitly instead of always using the path baked in at install time.

| Situation | What runs | What you see |
| --- | --- | --- |
| No override, one checkout | baked-in checkout | nothing — **unchanged** |
| `OPENRAL_REPO_ROOT=/path` | that checkout (venv **and** colcon overlay **and** `robots/`) | `openral: repo root /path (OPENRAL_REPO_ROOT override; installed default …)` on stderr |
| `OPENRAL_REPO_ROOT` points at a tree with no executable `.venv/bin/openral` | nothing — exit 1 | error naming the tree; **never** falls back to the baked path |
| No override, but cwd is inside a *different* checkout that has its own `.venv/bin/openral` | still the baked-in checkout | `WARNING: cwd is inside the OpenRAL checkout …, but this launcher is baked to …` + the `export OPENRAL_REPO_ROOT=…` fix |

`install-cli` writes exactly **one** launcher (`~/.local/bin/openral`), so there is no sibling wrapper needing the same fix.

Docs: `docs/contributing/toolchain.md` gains the behaviour matrix under the CLI section plus a self-help bullet for "`openral` seems to run the wrong branch".

## Why

The generated launcher hardcodes `_OPENRAL_DIR` to the checkout that generated it. Run `openral` from a *different* checkout — a git worktree used for validation — and the wrapper silently exec'd the **original** checkout's venv, colcon overlay and `robots/` manifests. The run executed the wrong code with nothing on stdout or stderr to say so, contaminating result provenance.

This is not hypothetical: **on a DGX Spark, a validation run launched from a worktree silently executed the parent checkout's branch**, and the results were attributed to the wrong tree. Nothing in the captured log distinguished the two.

Two design points worth calling out:

- **A bad override is a hard error, not a fallback.** Silently falling back to the baked path when `OPENRAL_REPO_ROOT` is unusable would recreate exactly the hazard the override exists to close — the caller asks for checkout B and gets checkout A's code with no signal.
- **The cwd mismatch warns, it does not switch.** The hardcoded default keeps working unchanged for the normal single-checkout case (CLAUDE.md §1.4 — no hidden fallbacks in either direction). The launcher only tells the operator what it is about to do.

The wrapper stays `set -euo pipefail`-safe; the new block is shellcheck-clean at `-S style` (the only finding in the rendered script is the pre-existing SC2012 on the `/opt/ros/*/setup.bash` glob, untouched here).

## How tested

`tests/unit/test_install_cli.py` — real bash, real `git init` repos, no mocks (CLAUDE.md §1.11). Two throwaway checkouts are built under `tmp_path`; both the `install/setup.bash` overlay and the stub `.venv/bin/openral` stamp their own checkout path into the output, so the assertions prove *which* tree supplied the overlay and which supplied the exec'd binary — not merely that something ran.

Four new tests:

- `test_repo_root_override_redirects_venv_and_overlay_and_announces_it` — override redirects both overlay and exec target, and prints the stderr provenance line.
- `test_repo_root_override_without_a_venv_cli_fails_instead_of_falling_back` — exit 1, baked CLI never runs.
- `test_warns_when_cwd_is_a_different_openral_checkout` — the Spark shape: WARNING on stderr, baked tree still executes.
- `test_no_mismatch_warning_for_the_normal_single_checkout_case` — regression guard that the default stays silent.

`_run_wrapper` now passes `cwd` and a scrubbed `OPENRAL_REPO_ROOT` explicitly, so the pre-existing tests no longer depend on the invoking shell's cwd/env.

```
$ pytest tests/unit/test_install_cli.py -q
9 passed in 1.17s
```

Confirmed the tests actually catch the bug — reverting only `scripts/install_cli.py` and re-running fails 3 of the 4 new tests (the fourth is the unchanged-default guard, correctly green both ways), with the failure output showing the hazard verbatim: `EXEC_REPO=…/openral-main` while cwd was `…/openral-worktree`, `stderr=''`.

Also exercised live against the real checkout, not just fixtures:

```
$ OPENRAL_REPO_ROOT=<worktree without .venv> ./openral-live --help
ERROR: OPENRAL_REPO_ROOT=… has no executable .venv/bin/openral.
       Run `just sync --all-packages` inside that checkout, or unset
       OPENRAL_REPO_ROOT to use the installed default (/home/adrian/workspace/openral).
exit=1

$ OPENRAL_REPO_ROOT=/home/adrian/workspace/openral ./openral-live --version
openral: repo root /home/adrian/workspace/openral (OPENRAL_REPO_ROOT override; installed default …)
<real openral CLI reached>
```

`ruff check`, `ruff format --check`, `mypy --strict` and the `render_wrapper` doctest all clean.

Repo state map / `docs/methods/` untouched: no package, schema, layer or public-symbol surface changed (`render_wrapper`'s signature is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUhD1uz93qMFJQsNxyTEM5
