### PR TITLE
fix(tests): make the opt-in robosuite lane actually run — and stop it prescribing a command it cannot run

### DIFF
--- a/.github/workflows/test-selective.yml
+++ b/.github/workflows/test-selective.yml
@@ -160,11 +160,24 @@ jobs:
       # test_cli_dataset_from_bag, …) fail with "Could not load libtorchcodec
       # … libavutil.so.* cannot open shared object file" whenever a broad diff
       # selects them. Install FFmpeg (provides libavutil.so.58 → core6).
-      - name: Install native runtime libs (torchcodec + MuJoCo OSMesa)
+      #
+      # `just` is installed for TWO reasons, both load-bearing:
+      #   1. tools/verify_test_envs.py (the robocasa-gr1 / simpler-env lanes)
+      #      shells out to `just sync --group <g>`. Without the binary those
+      #      lanes died with a bare `FileNotFoundError: 'just'` traceback
+      #      before running a single test.
+      #   2. Every optional-dependency failure in openral_sim._deps prints
+      #      "Install it first, then re-run: just sync --all-packages --group
+      #      <g> --inexact". A remediation you cannot run in the environment
+      #      that printed it is worse than no remediation — it sends the next
+      #      reader down a dead end. CLAUDE.md §1.2 (truth over plausibility).
+      # ubuntu-24.04 ships just 1.21 in universe, so no extra action/tap.
+      - name: Install native runtime libs (torchcodec + MuJoCo OSMesa + just)
         if: steps.select.outputs.any == 'true'
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends ffmpeg libosmesa6
+          sudo apt-get install -y --no-install-recommends ffmpeg libosmesa6 just
+          just --version
 
       - name: Install Python dependencies
         if: steps.select.outputs.any == 'true'

--- a/docs/contributing/selective-testing.md
+++ b/docs/contributing/selective-testing.md
@@ -80,6 +80,35 @@ suite.
    real LeRobot dataset. Wire-only sidecar tests use the `sidecar-wire` lane;
    sidecar-backed runtime lanes keep separate logical names because their
    preflight requirements differ.
