### PR TITLE
fix(ci): stop the DCO hook duplicating trailers and splitting bodies on `---`

### DIFF
--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -29,9 +29,48 @@ fi
 
 trailer="Signed-off-by: $name <$email>"
 
-# Idempotent: only append when this exact trailer isn't already present
-# (covers `git commit -s`, amend, and re-runs).
-if ! grep -qiF "$trailer" "$msg_file"; then
-    git interpret-trailers --if-exists doNothing \
+# Idempotent, keyed on the EMAIL — the stable half of the identity. Matching on
+# the fully formatted trailer was wrong: `user.name` ("AdrianLlopart") often
+# differs in spelling from the name already recorded in the message ("Adrian
+# Llopart"), so the check missed and a *second* sign-off was appended every time
+# a rebase replayed the commit (reword/edit steps and `rebase --continue` do
+# re-run this hook, with the ORIGINAL message).
+#
+# Anchored to the start of the line so a diff hunk in a `--verbose` message
+# ("+Signed-off-by: …") can never be mistaken for an existing trailer.
+if grep -i '^[[:space:]]*Signed-off-by:' "$msg_file" | grep -qiF "<$email>"; then
+    exit 0
+fi
+
+# `git interpret-trailers` treats a lone `---` as the end of the message (the
+# start of a patch), and inserts the trailer *above* it — which splits a body
+# that legitimately contains `---` and buries the trailer mid-message. Disable
+# that with `--no-divider` (git >= 2.24); older git has no such option, so fall
+# back to appending the trailer ourselves.
+# (`-h` exits 129, so capture first — under `pipefail` that status would
+# otherwise mask grep's answer and always send us down the fallback.)
+trailers_help="$(git interpret-trailers -h 2>&1 || true)"
+if printf '%s\n' "$trailers_help" | grep -q -- '--no-divider'; then
+    git interpret-trailers --no-divider --if-exists doNothing \
         --trailer "$trailer" --in-place "$msg_file"
+else
+    # Insert before the `--verbose` scissors line if there is one (everything
+    # below it is stripped), otherwise at the end. A blank separator is added
+    # only when the message doesn't already end in a trailer block, so we never
+    # split an existing `Co-Authored-By:`/`Signed-off-by:` group.
+    sep=""
+    if [ -s "$msg_file" ]; then
+        last="$(grep -v '^#' "$msg_file" | grep -v '^[[:space:]]*$' | tail -n 1 || true)"
+        if [ -n "$last" ] && ! printf '%s\n' "$last" | grep -qE '^[A-Za-z][A-Za-z-]*:[[:space:]]'; then
+            sep="yes"
+        fi
+    fi
+    tmp_file="$msg_file.dco.$$"
+    awk -v trailer="$trailer" -v sep="$sep" '
+        function emit() { if (sep != "") print ""; print trailer; done = 1 }
+        /^#.*>8/ && !done { emit() }
+        { print }
+        END { if (!done) emit() }
+    ' "$msg_file" >"$tmp_file"
+    mv "$tmp_file" "$msg_file"
 fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,11 @@ is signed off.
 
 **Tip — never think about `-s` again.** `just bootstrap` installs the git hooks
 (`.githooks/`), including a `prepare-commit-msg` hook that auto-appends the
-`Signed-off-by` trailer to any commit missing one, using your Git identity. To
+`Signed-off-by` trailer to any commit missing one, using your Git identity. It
+recognises an existing sign-off by your **email**, so a rebase that replays a
+commit (`reword`, `edit`, `rebase --continue`) never adds a second trailer even
+if the recorded name is spelled differently from your `user.name`; a `---` line
+in the body is treated as prose, not as the end of the message. To
 enable them without a full bootstrap, run `just install-hooks` — it points
 `core.hooksPath` at `.githooks/` and builds the pre-commit environments, so the
 same command also wires up ruff, ruff-format, mypy, codespell, and the

