### PR TITLE
docs: close the collision stack's evidence and stale-claim debt

### DIFF
--- a/cpp/openral_safety_kernel/README.md
+++ b/cpp/openral_safety_kernel/README.md
@@ -4,6 +4,10 @@
 > chunk-rate boundary. Replaces F5's Python pass-through
 > (`packages/openral_safety/SafetyPassthroughNode`) behind the same
 > topic contract. **Python proposes, C++ disposes.** (CLAUDE.md §1.5).
+>
+> The `spark:~/openral-runs/…` validation rounds cited throughout this file are
+> catalogued — with what each concluded and what is still open — in
+> [`docs/reference/collision-validation-evidence.md`](../../docs/reference/collision-validation-evidence.md).
 
 ## Topic contract
 

--- a/cpp/openral_safety_kernel/include/openral_safety_kernel/validator.hpp
+++ b/cpp/openral_safety_kernel/include/openral_safety_kernel/validator.hpp
@@ -23,9 +23,14 @@ enum class ViolationKind : std::uint8_t {
   kForce = 1,       ///< openral_msgs::FailureTrigger::KIND_FORCE
   kWorkspace = 2,   ///< openral_msgs::FailureTrigger::KIND_WORKSPACE
   kController = 5,  ///< openral_msgs::FailureTrigger::KIND_CONTROLLER
-  // Geometric self/world collision. The value must exist so the
-  // enum stays 1:1 with the IDL; the geometric check that *emits* it lands
-  // in a follow-up PR (this kernel does not yet produce kCollision).
+  // Geometric self/world collision. The value must exist so the enum stays
+  // 1:1 with the IDL. It is no longer only a reservation: the lifecycle node
+  // does emit it — `SafetyKernelLifecycleNode::publish_collision_failure`
+  // stamps `FailureTrigger::KIND_COLLISION`, and the collision report path
+  // latches the fault and publishes `SafetyStatus::KIND_COLLISION` alongside
+  // the E-stop. `validate()` itself still never returns this kind: the
+  // allocation-free bound checks in this file are per-joint/per-mode, while
+  // the geometric check runs against the world/voxel model on the node.
   kCollision = 10,  ///< openral_msgs::FailureTrigger::KIND_COLLISION
 };
 