+
+   **A selected directory counts as selecting the lane files inside it.**
+   `targets` mixes files (from the import scan) with directories (a package's
+   whole `tests/` dir, or an `extra_triggers` value like `tests/unit`), and a
+   directory string never `fnmatch`es a file glob. So a lane-owned file only
+   reachable *inside* a directory target used to drop out of its lane while
+   still being "selected": it ran in the cheap partition, skipped for want of
+   the optional stack, and reported green. That is the exact failure this
+   mechanism exists to prevent, and it is why the only `python/hal/tests` files
+   ever reaching the `libero` lane were the two in `isolate_globs` (peeling
+   makes them explicit file targets). The selector now expands directory targets
+   to the concrete lane files beneath them, so containment is enough. Practical
+   effect: a `robots/**` diff (which selects `tests/unit`) now also reruns the
+   `clip`, `opencv`, `onnx-export` and `sidecar-wire` lanes it always implicitly
+   selected but never actually exercised.
+
+   **A lane is assigned per FILE, so one file must not straddle two mutually
+   exclusive groups.** LIBERO pins `robosuite==1.4`, RoboCasa/OpenArm need
+   `>=1.5`, and the two cannot coexist in one venv (CLAUDE.md — "LIBERO↔RoboCasa
+   groups are mutually exclusive"). `python/hal/tests/test_sim_attached_action_dim.py`
+   used to hold both LIBERO tests and the OpenArm tabletop test; run in the
+   `libero` lane the LIBERO half imported robosuite 1.4 first, and the OpenArm
+   half then hit `openral_sim._deps._assert_no_live_dependency_swap`, which
+   correctly refuses to swap robosuite underneath live objects — so it *failed*
+   rather than ran, on every PR whose diff reached `python/hal/tests`. The
+   OpenArm test now lives in its own file
+   (`python/hal/tests/test_sim_attached_openarm_action_dim.py`) on the `robocasa`
+   lane. When you add a test needing a different optional stack from its file's
+   neighbours, give it its own file.
 7. **Ignored domains.** `cpp/**` is covered by `test-ros2` (colcon) / the
    safety-kernel ctest, not the Python suite, so a pure-C++ change selects
    nothing here rather than forcing a wasteful full Python run.

--- a/python/hal/tests/test_sim_attached_action_dim.py
+++ b/python/hal/tests/test_sim_attached_action_dim.py
@@ -167,8 +167,9 @@ def test_send_action_surfaces_terminal_guard_without_reset() -> None:
 #
 # Before the fix ``_probe_env_action_dim`` fell back to a hardcoded 11 for any
 # backend that didn't expose ``action_dim``. The native MuJoCo backends
-# (so101_box → 6, tabletop_push → robot actuator count, openarm_tabletop_pnp →
-# bimanual state_dim) require a specific width and raise on a 11-wide
+# (so101_box → 6, tabletop_push → robot actuator count; and, in the sibling
+# `test_sim_attached_openarm_action_dim.py`, openarm_tabletop_pnp → bimanual
+# state_dim) require a specific width and raise on a 11-wide
 # ``env.step``. Each now reports its true width via an ``action_dim`` property,
 # so the probe resolves the authoritative width for a HAL built with NO
 # explicit ``env_action_dim`` — used by both ``send_action`` and ``idle_step``.
@@ -219,35 +220,11 @@ def test_tabletop_push_action_dim_matches_robot_actuator_count() -> None:
     assert hal._env_action_dim == env.action_dim
 
 
-@_requires_renderer
-def test_openarm_tabletop_action_dim_matches_state_dim() -> None:
-    """Native openarm_tabletop_pnp reports its bimanual state_dim; the HAL probe resolves it.
-
-    Built through the deploy-sim ``build_sim_env_from_yaml`` loader (robosuite
-    MJCF wrapper). The ``openarm_tabletop_pnp`` scene mandates a ``base_pose``
-    at compose time; the loader now propagates the
-    SimScene YAML's ``base_pose`` into the composed ``SimEnvironment``,
-    so the scene builds through the loader exactly as it does through the direct
-    factory path.
-    """
-    pytest.importorskip("openral_sim")
-    pytest.importorskip("mujoco")
-    pytest.importorskip("robosuite")
-    from openral_core import RobotDescription
-    from openral_hal.sim_attached import SimAttachedHAL
-    from openral_hal.sim_bringup import build_sim_env_from_yaml
-
-    env, seed = build_sim_env_from_yaml(
-        "scenes/sim/openarm_tabletop.yaml", robot_id_fallback="openarm"
-    )
-    # state_dim is derived from the manifest joint count (bimanual OpenArm v2).
-    assert env.action_dim == env._state_dim
-    assert env.action_dim > 0
-
-    desc = RobotDescription.from_yaml("robots/openarm/robot.yaml")
-    hal = SimAttachedHAL(env, desc, env_reset_seed=seed)
-    hal.connect()
-    assert hal._env_action_dim == env.action_dim
+# NB: the openarm_tabletop_pnp counterpart of the two tests above deliberately
+# does NOT live here — see `test_sim_attached_openarm_action_dim.py`. This is a
+# LIBERO file (robosuite==1.4); the OpenArm scene needs robosuite>=1.5, and
+# tools/test_selection.toml assigns a dependency lane per FILE, so a file
+# holding both is always wrong for one of them.
 
 
 def test_probe_raises_for_non_introspectable_env_without_override() -> None:

--- a/python/hal/tests/test_sim_attached_openarm_action_dim.py
+++ b/python/hal/tests/test_sim_attached_openarm_action_dim.py
@@ -1,0 +1,111 @@
+"""SimAttachedHAL probes the OpenArm v2 tabletop env's true action width.
+
+Split out of ``test_sim_attached_action_dim.py``, which is a **LIBERO** file:
+LIBERO pins ``robosuite==1.4`` while the ``openarm_tabletop_pnp`` scene needs
+``robosuite>=1.5`` (the ``robocasa`` dependency group — see
+``openral_sim._deps._openarm_robosuite_plan``). The two pins are mutually
+exclusive in one venv (CLAUDE.md — "LIBERO↔RoboCasa groups are mutually
+exclusive"), and ``tools/test_selection.toml`` assigns a dependency lane
+**per file**, so a file holding both halves is always wrong for one of them.
+
+Concretely: run inside the ``libero`` lane, the LIBERO tests above this one
+imported robosuite 1.4, then this test's ``ensure_backend_deps`` probe found
+the wrong robosuite and ``_assert_no_live_dependency_swap`` correctly refused
+to swap the package under live objects — so the test failed instead of
+running, on every PR whose diff selected ``python/hal/tests/``. Keeping it in
+its own file lets ``requirement_globs.robocasa`` give it the robosuite>=1.5
+env it actually needs.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# The classic renderer calls glXOpenDisplay() and raises SIGABRT on headless
+# runners; EGL avoids the display requirement entirely.
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+
+def _mujoco_renderer_probe_error() -> str | None:
+    """Return ``None`` if a MuJoCo off-screen renderer can be created, else a reason.
+
+    Creating a ``mujoco.Renderer`` on a headless host without a working GL/EGL
+    stack calls ``abort()`` at the C level (SIGABRT), which a Python
+    ``try/except`` cannot catch — an in-process probe therefore crashes pytest
+    outright (``Fatal Python error: Aborted``) and takes the whole partition
+    down with it. Running the probe in a subprocess turns that abort into a
+    non-zero exit code we can detect and convert into a clean skip reason,
+    leaving collection alive. Mirrors ``test_sim_attached_action_dim`` /
+    ``test_sim_attached_idle_step`` / ``tests/sim/conftest`` (sibling test
+    roots we cannot import across).
+    """
+    import subprocess
+    import sys
+
+    probe = (
+        "import mujoco;"
+        "m = mujoco.MjModel.from_xml_string('<mujoco><worldbody></worldbody></mujoco>');"
+        "r = mujoco.Renderer(m, 1, 1); r.close()"
+    )
+    env = dict(os.environ)
+    env.setdefault("MUJOCO_GL", "egl")
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", probe],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+            check=False,
+        )
+    except FileNotFoundError:  # mujoco import unavailable in the probe interpreter
+        return "mujoco unavailable for renderer probe"
+    except subprocess.TimeoutExpired:
+        return "mujoco renderer probe timed out (120s)"
+    if proc.returncode == 0:
+        return None
+    stderr_lines = (proc.stderr or "").strip().splitlines()
+    detail = stderr_lines[-1] if stderr_lines else "no stderr"
+    return f"renderer probe exited {proc.returncode}: {detail}"
+
+
+# The openarm_tabletop backend renders an RGB observation inside ``connect()``;
+# on a headless runner without a GL stack that SIGABRTs the process.
+_RENDERER_ERROR = _mujoco_renderer_probe_error()
+_requires_renderer = pytest.mark.skipif(
+    _RENDERER_ERROR is not None,
+    reason=f"mujoco renderer unavailable: {_RENDERER_ERROR}",
+)
+
+
+@_requires_renderer
+def test_openarm_tabletop_action_dim_matches_state_dim() -> None:
+    """Native openarm_tabletop_pnp reports its bimanual state_dim; the HAL probe resolves it.
+
+    Built through the deploy-sim ``build_sim_env_from_yaml`` loader (robosuite
+    MJCF wrapper). The ``openarm_tabletop_pnp`` scene mandates a ``base_pose``
+    at compose time; the loader now propagates the
+    SimScene YAML's ``base_pose`` into the composed ``SimEnvironment``,
+    so the scene builds through the loader exactly as it does through the direct
+    factory path.
+    """
+    pytest.importorskip("openral_sim")
+    pytest.importorskip("mujoco")
+    pytest.importorskip("robosuite")
+    from openral_core import RobotDescription
+    from openral_hal.sim_attached import SimAttachedHAL
+    from openral_hal.sim_bringup import build_sim_env_from_yaml
+
+    env, seed = build_sim_env_from_yaml(
+        "scenes/sim/openarm_tabletop.yaml", robot_id_fallback="openarm"
+    )
+    # state_dim is derived from the manifest joint count (bimanual OpenArm v2).
+    assert env.action_dim == env._state_dim
+    assert env.action_dim > 0
+
+    desc = RobotDescription.from_yaml("robots/openarm/robot.yaml")
+    hal = SimAttachedHAL(env, desc, env_reset_seed=seed)
+    hal.connect()
+    assert hal._env_action_dim == env.action_dim

--- a/python/sim/src/openral_sim/_deps.py
+++ b/python/sim/src/openral_sim/_deps.py
@@ -1929,6 +1929,56 @@ def _display_install_banner(plan: BackendInstallPlan) -> None:
     )
 
 
+def _just_free_equivalent(manual_hint: str) -> str | None:
+    """Rewrite a ``just sync …`` hint into the commands that recipe actually runs.
+
+    Mirrors the ``sync`` recipe in the repo ``Justfile``: force
+    ``--all-packages`` unless the caller already scoped the sync, then repair
+    the malformed ``hf-libero`` install. Returns ``None`` for a hint that is not
+    a ``just sync`` invocation (e.g. the ``git clone …`` sidecar hints) — those
+    are runnable as they stand.
+
+    Example:
+        >>> _just_free_equivalent("just sync --group libero")  # doctest: +ELLIPSIS
+        'uv sync --all-packages --group libero && uv run ...repair_hf_libero_install.py'
+        >>> _just_free_equivalent("git clone https://example.invalid/x") is None
+        True
+    """
+    prefix = "just sync "
+    if not manual_hint.startswith(prefix):
+        return None
+    args = manual_hint[len(prefix) :].strip()
+    scoped = any(flag in f" {args} " for flag in (" --all-packages ", " --package ", " -p "))
+    sync = f"uv sync {args}" if scoped else f"uv sync --all-packages {args}"
+    return f"{sync} && uv run --no-sync python scripts/repair_hf_libero_install.py"
+
+
+def remediation(manual_hint: str) -> str:
+    """Return ``manual_hint``, plus a runnable equivalent when ``just`` is absent.
+
+    Every hint in this module names ``just sync …`` because that is the repo's
+    documented entry point (CLAUDE.md — "always ``just sync`` (never bare ``uv
+    sync``)"). But these messages are also raised inside environments that never
+    installed ``just``: CI runners, Docker images, a fresh box. A remediation
+    you cannot run where it was printed is a defect of its own — it costs the
+    reader a round trip to find out the instruction was impossible, which is
+    exactly how the hosted `select-and-test` runner behaved. Keep the canonical
+    command first (what the docs say, and what a normal dev host runs) and
+    append the expansion only when the binary really is missing, so the common
+    case stays uncluttered.
+
+    Example:
+        >>> "just sync --group libero" in remediation("just sync --group libero")
+        True
+    """
+    if shutil.which("just") is not None:
+        return manual_hint
+    equivalent = _just_free_equivalent(manual_hint)
+    if equivalent is None:
+        return manual_hint
+    return f"{manual_hint}\n  (`just` is not on PATH here — equivalently: {equivalent})"
+
+
 def _assert_no_live_dependency_swap(plan: BackendInstallPlan) -> None:
     """Refuse to re-pin a distribution this interpreter has already imported.
 
@@ -1967,7 +2017,7 @@ def _assert_no_live_dependency_swap(plan: BackendInstallPlan) -> None:
         f"would swap the package underneath live objects and produce confusing "
         f"duplicate-class errors (e.g. 'X is not a MujocoXML instance') rather "
         f"than a clean failure.\n"
-        f"Install it first, then re-run in a fresh process:\n  " + plan.manual_hint
+        f"Install it first, then re-run in a fresh process:\n  " + remediation(plan.manual_hint)
     )
 
 