--- a/tests/unit/test_dco_sign_off_hook.py
+++ b/tests/unit/test_dco_sign_off_hook.py
@@ -1,0 +1,185 @@
+"""Regression tests for the DCO sign-off hook (``.githooks/prepare-commit-msg``).
+
+The hook auto-appends a ``Signed-off-by:`` trailer so the ``Verify Signed-off-by``
+CI passes without anyone remembering ``git commit -s``. Two defects corrupted a
+real commit (``990d70b``) during a stack rebase:
+
+1. Idempotence keyed on the *formatted* trailer built from ``git config
+   user.name``. A configured ``AdrianLlopart`` never matched the ``Adrian
+   Llopart`` already recorded in the message, so every rebase step that re-runs
+   the hook (``reword``/``edit``, ``rebase --continue``) appended another
+   sign-off.
+2. ``git interpret-trailers`` reads a lone ``---`` as the start of a patch and
+   inserted the trailer *above* it — splitting a body that legitimately contains
+   ``---`` and burying the trailer in the middle of the prose.
+
+These tests drive the real hook through real ``git commit`` and ``git rebase``
+invocations in a throwaway repository, so they neither need nor are affected by
+the hooks installed in the OpenRAL checkout itself.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOK = Path(__file__).resolve().parents[2] / ".githooks" / "prepare-commit-msg"
+
+NAME = "AdrianLlopart"
+EMAIL = "adrianllopart@gmail.com"
+TRAILER = f"Signed-off-by: Adrian Llopart <{EMAIL}>"
+
+#: A body whose middle paragraph is separated by ``---``, mirroring the
+#: safety-WG rationale that commit 990d70b carried when it was mangled.
+DIVIDER_BODY = (
+    "fix(safety): keep the workspace-violation rationale intact\n"
+    "\n"
+    "The safety WG asked for the derivation to travel with the commit.\n"
+    "\n"
+    "---\n"
+    "\n"
+    "Below the divider: the conservative bound this change preserves.\n"
+)
+
+
+def _env(repo: Path, extra: dict[str, str] | None = None) -> dict[str, str]:
+    """A git environment with the ambient user/system config neutralised."""
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": str(repo.parent),
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+        "GIT_AUTHOR_NAME": NAME,
+        "GIT_AUTHOR_EMAIL": EMAIL,
+        "GIT_COMMITTER_NAME": NAME,
+        "GIT_COMMITTER_EMAIL": EMAIL,
+    }
+    env.update(extra or {})
+    return env
+
+
+def _git(
+    repo: Path, *args: str, extra_env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Run git in ``repo``, failing loudly on a non-zero exit."""
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env=_env(repo, extra_env),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A real git repo whose only active hook is the real ``prepare-commit-msg``."""
+    hooks = tmp_path / "hooks"
+    hooks.mkdir()
+    hook_copy = hooks / "prepare-commit-msg"
+    hook_copy.write_bytes(HOOK.read_bytes())
+    hook_copy.chmod(0o755)
+
+    work = tmp_path / "repo"
+    work.mkdir()
+    _git(work, "init", "-q", "-b", "master", ".")
+    _git(work, "config", "core.hooksPath", str(hooks))
+    _git(work, "config", "user.name", NAME)
+    _git(work, "config", "user.email", EMAIL)
+    (work / "seed.txt").write_text("seed\n")
+    _git(work, "add", "seed.txt")
+    _git(work, "commit", "-q", "-m", "chore: seed")
+    return work
+
+
+def _commit(repo: Path, message: str, filename: str) -> None:
+    (repo / filename).write_text(f"{filename}\n")
+    _git(repo, "add", filename)
+    msg_file = repo.parent / f"{filename}.msg"
+    msg_file.write_text(message)
+    _git(repo, "commit", "-q", "-F", str(msg_file))
+
+
+def _message(repo: Path, rev: str = "HEAD") -> str:
+    return _git(repo, "log", "-1", "--format=%B", rev).stdout
+
+
+def test_appends_sign_off_to_a_plain_commit(repo: Path) -> None:
+    """The ordinary fresh-commit case is unchanged: one trailer, at the end."""
+    _commit(repo, "feat(hal): add a joint limit probe\n", "a.txt")
+
+    message = _message(repo)
+    assert message.count("Signed-off-by:") == 1
+    assert message.strip().endswith(f"Signed-off-by: {NAME} <{EMAIL}>")
+
+
+def test_does_not_duplicate_an_existing_sign_off_spelled_differently(repo: Path) -> None:
+    """Idempotence keys on the email, so a differently spelled name still matches.
+
+    The old hook also survived this particular shape — not because its check
+    worked, but because ``--if-exists doNothing`` saw a ``Signed-off-by`` key in
+    the trailing trailer block and declined. That safety net disappears the
+    moment a ``---`` divider hides the existing trailer (see the divider and
+    rebase tests), which is exactly how 990d70b ended up with two sign-offs.
+    """
+    _commit(repo, f"fix(sensors): clamp the stale deadline\n\n{TRAILER}\n", "b.txt")
+
+    message = _message(repo)
+    assert message.count("Signed-off-by:") == 1
+    assert TRAILER in message
+
+
+def test_divider_in_the_body_is_not_split_by_the_trailer(repo: Path) -> None:
+    """A `---` line is body prose, not a patch separator: the body survives intact."""
+    _commit(repo, DIVIDER_BODY, "c.txt")
+
+    message = _message(repo)
+    assert message.count("Signed-off-by:") == 1
+    # Every body line keeps its order, and nothing is injected above the divider.
+    assert DIVIDER_BODY.strip() in message
+    assert message.strip().endswith(f"Signed-off-by: {NAME} <{EMAIL}>")
+
+
+def test_rebase_reword_replay_neither_duplicates_nor_corrupts(repo: Path) -> None:
+    """The observed failure: a rebase replay re-runs the hook on the ORIGINAL message."""
+    _commit(repo, f"{DIVIDER_BODY}\n{TRAILER}\n", "d.txt")
+    pristine = _message(repo)
+    assert pristine.count("Signed-off-by:") == 1
+
+    # `reword` (like `edit` and `rebase --continue`) re-runs prepare-commit-msg,
+    # feeding it the original message; a plain `pick` fast-forwards and does not.
+    sequence_editor = repo.parent / "reword.py"
+    sequence_editor.write_text(
+        "import pathlib, sys\n"
+        "p = pathlib.Path(sys.argv[1])\n"
+        "p.write_text(p.read_text().replace('pick ', 'reword ', 1))\n"
+    )
+    rebase_env = {
+        "GIT_SEQUENCE_EDITOR": f"{sys.executable} {sequence_editor}",
+        "GIT_EDITOR": "true",
+    }
+    for _ in range(2):  # a stack rebase replays the same commit more than once
+        _git(repo, "rebase", "-i", "master~1", extra_env=rebase_env)
+
+    assert _message(repo) == pristine
+
+
+@pytest.mark.parametrize("source", ["merge", "squash"])
+def test_merge_and_squash_messages_are_left_alone(repo: Path, source: str) -> None:
+    """Those aren't a single authored change, so the hook must not sign them off."""
+    msg_file = repo.parent / "msg.txt"
+    original = "Merge branch 'topic'\n"
+    msg_file.write_text(original)
+    subprocess.run(
+        [str(HOOK), str(msg_file), source],
+        cwd=repo,
+        env=_env(repo),
+        check=True,
+        capture_output=True,
+    )
+    assert msg_file.read_text() == original