--- a/cpp/openral_safety_kernel/test/test_lifecycle_kernel.cpp
+++ b/cpp/openral_safety_kernel/test/test_lifecycle_kernel.cpp
@@ -277,9 +277,12 @@ TEST_F(LifecycleKernelTest, ResetServiceRespectsCooldown) {
 
 // The ViolationKind enum must stay 1:1 with the IDL KIND_*
 // constants so the lifecycle node can publish a FailureTrigger without
-// translation (validator.hpp documents this contract). kCollision is added
-// for the geometric-safety check; the value must equal KIND_COLLISION even
-// though the kernel does not yet *emit* it.
+// translation (validator.hpp documents this contract). kCollision carries the
+// geometric-safety check's number, and the node does emit it:
+// `publish_collision_failure` stamps `FailureTrigger::KIND_COLLISION` and the
+// collision report path publishes `SafetyStatus::KIND_COLLISION` with the
+// E-stop. This test pins the number, not the emission — the emission itself is
+// covered by the collision tests below and in test_collision.cpp.
 TEST(ViolationKindMapping, EnumValuesMatchFailureTriggerConstants) {
   using openral_msgs::msg::FailureTrigger;
   EXPECT_EQ(static_cast<std::uint8_t>(osk::ViolationKind::kForce), FailureTrigger::KIND_FORCE);

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5,13 +5,36 @@ Decision Records (ADRs). As of 2026-07-08 the ADR log itself lives in the
 private [`OpenRAL/management`](https://github.com/OpenRAL/management) repo,
 under `adr/` — not in this public repo.
 
-This public repo no longer cites individual decisions by number. Code
-comments, docstrings, and docs describe *why* in prose instead — what a
-piece of behavior does and the concept behind it — without a citation a
-reader here can't follow. Contributors without access to
-`OpenRAL/management` who want the full rationale, alternatives considered,
-or history behind a specific piece of behavior can ask by opening an issue
-in this repo.
+This public repo **does** cite individual decisions by number. Code
+comments, docstrings, tests, and docs carry bare `ADR-NNNN` identifiers as
+shorthand for the decision that fixed a contract — as of `2edcf67` there
+are 398 such citations on 334 lines across 98 files, spanning 14 distinct
+numbers (most cited: `ADR-0097`, `ADR-0096`, `ADR-0092`, `ADR-0088`,
+`ADR-0095`). Those identifiers are deliberately **not links**: the record
+they name lives in the private repo, and a dead link would be worse than a
+bare id. Prose around a citation is written to stand on its own, so a
+reader without access can follow *what* the behavior is even when they
+cannot read *why it was chosen*.
+
+Two consequences worth stating plainly rather than leaving a reader to
+discover:
+
+- **The number is a handle, not a coordinate.** The ADR log is append-only
+  but not gap-free, and cross-references inside it use filenames rather
+  than integers. Do not infer an ordering, a date, or a dependency from a
+  number's neighbours.
+- **Some cited numbers are not on the private repo's `main` either.** The
+  collision-stack citations `ADR-0092`, `ADR-0094` and `ADR-0095` live on
+  an unmerged draft branch (`safety/xr1-deploy-sim`) of
+  `OpenRAL/management`, and `ADR-0093` on `adr/0093-quantization-dtype-fp8`;
+  the implementations they describe are merged here on `master` while the
+  decision records that name them are not yet merged there. `ADR-0096` and
+  `ADR-0097` are on `main`. So a maintainer resolving one of those four
+  numbers has to look on the branch, not just the default branch.
+
+Contributors without access to `OpenRAL/management` who want the full
+rationale, alternatives considered, or history behind a specific piece of
+behavior can ask by opening an issue in this repo, quoting the identifier.
 
 The decision discipline is unchanged: adding, removing, renaming, or moving
 a responsibility between the eight architecture layers (§3 of

--- a/docs/methods/14-duplication-watch.md
+++ b/docs/methods/14-duplication-watch.md
@@ -137,6 +137,79 @@ contributor should look at before adding similar code.
    pins that identity — keep it that way, because a phase-aware branch on
    one side only is exactly how this mirror would drift.
 
+9. **Support-witness acceptance caps — *deliberate C++/Python mirror, update
+   in lockstep.*** The kernel's two ingest caps on what a
+   `SupportContactWitness` may claim are ROS parameters declared with their
+   defaults in
+   `cpp/openral_safety_kernel/src/lifecycle_kernel.cpp` —
+   `support_witness_max_patch_radius_m` (`0.5`) and
+   `support_witness_max_penetration_m` (`0.01`) — and the *producer* refuses
+   at the same two numbers, written independently as
+   `_SUPPORT_MAX_PATCH_RADIUS_M = 0.5` and
+   `_SUPPORT_MAX_PENETRATION_M = 0.01` in
+   `python/hal/src/openral_hal/_sim_attachment_evidence.py:51-52`. They are
+   not consolidated because the kernel must not trust a producer-supplied
+   bound — the cap is exactly the thing the kernel applies to a message it
+   did not author, and a shared constant would make the check circular.
+   **The drift consequence is asymmetric and both directions are bad.**
+   Loosen the producer past the kernel and the kernel fails the whole
+   attachment message closed (`ROSSafetyViolation`-class drop, not a
+   silent one) — noisy, but conservative. Tighten the producer below the
+   kernel and the shortfall is invisible: legitimate contact is never
+   attested, the witness never arms, and the robot stops on ordinary
+   support contact with nothing in the logs naming a cap as the reason.
+   **When either number moves, move both in the same PR** and re-run the
+   kernel's ingest gtests together with the producer's refusal tests.
+
+10. **Place-region bounds — *deliberate C++/Pydantic mirror, update in
+    lockstep.*** `kMaxPlaceRegionHalfExtentM = 1.5` and
+    `kMaxPlaceRegionVolumeM3 = 8.0`
+    (`cpp/openral_safety_kernel/include/openral_safety_kernel/collision.hpp`)
+    are the kernel's bounds on the ADR-0097 approach region, and
+    `PlaceRegion.MAX_HALF_EXTENT_M = 1.5` / `PlaceRegion.MAX_VOLUME_M3 = 8.0`
+    (`python/core/src/openral_core/schemas.py`, enforced in
+    `_validate_region`) are the schema's. The double check is deliberate and
+    is named in `PlaceRegion`'s own docstring: an over-large region is
+    "rejected here and again in the kernel, both times toward *no
+    allowance*". Since this bound gates a **margin reduction**, both sides
+    fail closed and neither may be deleted in favour of the other — the
+    kernel cannot assume the Pydantic validator ran (the message may reach
+    it from a producer that never constructed the model), and the schema
+    must still refuse locally so a bad region is a producer-side error
+    rather than a kernel-side refusal log. **The drift consequence:** raise
+    the Pydantic ceiling without the kernel's and every oversize region is
+    accepted by the producer and then silently discarded by the kernel, so
+    the place phase runs with **no** allowance while every log line says the
+    declaration is live — the exact failure the ADR-0097 amendment's
+    clock-domain bug already produced once. Raise the kernel's without the
+    schema's and the extra room is unreachable. `PlaceRegionStatus::kOversize`
+    is the kernel-side refusal to grep for.
+
+11. **`FailureTrigger` / `SafetyStatus` `KIND_*` numbers — *three-way
+    mirror, and one leg is currently drifted.*** The numbers are declared in
+    `packages/msgs/msg/FailureTrigger.msg`, **redeclared** in
+    `packages/msgs/msg/SafetyStatus.msg` (ROS IDL has no cross-message
+    constant reuse), and mirrored a third time as plain Python ints in
+    `python/observability/src/openral_observability/failure_bus.py` so
+    callers can publish typed failure events without a sourced ROS install.
+    The C++ `ViolationKind` enum
+    (`cpp/openral_safety_kernel/include/openral_safety_kernel/validator.hpp`)
+    is a fourth partial copy of the same numbering.
+    `tests/unit/test_safety_status_msg.py` pins the two IDL blocks against
+    each other and pins `DROP_*` disjoint from `KIND_*`; a kernel gtest
+    (`ViolationKindMapping.EnumValuesMatchFailureTriggerConstants`) pins the
+    enum. **Nothing pins the `failure_bus.py` leg, and it has drifted:** it
+    stops at `KIND_REASONER_TIMEOUT = 9` (plus
+    `KIND_SUPPRESSED_SUMMARY = 254`) and is missing `KIND_COLLISION = 10`,
+    which the IDL, the kernel enum and the kernel's
+    `publish_collision_failure` all carry. The consequence is scoped but
+    real: any non-ROS caller that reaches for a symbolic collision kind
+    finds none and must hard-code `10`. Fixing it is a code change and is
+    deliberately **not** made in this docs pass — it is recorded here so the
+    next PR touching `failure_bus.py` closes it and adds the missing
+    contract test rather than re-deriving the discovery. **When a `KIND_*`
+    number is added, all four sites move together.**
+
 ### Already correctly DRY (do not flag)
 
 - **SimSensorBridge** — the single source for RGB camera publishing + MuJoCo viewer

--- a/docs/reference/collision-validation-evidence.md
+++ b/docs/reference/collision-validation-evidence.md
@@ -1,0 +1,349 @@
+# Collision-stack validation evidence
+
+Where the numbers in the collision stack's code comments, READMEs and PR bodies
+came from, what each validation round actually concluded, and what is still
+open.
+
+## Why this page exists
+
+The attached-payload collision work (issue #102, PRs
+[#128](https://github.com/OpenRAL/openral/pull/128)–[#135](https://github.com/OpenRAL/openral/pull/135))
+is calibrated against measurements taken on a real host, not against
+first-principles constants. Those measurements are cited all over the tree —
+`spark:~/openral-runs/2026-08-15-final-battery/`, "round-8 r2", "the 2/5
+battery" — but until now the ledger they refer to lived only in PR
+descriptions and in a run store on one machine. That is a reproducibility gap
+(CLAUDE.md §1.8): a reader could see a constant justified by a run they had no
+way to look up, and a future maintainer could not tell which conclusions were
+still current.
+
+This page is the in-tree ledger. It records **what each round measured and
+concluded**, with the artifact path, and it is deliberate about the difference
+between a number a file states and an inference drawn from several.
+
+## Reading the citations
+
+- **Artifact paths** are of the form `spark:/home/allopart/openral-runs/<round>/`.
+  `spark` is the project's DGX Spark (GB10) validation host; the run store is
+  not public and not in this repo. In-tree citations abbreviate it as
+  `spark:~/openral-runs/…` — same location.
+- **Stack tips** are commit SHAs in this repo. Some are *branch* tips that were
+  replayed on merge, so they are reachable by SHA but are not ancestors of
+  `master`; where that is true it is said explicitly, with the merged
+  counterpart.
+- Where a round produced no written conclusion, this page says **outcome
+  unrecorded** rather than reconstructing one.
+
+## The rounds
+
+### 2026-08-13 — `matrix-baseline`, `postfix-matrix`
+
+`spark:/home/allopart/openral-runs/2026-08-13-matrix-baseline/`,
+`…/2026-08-13-postfix-matrix/`
+
+**No written summary exists for either.** What survives in-tree is the single
+finding they are cited for: the baguette run E-stopped at a reported
+`-15.70 mm` while MuJoCo's own contact list carried six real contacts of
+`-0.87..-1.37 mm`. That gap is the discretisation inflation the support-contact
+witness's geometry accounts for exactly — a ~1 mm physical contact reads as up
+to ~15 mm of *cube* penetration at 25 mm resolution — and it is why the
+witness measures depth against the attested plane rather than the cell cube
+(`cpp/openral_safety_kernel/README.md`; hazard log Entry 012).
+
+### 2026-08-14 — `adjudication`, `acceptance`, `final`, `round5`, `round6`, `round7`
+
+**No written summaries.** Two of these rounds are load-bearing and are cited by
+their per-run artifact paths:
+
+**Round 5** (`…/2026-08-14-round5/baguette/seed1_run2`) stopped the flagship
+counter→cabinet insertion at `-1.78 mm` with the payload 66–67 mm *inside* the
+target cabinet. Nothing distinguished "arrived at its declared destination"
+from "grazed a wall" — the failure ADR-0097's place-phase witness answers.
+The same round supplies the attach-window timeline: the attach sweep ran at
+`1786710428.38` and the E-stop at `1786710431.16`, **2.78 s — ~28 published
+grids at the bridge's 10 Hz — later**, with the payload still on its stale
+silhouette, and the field cell at `22.13 mm`. That timeline is replayed as
+`PayloadClearing.TheAttachWindowOutlivesTheFieldRunsTwentyEightGrids`.
+
+**Round 6** (`…/2026-08-14-round6/baguette/seed1_carry_*`) showed the place
+witness cannot arm for an enclosed target even with a correct declaration: the
+E-stop fired at `horizon_step 0` on `attached:sim:obj_main` vs `voxel_178099`
+at `min_distance = -4.9 mm`, with the payload still 22–30 mm from real shelf
+contact. A witness earned by touching can never arm if the payload is stopped
+before it can touch — the reason ADR-0097 gained its declaration-scoped
+approach allowance.
+
+The same day produced the witness/clearing defect, 2/2:
+`support_witness_separated live=0x0 was=0x1` 2.7 s after arming with ground
+truth `+0.000 mm` still touching, then the same contact E-stopping unexempted
+(`sweep_min == min_distance`) as soon as a support cell returned to the map.
+That is what the clearing/exemption partition exists to prevent.
+
+### 2026-08-15 — `round8`
+
+`spark:/home/allopart/openral-runs/2026-08-15-round8/`
+
+**No written summary.** Cited for two things: run r2's co-planar cell at
+`+42.9 mm` above the attested plane against a then-`~15–19 mm` envelope (the
+excess of `+24.4 mm` ≈ one 25 mm voxel that drove the height calibration), and
+the refusal-taxonomy defect — **672–811 identical `reason=bounds` warnings per
+run**, none of which described a bound.
+
+### 2026-08-15 — `baguette-battery` (5 runs)
+
+`spark:/home/allopart/openral-runs/2026-08-15-baguette-battery/` —
+`BATTERY_SUMMARY.txt` (a table plus per-run JSON; no prose verdict).
+
+**0/5 completions.** The battery's value was diagnostic, not a pass rate:
+
+- It **refuted the suspected "sliding" class outright.** Run 4 moved the
+  payload `10.15 mm` during the stop and the lateral patch gate (`138.82 mm`
+  recorded, quoted in-tree as 135.7 mm for the round-8 lattice) never came near
+  the `84.23 mm` actual offset.
+- It **named the real class**: adjacent co-planar structure — a raised edge or
+  a neighbouring stack on the same support surface — sitting about one voxel
+  above the attested plane while the payload is in genuine, continuing support
+  contact.
+- **Run 1 was the approach allowance's first in-vivo firing**: `-26.48 mm` of
+  predictive-check penetration (`min == sweep`, so nothing was exempted) at a
+  ground-truth `-2.43 mm` contact — `1.48 mm` past the then-cap of
+  `min(one voxel, 25 mm)`. Since the map-vs-truth error at a placement pose is
+  itself about one voxel, a one-voxel allowance is *structurally* marginal, not
+  occasionally short.
+
+Both findings became maintainer-approved calibrations on 2026-08-15: the
+witness height envelope gains `+ resolution` inside the lateral patch, and the
+allowance cap moves from `min(one voxel, 2.5 cm)` to `min(1.5 × voxel, 4 cm)`
+(hazard log Entry 012 "Calibration 2026-08-15", Entry 013 HZ-0097-4, ADR-0097's
+Second Amendment).
+
+Runs 2 and 3 both tripped on `panda_link1` at `-0.42 mm` / `-2.46 mm` with
+`min == sweep` — arm-vs-world, nothing to do with the payload. Run 5 tripped
+`panda_link5` at `-23.5 mm` after re-attestation.
+
+### 2026-08-15 — `final-battery` (9 runs) — the #102 acceptance round
+
+`spark:/home/allopart/openral-runs/2026-08-15-final-battery/` —
+`BATTERY_SUMMARY.txt`, 282 lines, the most complete record in the store.
+
+Stack tip **`e35ed68`** ("one voxel more headroom, on the cap and on the
+envelope", branch `feat/quantization-headroom`), clean 27-package colcon
+rebuild, DGX Spark.
+
+| suite | n | result |
+|---|---|---|
+| baguette (`PickPlaceCounterToCabinet`, place declaration) | 5 | **2/5 completions** — run 2 (step 575) and run 3 (step 595), each `transitions=1`, neither with a collision verdict |
+| sink_cup | 3 | 0/3 |
+| fridge_drawer (no declaration — the control) | 1 | stop persists **byte-identically** to the pre-calibration baseline: `a=panda_link7 b=voxel_165738 min_distance_m=-0.00479038 sweep_min_distance_m=-0.00479038 place_allowance_active=0` |
+
+The summary records the acceptance criterion as **MET, on the named scene,
+twice independently, at stack tip `e35ed68`**, and the fridge_drawer control as
+proof the two headrooms did not absorb a real interpenetration.
+
+**Three caveats the battery states about itself, kept here verbatim in
+substance:**
+
+1. `sweep_min == min_distance` in **every** one of the 5 baguette runs, and
+   `place_allowance_active=0` on every trip — 0 occurrences of
+   `place_allowance_active=1` anywhere in any run. So neither the witness nor
+   the allowance was the mechanism of the two successes; nothing was exempted.
+   The summary says so plainly: *"I cannot quote a `place_allowance_active=1`
+   line or a live co-planar witness exemption from THIS battery, because
+   neither event occurred in any of the 9 runs."*
+2. sink_cup's 0/3 is inside its own historical base rate — across all 8
+   recorded sink_cup attempts on this host at every tip, sink_cup completed
+   exactly **once**. 0/3 is not a signal.
+3. **The acceptance ran before PR #135.** `e35ed68` is the branch tip of what
+   merged to `master` as `a031f3b` (PR
+   [#133](https://github.com/OpenRAL/openral/pull/133), merge
+   `b760a5f`); PR [#134](https://github.com/OpenRAL/openral/pull/134) (merge
+   `4934080`) and PR [#135](https://github.com/OpenRAL/openral/pull/135) (merge
+   `2edcf67`, the octree→grid rasterization fix) both landed after it. **This
+   ordering is derived here from the recorded tips; no file in the run store
+   draws the conclusion in those words.** It matters because #135 makes the
+   occupancy map strictly denser (below), so the 2/5 was measured against a
+   sparser map than `master` publishes today.
+
+### 2026-08-16 — `defect-ab`
+
+`spark:/home/allopart/openral-runs/2026-08-16-defect-ab/` — probe JSONs only,
+**no summary. Outcome unrecorded.**
+
+### 2026-08-16 — `postfix-matrix` — the #135 before/after
+
+`spark:/home/allopart/openral-runs/2026-08-16-postfix-matrix/` —
+`BATTERY_SUMMARY.txt`, 304 lines.
+
+The matrix re-run at `2edcf67` (#135 merged) against the `e35ed68` baseline.
+The recorded verdict on the flagship scene:
+
+> baguette (place decl, N=5) — BEFORE: **2/5** completions (run2, run3
+> `sim.task_success=true`). AFTER (`2edcf67`): **0/5** completions, no run
+> reached `sim.task_success`.
+
+and the summary's own caveat, verbatim:
+
+> HONEST CAVEAT ON THE RATE. This scene is stated to be behaviourally
+> non-deterministic under XR-1; 2/5 vs 0/5 at N=5 is not statistically
+> separable on its own. But the direction is mechanistically expected: the
+> collision map on this scene is now 4094 → 9038 median occupied cells
+> (+121%), strictly additive, so the stack can only stop MORE often, never
+> less. bag3 shows the full manipulation still runs end-to-end under the
+> denser map without tripping. Recommend a larger-N baguette rerun before
+> treating 0/5 as a settled rate.
+
+This is the **"2/5 non-determinism" caveat** other documents refer to. #135's
+conservativeness proof is the reason the direction is expected rather than
+alarming: the fix may only ever *add* cells to the kernel's grid.
+
+### 2026-08-16 — the paired n=15 A/B, and `master-1`
+
+The recommended larger-N rerun, run as a paired control with **one** variable —
+the octree→grid rasterization rule:
+
+| arm | path | tip | n |
+|---|---|---|---|
+| post-#135 | `spark:/home/allopart/openral-runs/2026-08-16-baguette-n15/` | `2edcf67` | 15 (`n1`…`n15`) |
+| pre-#135 control | `spark:/home/allopart/openral-runs/2026-08-16-baguette-pre135-n15/` | `4934080` | 15 (`p1`…`p15`) |
+| single re-run | `spark:/home/allopart/openral-runs/2026-08-16-master-1/` | `2edcf67` | 1 |
+
+Identical scene YAML, prompt, seed (1) and deadline (420 s) across both arms;
+the recorded `git diff --stat 4934080 2edcf67` touches five files — one doc,
+one README, and three in `packages/openral_octomap_bridge` — and **zero Python
+files**.
+
+**The A/B's conclusion is unrecorded.** No file in the run store states an
+outcome, verdict or comparison for the experiment. The pre-#135 arm carries no
+`BATTERY_SUMMARY`, no notes, no `VERDICTS.json` and no per-run adjudication;
+the post-#135 arm's `VERDICTS.json` is timestamped seven minutes *before* the
+control arm started, so it cannot be — and is not — a comparison document. No
+later file mentions both arms. The comparison scripts were copied into both
+arms and produced output for neither.
+
+What the raw run logs do record:
+
+- **Both arms: 0/15 completions.** All 30 runs `"success": false`; all 30
+  `seed1_task_success.txt` files `success=False transitions=0
+  ever_succeeded=False`.
+- `place_allowance_active=1 occurrences: 0` in all 30 runs.
+- Latch classes, post-#135: 13 × `kind_collision (world)`, 1 × `kind_collision
+  (self)` (n4), 1 bare `/openral/estop` (n6). Pre-#135: 11 × world, 3 × self
+  (p10–p12), 1 bare `/openral/estop` (p6).
+- The post-#135 arm has per-run adjudication in `VERDICTS.json`, bucketed as
+  `collision-real` (7 runs), `collision-map-conservatism` (7), `self-collision`
+  (1). Two of the map-conservatism runs (n11, n13) record
+  `gt_beyond_distmax: true` at `distmax 0.1 m` over 883 / 821 probed pairs —
+  no solid world geometry within 100 mm of the link the kernel stopped on.
+
+**So the honest statement is: at n=15 neither arm completed the task, the
+per-arm latch classes differ but were never compared in writing, and the
+experiment's intended verdict on #135's behavioural effect was never
+recorded.** Anyone re-opening this should re-run the comparison scripts against
+both arms rather than trusting a remembered result.
+
+`2026-08-16-master-1` is a single baguette run at `2edcf67`: E-stop during
+**carry** on the attached payload, `a=attached:sim:obj_main b=voxel_92208
+step=0 min_distance_m=-0.00418456 sweep_min_distance_m=-0.0355338` —
+divergent, i.e. an exemption *was* active — at tick 264, `success=false`.
+
+### 2026-08-22 — `master-1`, four scenes at `2edcf67`
+
+`spark:/home/allopart/openral-runs/2026-08-22-master-1/` — `NOTES.md`. The most
+recent round, and the current state of the stack.
+
+Tip `2edcf67`, verified equal to `origin/master` at run time; full clean
+rebuild (27/27 packages); reasoner off, SLAM + Nav2 + octomap + kernel check
+on; seed 1 pinned. **No safety knob touched.** Exactly one `safety.collision`
+and one `estop_ground_truth_snapshot` per run.
+
+| scene | grasped | E-stop pair | kernel min / sweep (m) | ground-truth verdict |
+|---|---|---|---|---|
+| baguette | yes | `panda_link5` vs `voxel_170781` (step 0) | −0.0209178 / −0.0209178 | **false positive** |
+| sink_cup | yes | `attached:sim:obj_main` vs `voxel_87084` (step −1) | −0.0133754 / −0.0133754 | legitimate |
+| fridge | no | `panda_link7` vs `voxel_169769` (step −1) | −0.0247489 / −0.0247489 | legitimate (scene-init) |
+| utensil | no | `panda_link1` vs `voxel_76001` (step −1) | −0.0172764 / −0.0172764 | **false positive** |
+
+`min_distance_m == sweep_min_distance_m` in all four → **no exemption active
+anywhere this round**; `place_allowance_active=1` occurrences: 0.
+
+**`sim.task_success_final = False` on all four scenes** —
+`PickPlaceCounterToCabinet` (1285 steps), `PickPlaceCounterToSink` (350),
+`PickPlaceFridgeShelfToDrawer` (102), `PickPlaceCounterToDrawer` (130), all
+`transitions=0`.
+
+**The carry phase on baguette was clean — and that is the round's one clear
+improvement.** Attach at `t=176.32` → `support_witness_armed`
+(`max_penetration_m=0.005597`, `patch_radius_m=0.113964`) →
+`place_region_armed` (`allowance_m=0.0375`) → `support_witness_separated` →
+detach at `t=226.54` (`place_region_dropped reason=detached`). Across 48 carry
+snapshots the payload travelled **870.76 mm** with both clearing shells and the
+interior at zero throughout and the nearest cell receding to +281 mm — **no
+E-stop during transport**. The prior round at the same tip tripped *during*
+carry on the payload itself. Witness, clearing and the partition behaved.
+
+**Two link-class false positives are open, and the hypothesis is not proven.**
+Both are robot-link-vs-voxel, both adjudicated against the ground-truth probe:
+
+- baguette: 431/431 candidate pairs probed, untruncated, **zero pairs within
+  100 mm**, against a kernel reading of −20.9 mm. A >120 mm discrepancy, far
+  outside the 25 mm-voxel quantization budget (~21.7 mm half-diagonal).
+- utensil: nearest true world geometry `robot0_link1` ↔
+  `stack_2_left_group_3_door_g2` at **+43.3 mm** against a kernel −17.3 mm — a
+  60.6 mm discrepancy, again beyond quantization. 489 pairs probed,
+  untruncated.
+
+The leading hypothesis, recorded as a hypothesis: the utensil evidence voxel
+sits at `base_link [0.0375, 0.0875, 0.1625]`, 195 mm from the link-1 origin at
+mobile-base height, so the **robot's own base / manipulator mount** may be
+entering the octomap as world occupancy. The ground-truth probe excludes
+exactly those bodies (`mobilebase0_*`, `robot0_base`, `robot0_link0`,
+`manipulator_mount`), so such self-occupancy would be invisible to it. The arm
+links themselves *are* correctly carved out — every `panda_link*` origin sits
+in a free cell in the baguette snapshot. **Not proven; under investigation.**
+
+**The place machinery was unarmed in the shipped scenes.** `place_declaration`
+appears in **zero** files under `scenes/` in this repo. The 08-22 round armed
+it only through ad-hoc scene copies in the round's own `scripts/` directory
+(`robocasa_baguette_place_seed1.yaml`, `robocasa_sink_cup_place_seed1.yaml`);
+the two `_direct_` scenes carry no declaration at all, and their kernel
+evidence contains no `place_region` or `support_witness` events. So a user
+running a shipped `scenes/deploy/robocasa_*.yaml` today gets **no** place
+declaration, **no** place witness and **no** approach allowance. A fix is in
+flight; until it lands, the ADR-0097 place path is exercised only by
+hand-authored scenes.
+
+Note also that XR-1 is stochastic across runs even at a pinned scene seed
+(`first_chunk_s` 90.96 vs 34.23, 1285 vs 632 steps for the same scene and tip),
+so per-run trajectories are not comparable between rounds — **only failure
+classes are.**
+
+## Standing caveats
+
+Five things a reader should carry away, all of them stated by the artifacts
+themselves rather than inferred:
+
+1. **The #102 acceptance is real but narrow, and it predates `master`.** Two
+   independent completions on one named scene, at branch tip `e35ed68`, with
+   **nothing exempted in either** — before #134 and #135 landed. It has not
+   been reproduced at `2edcf67`.
+2. **2/5 vs 0/5 at n=5 is not statistically separable** on a scene the run
+   store itself calls behaviourally non-deterministic under XR-1.
+3. **The n=15 A/B that was supposed to settle that never had its outcome
+   written down.** Both arms are 0/15; the comparison was not made.
+4. **As of 2026-08-22 the stack completes no scene.** Carry-phase machinery
+   behaves; two link-class false positives are open; the place path is unarmed
+   in every shipped scene.
+5. **Several rounds have no written summary at all** (all of 08-13 and 08-14,
+   `round7`, `round8`, `defect-ab`). Their findings survive only as constants
+   and comments in this repo. Treat a citation to one of those rounds as a
+   citation to the in-tree comment that carries it, not to a retrievable
+   verdict.
+
+## Related
+
+- `cpp/openral_safety_kernel/README.md` — the witness, the partition, the
+  allowance, and the geometry each calibration changed.
+- `packages/openral_octomap_bridge/README.md` — payload clearing, the attach
+  sweep window, and the rasterization change #135 made.
+- [Design decisions](../decisions.md) — how ADR numbers are cited here and
+  where the records live.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
     - Sim environments: reference/sim-environments.md
     - aarch64 CUDA hosts (DGX Spark / Jetson): reference/aarch64-support.md
     - Telemetry (spans, metrics, logs): reference/telemetry.md
+    - Collision-stack validation evidence: reference/collision-validation-evidence.md
     - Design decisions: decisions.md
   - Contributing:
     - Development: contributing/development.md

--- a/packages/openral_octomap_bridge/README.md
+++ b/packages/openral_octomap_bridge/README.md
@@ -567,9 +567,9 @@ either side of `patch_radius + circumradius`; a lift clears and withholds
 nothing at all; a payload rolled 90° carries its attested plane with it (the
 normal is rotated, the point translated); and a malformed attestation clears
 nothing at all. Its third part pins the **attach-transition window**: the round-5 field cell at
-22.13 mm survives the steady reach and clears at the attach reach; the field
-run's 28 grids of unmoved payload all clear it (the test a one-shot sweep fails
-27 times over); the window closes to the millimetre once the payload has moved a
+22.13 mm survives the steady reach and clears at the attach reach; the 29 grids
+that replay the field run's ~28-grid gap all clear it (the test a one-shot sweep
+fails 28 times over); the window closes to the millimetre once the payload has moved a
 voxel, and does not re-open when it comes back; a new revision, a second
 payload, and a release-then-grasp each open one while carrying does not; a frame
 that clears nothing cannot advance one; the padded sweep still withholds

--- a/packages/openral_octomap_bridge/README.md
+++ b/packages/openral_octomap_bridge/README.md
@@ -4,6 +4,11 @@ Lowers a **3-D OctoMap** into the safety kernel's dense, base-frame
 `openral_msgs/OccupancyVoxels` grid for the kernel's allocation-free
 capsule-vs-voxel world-collision check.
 
+The field runs this file cites by round (round-5's grid timeline, the 2026-08-13
+lattice phase, the `robocasa_drawer_utensil` rasterization measurement) are
+catalogued in
+[`docs/reference/collision-validation-evidence.md`](../../docs/reference/collision-validation-evidence.md).
+
 ## Why a bridge (and not the kernel)
 
 The C++ safety kernel must stay small, auditable, and allocation-free on its

--- a/packages/openral_octomap_bridge/test/test_payload_clearing.cpp
+++ b/packages/openral_octomap_bridge/test/test_payload_clearing.cpp
@@ -1268,8 +1268,10 @@ TEST(PayloadClearing, TheAttachWindowOutlivesTheFieldRunsTwentyEightGrids) {
   // sweep — ~28 published grids at 10 Hz — with the payload still on its stale
   // silhouette. The bridge re-rasterizes the grid from the octree every tick and
   // nothing retires an occluded cell, so the residue is re-supplied on EVERY one
-  // of those grids: a sweep that widened its reach only on the first would have
-  // published 27 grids carrying the cell that stopped the robot.
+  // of those grids. The loop below is inclusive of both ends — 29 grids, the
+  // attach frame plus the 28 that elapsed before the stop — so a sweep that
+  // widened its reach only on the first would have published the remaining 28
+  // carrying the cell that stopped the robot.
   bridge::AttachSweepLedger ledger;
   const bridge::PayloadPrimitive payload =
       payload_at_distance(lowered(deploy_sim_tree()), kFieldRound6Distance);


### PR DESCRIPTION
Docs, comments and one new reference page. **No behaviour, no test assertion, no
schema, no package, no repo-state-map change.**

## What changed

Five commits, each a separately verified claim that was wrong or missing.

### 1. `docs(safety)` — the kernel does emit `kCollision`

`validator.hpp` and `test_lifecycle_kernel.cpp` both said the kernel "does not
yet produce kCollision" and that the geometric check emitting it "lands in a
follow-up PR". That follow-up landed in this stack: the lifecycle node's
collision report path latches the fault and publishes
`SafetyStatus::KIND_COLLISION` with the E-stop, and `publish_collision_failure`
stamps `FailureTrigger::KIND_COLLISION`.

The still-true half is now said precisely: the allocation-free `validate()`
never returns this kind, because its checks are per-joint/per-mode while the
geometric check runs against the world/voxel model on the node.

### 2. `docs(world-state)` — attach-window grid count

The bridge README told the story two ways: "29 consecutive grids … fails on 28
of them" in the narrative, "the field run's 28 grids … fails 27 times over" in
the test inventory. `TheAttachWindowOutlivesTheFieldRunsTwentyEightGrids` loops
`0 .. 28` **inclusive** = 29 grids, so the narrative was right and the inventory
was one short on both numbers — as was the test's own comment. Corrected, with
the inclusive loop made explicit. The field's own ~28-grid figure is unchanged,
which is why the test name still says TwentyEight.

### 3. `docs` — how this repo actually cites decisions

`docs/decisions.md` opened with "This public repo no longer cites individual
decisions by number." It does: measured at `2edcf67`, **398 citations on 334
lines across 98 files, 14 distinct numbers**, led by ADR-0097 (165), ADR-0096
(65), ADR-0092 (57), ADR-0088 (30), ADR-0095 (29).

Replaced with the truth plus two consequences a reader otherwise discovers the
hard way: the number is a handle and not a coordinate (append-only but not
gap-free; internal cross-refs use filenames); and ADR-0092/0094/0095 live on the
unmerged `safety/xr1-deploy-sim` branch of the private repo with ADR-0093 on
`adr/0093-quantization-dtype-fp8`, so four cited numbers are not on that repo's
`main` either. Identifiers stay unlinked, and prose around a citation still has
to stand on its own.

### 4. `docs(methods)` — three untracked hand-synchronized mirrors

The watch list tracked one cross-package mirror. Three more pairs must move
together and nothing told a contributor so:

- **Support-witness acceptance caps** — kernel `support_witness_max_patch_radius_m`
  (0.5) / `support_witness_max_penetration_m` (0.01) vs producer
  `_SUPPORT_MAX_*` (`_sim_attachment_evidence.py:51-52`). Deliberately not
  consolidated: the cap is what the kernel applies to a message it did not
  author. Drift is asymmetric — producer looser is noisy but conservative;
  producer tighter is **invisible**, and the robot stops on ordinary support
  contact with nothing naming a cap.
- **Place-region bounds** — `kMaxPlaceRegionHalfExtentM` / `kMaxPlaceRegionVolumeM3`
  vs `PlaceRegion.MAX_HALF_EXTENT_M` / `MAX_VOLUME_M3`. Raise the schema's alone
  and every oversize region is accepted by the producer then silently dropped by
  the kernel: the place phase runs with no allowance while the logs say the
  declaration is live.
- **`FailureTrigger` / `SafetyStatus` `KIND_*`** — a four-way mirror across two
  IDL files, `failure_bus.py` ints, and the kernel's `ViolationKind`. Three legs
  are test-pinned; **the `failure_bus.py` leg is not, and has drifted**: it stops
  at `KIND_REASONER_TIMEOUT = 9` and is missing `KIND_COLLISION = 10`. Recorded,
  not fixed — closing it adds a public symbol and a contract test, which is a
  code change and out of scope here.

### 5. `docs(reference)` — the validation evidence, in-tree

New `docs/reference/collision-validation-evidence.md`: the round-by-round ledger
2026-08-13 → 2026-08-22, sourced from the run store's own `BATTERY_SUMMARY` /
`NOTES` / `VERDICTS.json` files, PR bodies #128–#135, and the citations the
kernel and bridge READMEs already carry. Cross-linked from both; added to the
mkdocs nav.

**The caveats it insists on:**

- The **#102 acceptance** (2/5 baguette, twice independently, run 2 step 575 /
  run 3 step 595) ran at branch tip `e35ed68` — the pre-merge form of what
  landed as `a031f3b` in #133 — so it **predates #134 and #135**. That ordering
  is derived from recorded tips; no run-store file states it in those words, and
  the page says so.
- **Nothing was exempted in either success**: `sweep_min == min_distance` and
  `place_allowance_active=0` across all 5 baguette runs, which the battery
  summary states itself.
- **2/5 vs 0/5 at n=5 is not statistically separable** on a scene the run store
  calls behaviourally non-deterministic under XR-1. #135 made the map +121%
  denser (strictly additive), so the direction is mechanistically expected.
- **The paired n=15 A/B across #135 has no recorded outcome.** Both arms are
  0/15; the pre-#135 arm has no summary, notes or adjudication, and the post-#135
  arm's `VERDICTS.json` predates the control run by 7 minutes, so it cannot be a
  comparison. Recorded as **outcome unrecorded** rather than reconstructed.
- **2026-08-22 completes no scene**: `task_success_final=False` on all four; the
  baguette carry phase clean over 870 mm with witness/clearing/partition
  behaving; two link-class false positives open (baguette 431/431 pairs probed,
  zero within 100 mm vs a kernel −20.9 mm; utensil +43.3 mm true vs −17.3 mm
  kernel) with an unproven base-self-occupancy hypothesis; and `place_declaration`
  in **zero** files under `scenes/`, so the ADR-0097 place path is unarmed in
  every shipped scene.
- Several 08-13/08-14 rounds have **no written summary at all**; the page names
  them so a citation to one reads as a citation to the in-tree comment carrying
  it, not to a retrievable verdict.

## Why

The audit found four stale or missing claims in the collision stack's
documentation and one un-recorded body of evidence. §1.2 (truth over
plausibility) and §1.8 (reproducibility) both say a constant justified by a
measurement a reader cannot look up is not justified.

## How tested

- `tools/refresh_methods_linenos.py --check` — exit 0.
- `uv run mkdocs build --strict` — exit 0 (the one nav INFO is pre-existing,
  `perf/deploy-baseline.md`).
- pre-commit gates on every commit: trailing whitespace, EOF, `clang-format`,
  `codespell`, Conventional Commit — all pass.
- No C++ line over 100 columns introduced.
- Each fixed claim re-verified against source before editing: `kCollision`
  emission at `lifecycle_kernel.cpp` (report path + `publish_collision_failure`);
  the 29-vs-28 arithmetic against the inclusive loop and
  `kFieldGridsBeforeEstop = 28`; the ADR citation counts by `grep`; each mirror's
  two constants read on both sides; the run-store files read read-only over ssh.

## Not done, deliberately

- **No hazard-log reviewer checkbox is signed.** Signatures are the maintainer's
  alone. The companion management-repo change adds an *addendum*, not a
  sign-off.
- **`failure_bus.py`'s missing `KIND_COLLISION` is recorded, not fixed** — it is
  a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUhD1uz93qMFJQsNxyTEM5