@@ -2017,7 +2067,8 @@ def ensure_backend_deps(backend_id: str) -> None:
             if not typer.confirm(f"Install {plan.backend_id} deps now?", default=False):
                 raise ROSConfigError(
                     f"{plan.backend_id} backend not installed. Either set "
-                    f"{_AUTO_INSTALL_ENV}=1 and re-run, or install manually:\n  " + plan.manual_hint
+                    f"{_AUTO_INSTALL_ENV}=1 and re-run, or install manually:\n  "
+                    + remediation(plan.manual_hint)
                 )
 
         for step in plan.steps:
@@ -2028,7 +2079,7 @@ def ensure_backend_deps(backend_id: str) -> None:
                 raise ROSConfigError(
                     f"{plan.backend_id} install failed at step "
                     f"{step.description!r}: {_step_failure_detail(exc)}Finish manually:\n  "
-                    + plan.manual_hint
+                    + remediation(plan.manual_hint)
                 ) from exc
 
         # Some packages need importlib's caches invalidated for newly-installed
@@ -2067,7 +2118,7 @@ def ensure_backend_deps(backend_id: str) -> None:
             raise ROSConfigError(
                 f"{plan.backend_id} install ran to completion but the probe "
                 f"still fails. Inspect the install output above and finish "
-                f"manually:\n  " + plan.manual_hint
+                f"manually:\n  " + remediation(plan.manual_hint)
             )
 
         # Post-install: silence the "No private macro file found" warnings