### PR DESCRIPTION
## What changed

`.githooks/prepare-commit-msg` (the DCO auto-sign-off hook, wired via `core.hooksPath`) had two defects that compounded into real commit corruption. Both are fixed, with a real regression test.

**1. Idempotence keyed on the formatted name instead of the email.** The check grepped for the exact string built from `git config user.name`. A configured `AdrianLlopart` never matches the `Adrian Llopart` already recorded in an existing trailer, so the check missed. It now keys on the **email** — the stable half of the identity — anchored to the start of the line, so a diff hunk in a `--verbose` message (`+Signed-off-by: ...`) can never be mistaken for an existing trailer.

**2. `git interpret-trailers` treated a body `---` as a patch divider.** It inserted the sign-off *above* the `---`, burying the trailer mid-message and splitting the prose below it. The hook now passes `--no-divider` (git >= 2.24), probed from `git interpret-trailers -h`. Older git falls back to appending the trailer directly — before the `--verbose` scissors line when one is present, and joining an existing trailer block rather than splitting it.

## Why

Observed corrupting **990d70b** during today's stack rebase (since repaired): a safety-WG rationale paragraph was split by an injected trailer, and the commit ended up with two `Signed-off-by` lines.

The two defects reinforce each other, which is why this went unnoticed for so long. On an ordinary message, `--if-exists doNothing` masks the name mismatch — interpret-trailers sees a `Signed-off-by` key in the trailing block and declines. But once a `---` divider hides the existing trailer from interpret-trailers, that safety net disappears and the duplicate lands. Rebase steps that re-run the hook (`reword`, `edit`, `rebase --continue`) feed it the **original** message, so a stack rebase re-triggers it on every replay.

## How tested

New `tests/unit/test_dco_sign_off_hook.py` — 6 tests, no mocks (§1.11). Each drives the **real** hook through real `git commit` / `git rebase -i` in a throwaway repo whose only active hook is a copy of the real one, so it neither needs nor is affected by the hooks installed in the OpenRAL checkout.

- fresh commit gets exactly one trailer, at the end (the normal case is unchanged)
- an existing sign-off with a differently spelled name is not duplicated
- a body containing `---` survives intact, trailer at the end
- **rebase `reword` replay** (run twice, as a stack rebase would) leaves the message byte-identical to the pristine original
- `merge` / `squash` messages are left alone

Verified these are genuine regression tests: against the pre-fix hook, the divider and rebase-replay tests **fail** (`assert 2 == 1` sign-offs); after the fix all 6 pass in 0.7 s.

The legacy-git fallback branch cannot fire on git 2.43, so it was exercised separately against a copy with the capability probe forced off, over five message shapes (plain body, `---` body, existing trailer block, `--verbose` scissors, repeat run) — all correct. Faking that path in the suite would have meant stubbing `git` itself, which §1.11 rules out.

`ruff check` / `ruff format --check` / `mypy --strict` clean on the new test; `bash -n` clean on the hook (the repo lints no shell — no shellcheck in `.pre-commit-config.yaml` — and shellcheck is not installed here). `CONTRIBUTING.md`, the one doc describing the hook's behavior, is updated in the same commit (§1.14).

This commit was itself made with the fixed hook active and is the dogfood case: the author's `user.name` is `AdrianLlopart` while the trailer reads `Adrian Llopart`, and the hook correctly added nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUhD1uz93qMFJQsNxyTEM5