--- a/tests/unit/test_deps_install_plans.py
+++ b/tests/unit/test_deps_install_plans.py
@@ -1001,3 +1001,103 @@ def test_step_failure_detail_handles_a_spawn_failure() -> None:
     detail = _deps._step_failure_detail(excinfo.value)
     assert "line(s) of step output" not in detail
     assert detail.endswith(". ")
+
+
+# ─── The remediation a failure prints must be runnable where it printed ────
+
+
+def _uv_only_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Narrow PATH to the real `uv` and nothing else — no `just` in sight.
+
+    Symlinks the actual uv binary rather than writing a stand-in, so the plan
+    builders (which resolve `uv` through `shutil.which`) keep working against
+    the real tool while `just` is genuinely absent.
+    """
+    uv = _deps.shutil.which("uv")
+    assert uv is not None, "uv must be on PATH to run this suite"
+    (tmp_path / "uv").symlink_to(uv)
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+
+class TestRemediationIsRunnableWhereItPrinted:
+    """`just sync …` is useless advice in an environment with no `just`.
+
+    The hosted `select-and-test` runner is exactly such an environment: the
+    OpenArm lane raised "Install it first, then re-run in a fresh process:
+    just sync --all-packages --group robocasa --inexact" on a container where
+    `just` does not exist, so following the instruction produced
+    `FileNotFoundError: 'just'`. CI now installs `just` (see
+    .github/workflows/test-selective.yml), but any other `just`-less container
+    reaching this message by another route must still get somewhere to go.
+    """
+
+    def test_expansion_matches_the_justfile_sync_recipe(self) -> None:
+        """Anti-drift: the expansion is only honest if the real recipe still does this.
+
+        Reads the repo's actual Justfile (CLAUDE.md §1.11 — a real fixture, not
+        a transcribed copy). If someone changes what `just sync` does, this
+        fails and the expansion gets updated with it.
+        """
+        recipe = (Path(__file__).resolve().parents[2] / "Justfile").read_text()
+        body = recipe.split("\nsync *args:", 1)[1].split("\n\n", 1)[0]
+        assert "uv sync --all-packages {{args}}" in body
+        assert "repair_hf_libero_install.py" in body
+
+    def test_unscoped_hint_gains_all_packages(self) -> None:
+        """`just sync --group X` forces --all-packages; a bare `uv sync` would not.
+
+        This is the whole reason the docs insist on `just sync`: without
+        `--all-packages`, `uv sync --group X` syncs only the workspace ROOT and
+        uninstalls every editable member. An expansion that dropped it would be
+        a venv-wrecker dressed as help.
+        """
+        expanded = _deps._just_free_equivalent("just sync --group libero")
+        assert expanded is not None
+        assert expanded.startswith("uv sync --all-packages --group libero")
+        assert "repair_hf_libero_install.py" in expanded
+
+    def test_already_scoped_hint_is_not_double_flagged(self) -> None:
+        """A hint that already says --all-packages must not get a second copy."""
+        hint = _openarm_robosuite_plan().manual_hint
+        expanded = _deps._just_free_equivalent(hint)
+        assert expanded is not None
+        assert expanded.count("--all-packages") == 1
+        assert expanded.startswith("uv sync --all-packages --group robocasa --inexact")
+
+    def test_non_sync_hint_is_left_alone(self) -> None:
+        """Sidecar hints (`git clone …`) are already runnable; do not rewrite them."""
+        assert _deps._just_free_equivalent("git clone https://example.invalid/x") is None
+
+    def test_message_carries_a_runnable_command_without_just(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """With `just` genuinely off PATH the message names something that works.
+
+        PATH is narrowed to a directory holding the real `uv` and nothing else
+        — a genuine environment change `shutil.which` resolves against, not a
+        patched lookup, and the exact shape of the CI runner that reported this
+        (uv present via setup-uv, `just` never installed).
+        """
+        _uv_only_path(monkeypatch, tmp_path)
+        assert _deps.shutil.which("just") is None
+        assert _deps.shutil.which("uv") is not None
+        hint = _openarm_robosuite_plan().manual_hint
+        text = _deps.remediation(hint)
+        assert hint in text, "the canonical command stays, for hosts that do have just"
+        assert "uv sync --all-packages --group robocasa --inexact" in text
+
+    def test_live_swap_refusal_surfaces_the_runnable_command(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The reported error — the OpenArm live-swap refusal — carries it too.
+
+        The guard itself is unchanged and still fires: this asserts the refusal
+        (which is correct behaviour) explains a remediation the reader can run.
+        """
+        _uv_only_path(monkeypatch, tmp_path)
+        monkeypatch.setitem(sys.modules, "robosuite", SimpleNamespace(__version__="1.4.0"))
+        with pytest.raises(ROSConfigError) as excinfo:
+            _deps._assert_no_live_dependency_swap(_openarm_robosuite_plan())
+        message = str(excinfo.value)
+        assert "already imported it" in message, "the guard must still refuse the swap"
+        assert "uv sync --all-packages --group robocasa --inexact" in message

--- a/tests/unit/test_select_tests.py
+++ b/tests/unit/test_select_tests.py
@@ -9,6 +9,7 @@ fail.
 
 from __future__ import annotations
 
+import fnmatch
 import importlib.util
 import sys
 from pathlib import Path
@@ -224,3 +225,56 @@ def test_unrelated_change_does_not_isolate_fork_test() -> None:
     # isolating un-selected tests would defeat selective execution.
     result = select_tests.select(REPO_ROOT, ["python/wam/src/openral_wam/core.py"], CONFIG)
     assert result.isolated_targets == []
+
+
+# --- lane files reachable only inside a selected DIRECTORY target -------------
+#
+# `targets` mixes files with directories. A requirement glob names a file, and a
+# directory string never fnmatches a file glob, so a lane-owned file that is only
+# reachable via its containing directory used to silently lose its lane: still
+# "selected", but run only in the cheap partition where it skips for want of the
+# optional stack — selected, never executed, green.
+
+_OPENARM_HAL_TEST = "python/hal/tests/test_sim_attached_openarm_action_dim.py"
+
+
+def test_lane_file_inside_a_selected_directory_reaches_its_lane() -> None:
+    # A python/hal change selects the whole `python/hal/tests` DIRECTORY. The
+    # OpenArm file lives inside it and is not peeled into isolated_targets, so
+    # only directory expansion can carry it into the robocasa lane.
+    result = select_tests.select(REPO_ROOT, ["python/hal/src/openral_hal/openarm.py"], CONFIG)
+    assert "python/hal/tests" in result.targets
+    assert _OPENARM_HAL_TEST not in result.targets, "the directory target covers it"
+    assert _OPENARM_HAL_TEST not in result.isolated_targets
+    assert _OPENARM_HAL_TEST in result.requirement_targets["robocasa"]
+
+
+def test_directory_expansion_does_not_invent_unselected_lane_files() -> None:
+    # Expansion must stay inside the selected directories: a leaf change that
+    # selects only python/wam's own tests must not drag in another dir's lane
+    # files. Widening here would defeat selective execution.
+    result = select_tests.select(REPO_ROOT, ["python/wam/src/openral_wam/core.py"], CONFIG)
+    assert _OPENARM_HAL_TEST not in result.requirement_targets.get("robocasa", [])
+
+
+def test_openarm_manifest_change_reaches_the_robosuite_lane() -> None:
+    # `robots/openarm/robot.yaml` is loaded for real by both OpenArm tests (the
+    # composed MJCF's actuators and the HAL's action width are derived from it),
+    # but a robots/** diff previously reached neither.
+    result = select_tests.select(REPO_ROOT, ["robots/openarm/robot.yaml"], CONFIG)
+    robocasa = result.requirement_targets["robocasa"]
+    assert _OPENARM_HAL_TEST in robocasa
+    assert "tests/sim/test_openarm_scene_pnp.py" in robocasa
+
+
+def test_openarm_test_is_not_on_the_libero_lane() -> None:
+    # LIBERO pins robosuite==1.4; the OpenArm scene needs >=1.5. A file on the
+    # libero lane that needs 1.5 hits _assert_no_live_dependency_swap and fails
+    # rather than runs — the regression this split exists to prevent.
+    libero = CONFIG.requirement_globs["libero"]
+    assert not any(fnmatch.fnmatch(_OPENARM_HAL_TEST, glob) for glob in libero), (
+        "the OpenArm test must never land in the robosuite==1.4 lane"
+    )
+    assert any(
+        fnmatch.fnmatch(_OPENARM_HAL_TEST, glob) for glob in CONFIG.requirement_globs["robocasa"]
+    )

--- a/tests/unit/test_select_tests.py
+++ b/tests/unit/test_select_tests.py
@@ -278,3 +278,14 @@ def test_openarm_test_is_not_on_the_libero_lane() -> None:
     assert any(
         fnmatch.fnmatch(_OPENARM_HAL_TEST, glob) for glob in CONFIG.requirement_globs["robocasa"]
     )
+
+
+def test_unattributed_source_full_run_still_reports_isolated_targets() -> None:
+    # Same contract as test_full_run_still_reports_isolated_targets: the
+    # full-suite invocation collects the fork-crashers, so it must be told to
+    # --ignore them and rerun each alone. Omitted, they ran inside the broad
+    # `tests/unit/` process and reintroduced issue #24 — a non-zero exit after
+    # an all-pass summary.
+    result = select_tests.select(REPO_ROOT, ["scripts/mystery_tool.py"], CONFIG)
+    assert result.full_run
+    assert _FORK_TEST in result.isolated_targets

--- a/tools/select_tests.py
+++ b/tools/select_tests.py
@@ -327,6 +327,18 @@ def select(
 
     # 1. Blast radius — any match forces a full run. The full-suite invocation
     #    still collects the isolate files, so report them for separate execution.
+    #
+    #    KNOWN GAP (issue #163): `requirement_targets` is left EMPTY here, so a
+    #    blast-radius diff runs ZERO opt-in dependency lanes — the widest diffs
+    #    get the least lane verification, and a failing PR can go green merely
+    #    by also touching `pyproject.toml`. The `if full_run:` branch in
+    #    `_requirement_targets` exists to expand every glob for exactly this
+    #    case and is currently unreachable. It is NOT switched on here because
+    #    the lanes it would then run include several the hosted GPU-less runner
+    #    cannot satisfy (isaacsim / robotwin / gr00t sidecars, CUDA- and
+    #    Vulkan-gated tests), which would make every blast-radius PR permanently
+    #    red. That needs a per-lane host-requirement concept first — see #163.
+    #    Written down rather than left silent (CLAUDE.md §1.4).
     for rel in changed_files:
         for glob in config.full_run_globs:
             if fnmatch.fnmatch(rel, glob):
@@ -369,6 +381,13 @@ def select(
             return SelectionResult(
                 full_run=True,
                 full_run_reason=f"unattributed source change: {rel}",
+                # Must be reported like the blast-radius return above: the
+                # full-suite step `--ignore`s these and reruns each alone.
+                # Omitted, they ran INSIDE the broad `tests/unit/` process and
+                # reintroduced issue #24 — a non-zero exit after an all-pass
+                # summary. (`requirement_targets` stays empty here for the same
+                # reason as the blast-radius return — issue #163.)
+                isolated_targets=isolate_files,
             )
 
     affected = transitive_dependents(graph, changed_pkgs)

--- a/tools/select_tests.py
+++ b/tools/select_tests.py
@@ -276,13 +276,36 @@ def _requirement_targets(
     *,
     full_run: bool,
 ) -> dict[str, list[str]]:
-    """Selected pytest targets that need an opt-in dependency group."""
+    """Selected pytest targets that need an opt-in dependency group.
+
+    ``targets`` holds a mix of FILE paths (top-level ``tests/`` files picked by
+    the import scan) and DIRECTORY paths (a package's whole ``tests/`` dir, or
+    an ``extra_triggers`` value like ``tests/unit``). A requirement glob names a
+    file, and a directory string never ``fnmatch``es a file glob — so a
+    lane-owned file that is only reachable *inside* a selected directory used to
+    drop out of its lane entirely. It still ran in the cheap partition, where
+    the optional stack is absent and it skips: selected, never executed, green.
+    That is the exact silent-degradation shape this selector exists to prevent,
+    and it is why the only ``python/hal/tests`` files that ever reached the
+    ``libero`` lane were the two in ``isolate_globs`` (peeling makes them
+    explicit file targets). Expand directory targets to the concrete lane files
+    beneath them so containment is enough.
+    """
     selected = set(isolated_targets)
     if full_run:
         for globs in config.requirement_globs.values():
             selected.update(_targets_matching_globs(repo_root, globs))
     else:
         selected.update(targets)
+        dir_targets = [t for t in targets if (repo_root / t).is_dir()]
+        if dir_targets:
+            prefixes = tuple(t.rstrip("/") + "/" for t in dir_targets)
+            for globs in config.requirement_globs.values():
+                selected.update(
+                    hit
+                    for hit in _targets_matching_globs(repo_root, globs)
+                    if hit.startswith(prefixes)
+                )
 
     out: dict[str, list[str]] = {}
     for requirement, globs in config.requirement_globs.items():

--- a/tools/test_selection.toml
+++ b/tools/test_selection.toml
@@ -65,14 +65,19 @@ isolate_globs = [
   # absent in most local checkouts so it skips there, which is why this only ever
   # bit on CI. Run alone in a fresh interpreter it passes clean.
   "tests/sim/test_dataset_emission.py",
-  # Each spins up a real LIBERO / robosuite-MJCF (openarm) OffScreenRenderEnv.
+  # Each spins up a real LIBERO / native-MuJoCo OffScreenRenderEnv.
   # robosuite/MuJoCo EGL contexts do not survive a sibling env's teardown in the
-  # same interpreter: once one file's openarm env is GC'd, the next file's LIBERO
+  # same interpreter: once one file's env is GC'd, the next file's LIBERO
   # env dies at reset with "<...RethinkMount> is not a MujocoXML instance" — even
   # on the correct robosuite 1.4 (issue #24 class, NOT a 1.4-vs-1.5 conflict).
   # Each file passes cleanly run alone, so isolate them per-process. The libero
   # lane is a no-ROS host, so idle_step's one rclpy-gated test legitimately skips
   # there — the isolated runner tolerates that (see test-selective.yml run_lane).
+  # NB: these are LIBERO (robosuite==1.4) files. The OpenArm tabletop test that
+  # used to sit in action_dim.py needs robosuite>=1.5 and now lives in
+  # `test_sim_attached_openarm_action_dim.py` on the `robocasa` lane — see the
+  # note there. It is deliberately NOT listed here: an isolated slot tolerates
+  # skips, and this lane's whole job is to reject them.
   "python/hal/tests/test_sim_attached_action_dim.py",
   "python/hal/tests/test_sim_attached_idle_step.py",
   # Mixed CPU/GPU sidecar files: the hosted selective runner exercises the
@@ -116,6 +121,18 @@ isolate_globs = [
 ]
 "robots/aloha_bimanual/**" = ["tests/sim/test_aloha_bimanual_hal_mujoco.py"]
 "robots/gr1/**" = ["tests/sim/test_gr1_robocasa_env_build.py"]
+# Both files load `robots/openarm/robot.yaml` for real (the composed MJCF's
+# actuator inventory and the HAL's state/action widths are DERIVED from it), so
+# a manifest edit must re-run them. Without this a `robots/openarm/**` diff
+# selected only tests/unit + the ROS package dirs and could not reach either.
+"robots/openarm/**" = [
+  "tests/sim/test_openarm_scene_pnp.py",
+  "python/hal/tests/test_sim_attached_openarm_action_dim.py",
+]
+"scenes/*/openarm*.yaml" = [
+  "tests/sim/test_openarm_scene_pnp.py",
+  "python/hal/tests/test_sim_attached_openarm_action_dim.py",
+]
 "rskills/**" = ["tests/unit"]
 "rskills/act-aloha*/**" = ["tests/sim/test_aloha_bimanual_act_aloha.py"]
 "rskills/diffusion-pusht/**" = ["tests/sim/test_pusht_2d_diffusion_pusht.py"]
@@ -145,6 +162,22 @@ libero = [
 ]
 robocasa = [
   "tests/sim/test_so100_robosuite_lift.py",
+  # The OpenArm v2 tabletop scene is a robosuite>=1.5 MJCF wrapper (backend
+  # `openarm_robosuite`; install plan in `openral_sim._deps`). Both files below
+  # were previously lane-less or MIS-laned, so neither had ever executed on CI:
+  # the scene smoke test skipped everywhere (the cheap env has no robosuite at
+  # all), and the HAL action-dim test was folded into the `libero` lane, where
+  # robosuite==1.4 is installed — `ensure_backend_deps` then correctly refused
+  # to hot-swap robosuite under an interpreter that had already imported 1.4,
+  # failing the lane for every PR whose diff reached `python/hal/tests/`.
+  # Running them HERE gives them the robosuite>=1.5 env they actually need.
+  # Batched (not isolated) on purpose: they coexist with
+  # test_so100_robosuite_lift.py in one interpreter — this lane installs no
+  # LIBERO, so there is no 1.4-vs-1.5 seam and no cross-file EGL teardown
+  # problem — and the batched path is the one that REJECTS a skip. An isolated
+  # slot tolerates skips, which is exactly how these stopped running.
+  "tests/sim/test_openarm_scene_pnp.py",
+  "python/hal/tests/test_sim_attached_openarm_action_dim.py",
 ]
 robocasa-gr1 = [
   "tests/sim/test_gr1_robocasa_env_build.py",

--- a/tools/verify_test_envs.py
+++ b/tools/verify_test_envs.py
@@ -480,6 +480,26 @@ def main(argv: list[str] | None = None) -> int:
         print(f"unknown group(s): {', '.join(unknown)}", file=sys.stderr)
         return 2
 
+    # Fail here, once, with an actionable message rather than N times with a
+    # bare `FileNotFoundError: [Errno 2] No such file or directory: 'just'`
+    # traceback out of subprocess.Popen — which is what the robocasa-gr1 and
+    # simpler-env lanes produced on the hosted runner, before a single test ran.
+    # `just sync` (not bare `uv sync`) is the required entry point: the recipe
+    # forces --all-packages and then repairs the malformed hf-libero install, so
+    # substituting a plain `uv sync` here would silently diverge from the
+    # documented flow. Say what is missing instead (CLAUDE.md §1.4).
+    if not args.no_sync and not args.dry_run and shutil.which("just") is None:
+        print(
+            "`just` is not on PATH, and this script syncs dependency groups "
+            "through `just sync` (the recipe forces --all-packages and repairs "
+            "the hf-libero install; a bare `uv sync` is not equivalent).\n"
+            "Install it — e.g. `sudo apt-get install -y just` on Ubuntu 24.04+, "
+            "`cargo install just`, or `uv tool install rust-just` — or re-run "
+            "with --no-sync if the groups are already installed.",
+            file=sys.stderr,
+        )
+        return 2
+
     rc = 0
     for group in requested:
         reason = _preflight_group(


### PR DESCRIPTION
## What changed

The `select-and-test` job's opt-in robosuite path failed for anyone whose diff
reached `python/hal/tests/`, with

```
ROSConfigError: openarm_robosuite needs a different robosuite than the one
installed, but this process has already imported it.
```

and separately told the reader to run `just sync …` on a container with no
`just`. Both are fixed; `_assert_no_live_dependency_swap` is untouched.

### 1. The guard was right; the lane assignment was wrong

`tools/test_selection.toml` picks a dependency lane **per file**.
`python/hal/tests/test_sim_attached_action_dim.py` held both LIBERO tests
(`robosuite==1.4`) and the OpenArm tabletop test (`robosuite>=1.5`, the
`robocasa` group) — mutually exclusive pins. In the `libero` lane the LIBERO
half imported robosuite 1.4 first, so `ensure_backend_deps("openarm_robosuite")`
found the wrong version and the guard correctly refused to swap the package
under live objects. The test **failed instead of running**, and ran correctly
nowhere else.

`tests/sim/test_openarm_scene_pnp.py` was in no lane at all — three tests that
had never executed on CI since they landed.

Fix: the OpenArm test moves to its own file on the `robocasa` lane, together
with `test_openarm_scene_pnp.py`. Batched, not isolated — the batched path is
the one that rejects a skip.

### 2. The selector dropped lane files that lived inside a directory target

`targets` mixes files with directories; a directory string never `fnmatch`es a
file glob. Any lane-owned file reachable only *inside* a selected directory
silently lost its lane: still "selected", but run only in the cheap partition
where it skips for want of the optional stack — selected, never executed, green.
Directory targets are now expanded to the lane files beneath them.

### 3. `just` was prescribed where `just` does not exist

`tools/verify_test_envs.py` shells out to `just sync` and died with a bare
`FileNotFoundError: 'just'` in the `robocasa-gr1` / `simpler-env` lanes; every
`_deps` hint names `just sync …` too. CI now installs `just` (ubuntu-24.04
universe), `verify_test_envs.py` preflights it with an actionable message
instead of a traceback, and `_deps.remediation()` appends the recipe's literal
expansion when `just` is genuinely off PATH.

## Why

Six-plus silent-degradation defects of the same family surfaced in this repo
this week: a plausible-looking wrong state produced quietly where a loud failure
was available. Two more here — a test that failed in the only lane that selected
it, and a whole file that skipped everywhere.

## How tested

- **The lane itself, for real**: `pytest
  python/hal/tests/test_sim_attached_openarm_action_dim.py
  tests/sim/test_openarm_scene_pnp.py tests/sim/test_so100_robosuite_lift.py`
  in a `--group robocasa` venv (robosuite 1.5.2, GTX 1060, EGL) — **18 passed,
  0 skipped**, one interpreter: exactly the batch and the strictness the lane
  applies. Run against `fcf7f01`, i.e. including #152's `robots/openarm/robot.yaml`
  changes.
- `tests/unit/test_select_tests.py` +4 cases; the directory-expansion one was
  confirmed to **fail** against the pre-fix `select_tests.py`.
- `tests/unit/test_deps_install_plans.py` +6 cases against a PATH narrowed to
  the real `uv` and nothing else, incl. one asserting the guard still refuses
  the swap while naming a runnable command; plus an anti-drift case that reads
  the real `Justfile`.
- `just lint`, `mypy --strict tools/ -p openral_sim -p openral_core`,
  full `tests/unit/`.

**Nothing is made to skip** — this strictly increases what executes: the OpenArm
HAL test now passes instead of failing, `test_openarm_scene_pnp.py`'s three tests
run for the first time, and a `robots/**` diff additionally reruns the `clip` /
`opencv` / `onnx-export` / `sidecar-wire` lanes it always implicitly selected but
never exercised.

## Not bundled

This PR touches `tools/test_selection.toml` + `tools/select_tests.py` +
`test-selective.yml`, all `full_run_globs`, so it forces a full run and every
lane — including lanes already failing on `master` for unrelated reasons
(`isaacsim`, `robotwin`, `gr00t` "produced no passing tests"; the `libero` /
`maniskill3` "still skipped selected tests" CUDA/Vulkan strictness). Those
predate this branch and are visible identically on run 32644213906 and PR #153's
run 32646951312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUhD1uz93qMFJQsNxyTEM5
