### PR TITLE
fix(ci): two independent ways select-and-test reported success over failure

### DIFF
--- a/.github/workflows/test-selective.yml
+++ b/.github/workflows/test-selective.yml
@@ -368,7 +368,6 @@ jobs:
           ISAACSIM_TARGETS: ${{ steps.select.outputs.isaacsim_targets }}
           ROBOTWIN_TARGETS: ${{ steps.select.outputs.robotwin_targets }}
           SIDECAR_WIRE_TARGETS: ${{ steps.select.outputs.sidecar_wire_targets }}
-          RLDX_TARGETS: ${{ steps.select.outputs.rldx_targets }}
           DATASET_TARGETS: ${{ steps.select.outputs.dataset_targets }}
           RLBENCH_TARGETS: ${{ steps.select.outputs.rlbench_targets }}
           GR00T_TARGETS: ${{ steps.select.outputs.gr00t_targets }}
@@ -380,35 +379,40 @@ jobs:
           OPENCV_TARGETS: ${{ steps.select.outputs.opencv_targets }}
           LOWERING_TARGETS: ${{ steps.select.outputs.lowering_targets }}
           ISOLATED_TARGETS: ${{ steps.select.outputs.isolated_targets }}
+          LEDGER: ${{ runner.temp }}/lane-ledger.jsonl
         run: |
-          # A grouped (batched) run must show passes and must not skip — a skip
-          # means the lane env was under-provisioned for a test that should run.
-          check_grouped_log() {
-            if [ "$rc" -eq 0 ] && ! grep -Eq '[0-9]+ passed' "$log"; then
-              echo "::error::opt-in lane ${group} selected tests but produced no passing tests"
-              rc=1
-            fi
-            if grep -Eq '[0-9]+ skipped' "$log"; then
-              echo "::error::opt-in lane ${group} still skipped selected tests; provision the missing env or move the target out of the strict lane"
-              rc=1
-            fi
+          # Accounting is done by tools/lane_report.py against pytest's junit
+          # XML, not by grepping the terse summary. Two reasons (issue #163):
+          #  * "any skip fails the lane" is right for anything this runner CAN
+          #    provide and wrong for anything it cannot. The report attributes a
+          #    skip to a DECLARED capability gap ([capability_gaps] in
+          #    tools/test_selection.toml) and fails on every other skip, so a
+          #    CUDA gate no longer reddens the lane while a real provisioning
+          #    gap ("panda.srdf not installed") still does.
+          #  * every lane now writes a LEDGER record, and the attest step below
+          #    checks the ledger against the selection. A lane that was selected
+          #    and never executed is a hard failure instead of an absence.
+          report_lane() {
+            local lane_rc=0
+            uv run --isolated --with pydantic --python 3.12 \
+              python tools/lane_report.py --ledger "$LEDGER" lane \
+              --lane "$1" --exit-code "$2" "${@:3}" || lane_rc=1
+            return "$lane_rc"
           }
           run_lane() {
             # `local` is load-bearing. Without it this function's `rc=0` reset
             # clobbered the CALLER's accumulator of the same name: a failing
             # lane followed by any passing lane exited 0, so the step's status
-            # reflected only the LAST non-empty lane. Verified on real runs —
-            # 32624877346, 32646323789, 32647641634, 32655994733 and
-            # 32656309517 all reported SUCCESS while carrying 12-13
-            # `::error::opt-in lane ...` messages in the log, because `lowering`
-            # happened to run last and pass. The strict-lane gate was therefore
-            # advisory for every lane except the final one.
+            # reflected only the LAST lane. Five runs went green carrying 12–13
+            # `::error::opt-in lane …` messages in the log.
             local group="$1"
             local targets="$2"
             [ -z "$targets" ] && return 0
             local dependency_group="$group"
-            local rc
+            local rc=0
+            local xml_args=()
             local log
+            local batched_xml
             extra_groups=()
             env_args=()
             if [ "$group" = "sim" ]; then
@@ -419,7 +423,7 @@ jobs:
             fi
             echo "::group::pytest opt-in group=${group} targets=${targets}"
             log=$(mktemp)
-            rc=0
+            batched_xml="$RUNNER_TEMP/lane-${group}-batched.xml"
             python3 scripts/repair_hf_libero_install.py || true
             # robocasa + robocasa-gr1 both need robosuite 1.5.2 from the git pin
             # (232ce7d4). The libero lane runs first and leaves robosuite 1.4.0
@@ -441,10 +445,12 @@ jobs:
             fi
             if [ "$rc" -eq 0 ]; then
               if [ "$group" = "simpler-env" ] || [ "$group" = "robocasa-gr1" ]; then
+                # verify_test_envs.py drives its own pytest, so there is no junit
+                # report to account from — judge it by exit code alone.
                 OPENRAL_ALLOW_ROBOCASA_ASSETS=1 uv run python tools/verify_test_envs.py \
                   --include-provisioned --groups "$group" 2>&1 | tee "$log" || rc=$?
                 python3 scripts/repair_hf_libero_install.py || true
-                check_grouped_log
+                report_lane "$group" "$rc" --from-exit-code || rc=1
               else
                 # Partition selected targets: files flagged for per-process
                 # isolation (ISOLATED_TARGETS, from tools/test_selection.toml
@@ -464,24 +470,34 @@ jobs:
                 if [ -n "$batched" ]; then
                   # shellcheck disable=SC2086 -- selector-emitted space-separated list.
                   env "${env_args[@]}" uv run --all-packages --group "$dependency_group" "${extra_groups[@]}" pytest $batched \
-                    -q -rs -p no:launch_testing -p no:launch_ros 2>&1 | tee "$log" || rc=$?
+                    -q -rs -p no:launch_testing -p no:launch_ros \
+                    --junit-xml="$batched_xml" 2>&1 | tee "$log" || rc=$?
                   python3 scripts/repair_hf_libero_install.py || true
-                  check_grouped_log
+                  xml_args+=(--junit-xml "$batched_xml")
                 fi
+                # Isolated files are accounted by the SAME rule as the batched
+                # run. They used to be judged on exit code alone, so any skip
+                # inside one was invisible — the batched/isolated asymmetry was
+                # a place a real gap could hide. Every skip they emit today is
+                # explained by a declared capability gap, so applying the strict
+                # rule costs nothing and closes the hole.
+                iso_n=0
                 for t in $isolated_here; do
                   echo "::group::pytest (isolated) ${t}"
+                  iso_n=$((iso_n + 1))
+                  iso_xml="$RUNNER_TEMP/lane-${group}-iso-${iso_n}.xml"
                   iso_rc=0
                   env "${env_args[@]}" uv run --all-packages --group "$dependency_group" "${extra_groups[@]}" pytest "$t" \
-                    -q -rs -p no:launch_testing -p no:launch_ros || iso_rc=$?
+                    -q -rs -p no:launch_testing -p no:launch_ros \
+                    --junit-xml="$iso_xml" || iso_rc=$?
                   python3 scripts/repair_hf_libero_install.py || true
                   echo "::endgroup::"
-                  # An isolated file may legitimately importorskip an optional dep
-                  # (e.g. rclpy on this no-ROS lane host): exit 5 == nothing
-                  # collected, a partial skip still exits 0. Only a real failure
-                  # (1 failed / 2 interrupted / segfault) fails the lane — mirrors
-                  # the full-run isolated path.
+                  # exit 5 == nothing collected (whole module importorskip'd):
+                  # a legitimate all-skipped outcome, judged from the report.
                   if [ "$iso_rc" -ne 0 ] && [ "$iso_rc" -ne 5 ]; then rc=1; fi
+                  xml_args+=(--junit-xml "$iso_xml")
                 done
+                report_lane "$group" "$rc" "${xml_args[@]}" || rc=1
               fi
             fi
             echo "::endgroup::"
@@ -498,7 +514,6 @@ jobs:
           run_lane isaacsim "$ISAACSIM_TARGETS" || rc=1
           run_lane robotwin "$ROBOTWIN_TARGETS" || rc=1
           run_lane sidecar-wire "$SIDECAR_WIRE_TARGETS" || rc=1
-          run_lane rldx "$RLDX_TARGETS" || rc=1
           run_lane dataset "$DATASET_TARGETS" || rc=1
           run_lane rlbench "$RLBENCH_TARGETS" || rc=1
           run_lane gr00t "$GR00T_TARGETS" || rc=1
@@ -510,3 +525,38 @@ jobs:
           run_lane opencv "$OPENCV_TARGETS" || rc=1
           run_lane lowering "$LOWERING_TARGETS" || rc=1
           exit $rc
+
+      # The anti-vacuity gate. Everything above can fail loudly; this step
+      # exists for the case where nothing failed because nothing RAN. It
+      # cross-checks the lane ledger against the selector's own output, so
+      # "tested nothing" and "tested everything and passed" can no longer
+      # report the same result (issue #163):
+      #   * a full_run diff that expanded to zero lanes fails outright — that
+      #     is the exact regression #163 describes;
+      #   * a lane the selector chose that produced no ledger record fails as
+      #     "selected but never executed";
+      #   * the ledger itself is written to the job summary, naming every lane
+      #     that was declared-not-run and the capability it needs, so the
+      #     coverage gap is legible instead of invisible.
+      # `always()` so a red lane still publishes the ledger.
+      - name: Attest lane coverage
+        if: ${{ always() && steps.select.outputs.any == 'true' }}
+        env:
+          FULL_RUN: ${{ steps.select.outputs.full_run }}
+          REQUIREMENT_TARGETS_JSON: ${{ steps.select.outputs.requirement_targets_json }}
+          LEDGER: ${{ runner.temp }}/lane-ledger.jsonl
+        run: |
+          python3 - > "$RUNNER_TEMP/selection.json" <<'PY'
+          import json, os, sys
+          json.dump(
+              {
+                  "full_run": os.environ.get("FULL_RUN", "false"),
+                  "requirement_targets_json": os.environ.get("REQUIREMENT_TARGETS_JSON") or "{}",
+              },
+              sys.stdout,
+          )
+          PY
+          uv run --isolated --with pydantic --python 3.12 \
+            python tools/lane_report.py --ledger "$LEDGER" attest \
+            --selection-json "$RUNNER_TEMP/selection.json" \
+            --summary "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test-selective.yml
+++ b/.github/workflows/test-selective.yml
@@ -394,10 +394,21 @@ jobs:
             fi
           }
           run_lane() {
-            group="$1"
-            targets="$2"
+            # `local` is load-bearing. Without it this function's `rc=0` reset
+            # clobbered the CALLER's accumulator of the same name: a failing
+            # lane followed by any passing lane exited 0, so the step's status
+            # reflected only the LAST non-empty lane. Verified on real runs —
+            # 32624877346, 32646323789, 32647641634, 32655994733 and
+            # 32656309517 all reported SUCCESS while carrying 12-13
+            # `::error::opt-in lane ...` messages in the log, because `lowering`
+            # happened to run last and pass. The strict-lane gate was therefore
+            # advisory for every lane except the final one.
+            local group="$1"
+            local targets="$2"
             [ -z "$targets" ] && return 0
-            dependency_group="$group"
+            local dependency_group="$group"
+            local rc
+            local log
             extra_groups=()
             env_args=()
             if [ "$group" = "sim" ]; then

--- a/docs/contributing/selective-testing.md
+++ b/docs/contributing/selective-testing.md
@@ -37,6 +37,16 @@ suite.
    try to be clever about a wide-blast change; a wrong *negative* would silently
    skip a regression.
 
+   A full run expands **every opt-in dependency lane** as well (rule 6). It did
+   not always: `requirement_targets` was left empty on both full-run exits, so a
+   blast-radius diff ran *zero* lanes and the job reported success having
+   executed none of them — indistinguishable from a run that executed them all
+   and passed ([#163](https://github.com/OpenRAL/openral/issues/163)). The
+   effect was the exact inverse of the intent: the widest diffs got the least
+   verification, and a red PR could be turned green by also touching
+   `pyproject.toml`. A root-`pyproject.toml`/`uv.lock` change is a *dependency*
+   change, which is precisely what the lanes exist to check.
+
    The one exception is release-please's release PR, and it is handled in the
    workflow rather than here — precisely so the selector keeps no special
    cases. `test-selective` short-circuits the `release-please--*` branch before
@@ -73,13 +83,20 @@ suite.
    `lowering`).
    The default cheap lane may still skip those tests; CI then reruns the matching
    targets with the named group installed and fails if the lane produces no
-   passing tests **or any skip**. This is what prevents “selected but skipped
-   because `gym_aloha` is absent” from going green. Mixed files with intentional
-   fixture-absence skips stay outside strict lanes. The `sim` lane also installs
-   the `dataset` extra because its dataset-emission target writes and reloads a
-   real LeRobot dataset. Wire-only sidecar tests use the `sidecar-wire` lane;
-   sidecar-backed runtime lanes keep separate logical names because their
-   preflight requirements differ.
+   passing tests **or any skip that is not a declared capability gap** (see
+   [Lane policy](#lane-policy--what-a-skip-is-allowed-to-mean) below). This is
+   what prevents “selected but skipped because `gym_aloha` is absent” from going
+   green. The `sim` lane also installs the `dataset` extra because its
+   dataset-emission target writes and reloads a real LeRobot dataset. Wire-only
+   sidecar tests use the `sidecar-wire` lane; sidecar-backed runtime lanes keep
+   separate logical names because their preflight requirements differ.
+
+   A lane declared with an **empty** glob list can never run — `run_lane`
+   returns at its `[ -z "$targets" ]` guard, logging nothing, and looks exactly
+   like a lane that simply was not selected. `rldx` sat in that state from the
+   day it was added; its real test is covered by `sidecar-wire` (the group
+   `rldx` merely includes), so the empty lane was removed and
+   `tests/unit/test_lane_report.py` now fails any lane declared with no globs.
 
    **A selected directory counts as selecting the lane files inside it.**
    `targets` mixes files (from the import scan) with directories (a package's
@@ -154,6 +171,76 @@ suite.
 
 Every selected target carries a human-readable reason.
 
+### Lane policy — what a skip is allowed to mean
+
+Once a full run expands every lane, the lanes have to be *judged* correctly, and
+the old rule ("a lane must have passing tests and must not skip **at all**")
+could not survive that. A GitHub-hosted `ubuntu-24.04` runner has no NVIDIA GPU,
+no Vulkan ICD, and no proprietary simulator sidecars. Tests gated on those skip
+there **forever**, so the blunt rule reddened lanes that had in fact done real
+work — the `sim` lane ran 162 passing tests on PR #153 and was failed anyway by
+13 `requires CUDA` skips.
+
+Three options were on the table, and only one is honest:
+
+| Option | Why not / why |
+| --- | --- |
+| Run nothing on a full run, but say so loudly | Rejected. It annotates the coverage hole instead of closing it, and a blast-radius diff (`uv.lock`!) is exactly when lanes matter most. |
+| Gate the unsatisfiable lanes behind a self-hosted runner label | Right long-term, unavailable today: no such runner is registered, and a required check waiting on a label that never appears is left `Expected` forever, blocking the merge. The declarations below name what *would* satisfy each gap, so this stays the upgrade path. |
+| **Run every satisfiable lane; declare the rest** | **Chosen.** Preserves all reachable coverage and makes the unreachable part legible instead of invisible. |
+
+The mechanism is a **declared capability allowlist**, not a blanket tolerance:
+
+- `[capability_gaps]` in `tools/test_selection.toml` names each capability the
+  runner provably lacks (`cuda`, `vulkan`, `sidecar`, `ros`), what it is, what
+  *would* satisfy it, and the skip-reason patterns that indicate it.
+- A skip matching a declared pattern is **declared-not-run** — allowed,
+  attributed to the gap, counted, and printed in the job summary. It is never
+  called "skipped" and never silently absent.
+- **Every other skip still fails the lane.** `panda.srdf not installed` is a
+  ROS-underlay asset (declared); `mujoco not installed` is a *provisioning bug*
+  and stays red. That distinction is the entire value of an allowlist over
+  "tolerate skips", and it is why the patterns are narrow.
+- Matching is **fail-closed**: reword a skip reason out of the declared patterns
+  and the lane goes red, not quietly green.
+- `[hosted_runner] gated_lanes` lists lanes with *zero* satisfiable coverage
+  here (`gr00t`, `isaacsim`, `rlbench`, `robotwin`). Every other lane must still
+  produce at least one passing test. The list is fail-closed **both ways**: a
+  gated lane that starts producing passing tests also fails, telling you to
+  remove it, so the declaration cannot rot and mask a lane that became
+  satisfiable.
+
+Batched and isolated targets are now judged by the **same** rule.  Isolated
+files used to be graded on exit code alone, so a skip inside one was invisible —
+an asymmetry a real gap could hide in. Every skip they emit today is explained
+by a declared gap, so closing the hole costs nothing.
+
+### Vacuous green is a failure, not a result
+
+`tools/lane_report.py` parses each lane's **junit XML** (not pytest's terse
+summary text) into a `LaneRecord`, appends it to a per-run *ledger*, and a final
+`Attest lane coverage` step cross-checks that ledger against the selector's own
+output. It fails when:
+
+- a `full_run` diff expanded to **zero** lanes — the #163 regression, guarded
+  directly;
+- a lane the selector **selected** produced no ledger record ("selected but
+  never executed");
+- any lane record is a failure.
+
+The ledger is written to the job summary, naming every declared-not-run lane and
+the capability it needs. So "tested nothing" and "tested everything and passed"
+can no longer report the same thing.
+
+> Two junit details are load-bearing and were verified against real pytest
+> output rather than assumed. A module-level `importorskip` emits
+> `message="collection skipped"` and puts the real reason in the element
+> **text**; reading only `message` would misclassify every such skip as
+> undeclared. And `simpler-env` / `robocasa-gr1` run their pytest *inside*
+> `verify_test_envs.py`, so they have no junit report at all and are recorded
+> explicitly as exit-code-only rather than being credited with per-test
+> accounting they never had.
+
 ### Usage
 
 ```bash
@@ -200,10 +287,12 @@ paid for runs that select zero tests:
    targets" launches each group as a background job (`&`), collects exit codes
    after all finish, and streams the logs in collapsible GitHub groups — cutting
    wall-clock time by roughly the number of partitions.
-4. **Opt-in lanes run only when selected and are zero-skip.** If no selected target needs
-   `gym_aloha`, the `sim` group is never installed. If one does, CI reruns just
-   those targets under `uv run --all-packages --group sim ...` and requires
-   passing tests with no skips in that lane.
+4. **Opt-in lanes run only when selected, and every skip must be accounted
+   for.** If no selected target needs `gym_aloha`, the `sim` group is never
+   installed. If one does, CI reruns just those targets under `uv run
+   --all-packages --group sim ...` and requires passing tests, with no skip
+   beyond the declared capability gaps (see
+   [Lane policy](#lane-policy--what-a-skip-is-allowed-to-mean)).
 5. **Stale runs are cancelled.** A `concurrency` group with `cancel-in-progress:
    true` stops any in-progress run on the same branch the moment a new push
    arrives.

--- a/docs/contributing/selective-testing.md
+++ b/docs/contributing/selective-testing.md
@@ -203,12 +203,20 @@ The mechanism is a **declared capability allowlist**, not a blanket tolerance:
   "tolerate skips", and it is why the patterns are narrow.
 - Matching is **fail-closed**: reword a skip reason out of the declared patterns
   and the lane goes red, not quietly green.
-- `[hosted_runner] gated_lanes` lists lanes with *zero* satisfiable coverage
-  here (`gr00t`, `isaacsim`, `rlbench`, `robotwin`). Every other lane must still
-  produce at least one passing test. The list is fail-closed **both ways**: a
-  gated lane that starts producing passing tests also fails, telling you to
-  remove it, so the declaration cannot rot and mask a lane that became
-  satisfiable.
+- A lane whose **every selected test** is explained by a declared gap is
+  `declared-not-run`: a pass, but a loudly reported one, named in the summary
+  with the capability it needs. A lane that collected **no tests at all** still
+  fails — that is a broken lane, not absent coverage.
+
+  The verdict is deliberately about what the diff *selected*, not a lane's full
+  potential. `sim` yields 162 passing tests when all seven of its files are
+  selected, but a diff touching only `rskills/act-aloha/**` selects just
+  `test_aloha_bimanual_act_aloha.py`, whose six tests are all CUDA-gated
+  (observed on proof run 32815008771). Failing that would punish a PR for
+  touching a GPU-only file — precisely the breakage this policy exists to
+  remove. There is deliberately **no** hand-maintained list of "lanes that
+  cannot run here": that would be a second source of truth that rots, while the
+  per-skip classification derives the verdict from evidence every run.
 
 Batched and isolated targets are now judged by the **same** rule.  Isolated
 files used to be graded on exit code alone, so a skip inside one was invisible —

--- a/docs/methods/10-tools.md
+++ b/docs/methods/10-tools.md
@@ -106,16 +106,26 @@ _Private helper of `validation_matrix.py`. Recovered from `run_xr1_full.py` and 
 ### `tools/select_tests.py`
 _Selective test execution — maps a git diff to the minimal pytest targets that can observe it. Backs `just test-changed` / the `test-selective` workflow. See [`docs/contributing/selective-testing.md`](../contributing/selective-testing.md)._
 
-- `class SelectionConfig(BaseModel)` (L65) — Typed view of `tools/test_selection.toml`: `full_run_globs`, `ignore_globs`, `isolate_globs`, `extra_triggers`.
-- `class SelectionResult(BaseModel)` (L75) — `full_run` / `full_run_reason` / `affected_packages` / `targets` / `isolated_targets` (own-process, issue #24) / `reasons` (per-target rationale).
-- `load_config(path) -> SelectionConfig` (L99) — Load + validate the TOML config.
-- `package_dir_import_names(repo_root) -> dict[str, str]` (L111) — `python/<dir>` → its `src/openral_*` import name.
-- `build_dependency_graph(repo_root) -> dict[str, set[str]]` (L130) — Import-name → direct `openral` deps, derived from each `pyproject.toml` (never hand-written).
-- `transitive_dependents(graph, changed) -> set[str]` (L154) — Closure of packages that depend on any changed package (includes `changed`).
-- `map_test_imports(repo_root) -> dict[str, set[str]]` (L181) — Each top-level `tests/` file → the `openral_*` packages it imports.
-- `select(repo_root, changed_files, config) -> SelectionResult` (L320) — Resolve changed paths to pytest targets (blast-radius → full run; else per-package dirs + import-intersecting tests), peeling `isolate_globs` matches into `isolated_targets`.
-- `changed_files_from_git(base, head, repo_root) -> list[str]` (L446) — Merge-base `git diff --name-only base...head`.
-- `main(argv=None) -> int` (L486) — CLI; `--files` / `--base/--head`, `--github-output` for CI step outputs.
+- `class CapabilityGap(BaseModel)` (L65) — A capability the CI runner provably cannot provide: `summary`, `satisfied_by`, `skip_patterns` (fnmatch globs matched against a skip's reason).
+- `class HostedRunnerPolicy(BaseModel)` (L79) — `gated_lanes`: lanes with zero satisfiable coverage on a hosted runner.
+- `class SelectionConfig(BaseModel)` (L85) — Typed view of `tools/test_selection.toml`: `full_run_globs`, `ignore_globs`, `isolate_globs`, `extra_triggers`, `requirement_globs`, `capability_gaps`, `hosted_runner`.
+- `class SelectionResult(BaseModel)` (L97) — `full_run` / `full_run_reason` / `affected_packages` / `targets` / `isolated_targets` (own-process, issue #24) / `requirement_targets` (per opt-in lane) / `reasons` (per-target rationale).
+- `load_config(path) -> SelectionConfig` (L121) — Load + validate the TOML config.
+- `package_dir_import_names(repo_root) -> dict[str, str]` (L133) — `python/<dir>` → its `src/openral_*` import name.
+- `build_dependency_graph(repo_root) -> dict[str, set[str]]` (L152) — Import-name → direct `openral` deps, derived from each `pyproject.toml` (never hand-written).
+- `transitive_dependents(graph, changed) -> set[str]` (L176) — Closure of packages that depend on any changed package (includes `changed`).
+- `map_test_imports(repo_root) -> dict[str, set[str]]` (L203) — Each top-level `tests/` file → the `openral_*` packages it imports.
+- `select(repo_root, changed_files, config) -> SelectionResult` (L370) — Resolve changed paths to pytest targets (blast-radius → full run; else per-package dirs + import-intersecting tests), peeling `isolate_globs` matches into `isolated_targets`.
+- `changed_files_from_git(base, head, repo_root) -> list[str]` (L489) — Merge-base `git diff --name-only base...head`.
+- `main(argv=None) -> int` (L529) — CLI; `--files` / `--base/--head`, `--github-output` for CI step outputs.
+
+### `tools/lane_report.py`
+_Opt-in lane accounting — decides, records and attests what each dependency lane actually ran. Makes a vacuous green impossible (issue #163). See [`docs/contributing/selective-testing.md`](../contributing/selective-testing.md)._
+
+- `class LaneRecord(BaseModel)` (L83) — One lane's accounted outcome: `lane` / `status` (`ran` / `declared-not-run` / `failed`) / `passed` / `failed` / `declared_skips` (gap → count) / `undeclared_skips` / `note`; `.declared_total` property.
+- `read_junit(paths) -> tuple[int, int, list[str]]` (L126) — Aggregate junit XML reports into `(passed, failed, skip_reasons)`; a lane may emit a batched report plus one per isolated file.
+- `build_record(lane, *, passed, failed, skip_reasons, config, exit_code=None, from_exit_code=False) -> LaneRecord` (L151) — Apply the lane policy: declared capability gaps are allowed and attributed, every other skip fails, `gated_lanes` membership is checked in both directions.
+- `main(argv=None) -> int` (L367) — CLI; `lane` (account one lane's reports) / `attest` (cross-check the ledger against the selection, write the job summary).
 
 ### `tools/audit_tests.py`
 _Test-suite auditor — flags dead / shadowed / duplicate / no-assertion tests; writes `docs/contributing/test-audit.md`. Read-only; never deletes. Backs `just test-audit`._

--- a/docs/methods/10-tools.md
+++ b/docs/methods/10-tools.md
@@ -107,25 +107,24 @@ _Private helper of `validation_matrix.py`. Recovered from `run_xr1_full.py` and 
 _Selective test execution — maps a git diff to the minimal pytest targets that can observe it. Backs `just test-changed` / the `test-selective` workflow. See [`docs/contributing/selective-testing.md`](../contributing/selective-testing.md)._
 
 - `class CapabilityGap(BaseModel)` (L65) — A capability the CI runner provably cannot provide: `summary`, `satisfied_by`, `skip_patterns` (fnmatch globs matched against a skip's reason).
-- `class HostedRunnerPolicy(BaseModel)` (L79) — `gated_lanes`: lanes with zero satisfiable coverage on a hosted runner.
-- `class SelectionConfig(BaseModel)` (L85) — Typed view of `tools/test_selection.toml`: `full_run_globs`, `ignore_globs`, `isolate_globs`, `extra_triggers`, `requirement_globs`, `capability_gaps`, `hosted_runner`.
-- `class SelectionResult(BaseModel)` (L97) — `full_run` / `full_run_reason` / `affected_packages` / `targets` / `isolated_targets` (own-process, issue #24) / `requirement_targets` (per opt-in lane) / `reasons` (per-target rationale).
-- `load_config(path) -> SelectionConfig` (L121) — Load + validate the TOML config.
-- `package_dir_import_names(repo_root) -> dict[str, str]` (L133) — `python/<dir>` → its `src/openral_*` import name.
-- `build_dependency_graph(repo_root) -> dict[str, set[str]]` (L152) — Import-name → direct `openral` deps, derived from each `pyproject.toml` (never hand-written).
-- `transitive_dependents(graph, changed) -> set[str]` (L176) — Closure of packages that depend on any changed package (includes `changed`).
-- `map_test_imports(repo_root) -> dict[str, set[str]]` (L203) — Each top-level `tests/` file → the `openral_*` packages it imports.
-- `select(repo_root, changed_files, config) -> SelectionResult` (L370) — Resolve changed paths to pytest targets (blast-radius → full run; else per-package dirs + import-intersecting tests), peeling `isolate_globs` matches into `isolated_targets`.
-- `changed_files_from_git(base, head, repo_root) -> list[str]` (L489) — Merge-base `git diff --name-only base...head`.
-- `main(argv=None) -> int` (L529) — CLI; `--files` / `--base/--head`, `--github-output` for CI step outputs.
+- `class SelectionConfig(BaseModel)` (L79) — Typed view of `tools/test_selection.toml`: `full_run_globs`, `ignore_globs`, `isolate_globs`, `extra_triggers`, `requirement_globs`, `capability_gaps`.
+- `class SelectionResult(BaseModel)` (L90) — `full_run` / `full_run_reason` / `affected_packages` / `targets` / `isolated_targets` (own-process, issue #24) / `requirement_targets` (per opt-in lane) / `reasons` (per-target rationale).
+- `load_config(path) -> SelectionConfig` (L114) — Load + validate the TOML config.
+- `package_dir_import_names(repo_root) -> dict[str, str]` (L126) — `python/<dir>` → its `src/openral_*` import name.
+- `build_dependency_graph(repo_root) -> dict[str, set[str]]` (L145) — Import-name → direct `openral` deps, derived from each `pyproject.toml` (never hand-written).
+- `transitive_dependents(graph, changed) -> set[str]` (L169) — Closure of packages that depend on any changed package (includes `changed`).
+- `map_test_imports(repo_root) -> dict[str, set[str]]` (L196) — Each top-level `tests/` file → the `openral_*` packages it imports.
+- `select(repo_root, changed_files, config) -> SelectionResult` (L363) — Resolve changed paths to pytest targets (blast-radius → full run; else per-package dirs + import-intersecting tests), peeling `isolate_globs` matches into `isolated_targets`.
+- `changed_files_from_git(base, head, repo_root) -> list[str]` (L482) — Merge-base `git diff --name-only base...head`.
+- `main(argv=None) -> int` (L522) — CLI; `--files` / `--base/--head`, `--github-output` for CI step outputs.
 
 ### `tools/lane_report.py`
 _Opt-in lane accounting — decides, records and attests what each dependency lane actually ran. Makes a vacuous green impossible (issue #163). See [`docs/contributing/selective-testing.md`](../contributing/selective-testing.md)._
 
-- `class LaneRecord(BaseModel)` (L83) — One lane's accounted outcome: `lane` / `status` (`ran` / `declared-not-run` / `failed`) / `passed` / `failed` / `declared_skips` (gap → count) / `undeclared_skips` / `note`; `.declared_total` property.
-- `read_junit(paths) -> tuple[int, int, list[str]]` (L126) — Aggregate junit XML reports into `(passed, failed, skip_reasons)`; a lane may emit a batched report plus one per isolated file.
-- `build_record(lane, *, passed, failed, skip_reasons, config, exit_code=None, from_exit_code=False) -> LaneRecord` (L151) — Apply the lane policy: declared capability gaps are allowed and attributed, every other skip fails, `gated_lanes` membership is checked in both directions.
-- `main(argv=None) -> int` (L367) — CLI; `lane` (account one lane's reports) / `attest` (cross-check the ledger against the selection, write the job summary).
+- `class LaneRecord(BaseModel)` (L81) — One lane's accounted outcome: `lane` / `status` (`ran` / `declared-not-run` / `failed`) / `passed` / `failed` / `declared_skips` (gap → count) / `undeclared_skips` / `note`; `.declared_total` property.
+- `read_junit(paths) -> tuple[int, int, list[str]]` (L124) — Aggregate junit XML reports into `(passed, failed, skip_reasons)`; a lane may emit a batched report plus one per isolated file.
+- `build_record(lane, *, passed, failed, skip_reasons, config, exit_code=None, from_exit_code=False) -> LaneRecord` (L149) — Apply the lane policy: declared capability gaps are allowed and attributed, every other skip fails, an all-gated lane is `declared-not-run` and an empty one fails.
+- `main(argv=None) -> int` (L368) — CLI; `lane` (account one lane's reports) / `attest` (cross-check the ledger against the selection, write the job summary).
 
 ### `tools/audit_tests.py`
 _Test-suite auditor — flags dead / shadowed / duplicate / no-assertion tests; writes `docs/contributing/test-audit.md`. Read-only; never deletes. Backs `just test-audit`._

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -403,6 +403,12 @@ gr00t = [
     # (diffusers, peft, timm, decord, dm-tree). Validated live: GR00T-N1.7 NF4
     # in-process solves LIBERO-spatial 5/5 at ~19 ms/step on an 8 GiB card.
     "lerobot[groot]",
+    # The NF4 quantization the adapter performs at load. `lerobot[groot]` does
+    # not pull it, so `tests/sim/test_franka_groot_libero.py` stopped at
+    # `importorskip("bitsandbytes")` and the lane never even reached its CUDA
+    # gate — an under-provisioned lane, not a hardware limit, so it is fixed by
+    # installing the package rather than excused as a capability gap (#163).
+    "bitsandbytes>=0.45",
 ]
 behavior-groot = [
     # OpenRAL-side wire for the official BEHAVIOR-1K Isaac-GR00T runtime.

--- a/tests/unit/test_lane_report.py
+++ b/tests/unit/test_lane_report.py
@@ -60,6 +60,7 @@ CONFIG = select_tests.load_config(CONFIG_PATH)
         ("RLBench/CoppeliaSim sidecar not provisioned", "sidecar"),
         ("could not import 'rclpy': No module named 'rclpy'", "ros"),
         ("panda.srdf not installed", "ros"),
+        ("moveit_resources panda.srdf not installed", "ros"),
     ],
 )
 def test_declared_capability_gaps_are_attributed(reason: str, expected: str) -> None:

--- a/tests/unit/test_lane_report.py
+++ b/tests/unit/test_lane_report.py
@@ -115,20 +115,27 @@ def test_fully_gated_lane_is_declared_not_run_never_silently_green() -> None:
     assert record.declared_skips == {"sidecar": 21}
 
 
-def test_undeclared_lane_with_no_passing_tests_fails() -> None:
-    # `sim` is NOT in gated_lanes, so zero coverage there is a failure even
-    # though every skip is individually excused.
-    record = _record("sim", passed=0, skips=["x requires CUDA"] * 4)
-    assert record.status == lane_report.STATUS_FAILED
-    assert "no passing tests" in (record.note or "")
+def test_narrow_selection_of_a_gated_file_is_declared_not_run_not_failed() -> None:
+    """A well-covered lane can still have every *selected* test gated.
+
+    Found by proof run 32815008771: a diff touching only `rskills/act-aloha/**`
+    selects one `sim` file whose six tests are all CUDA-gated, so the lane had
+    0 passed and 6 declared skips. `sim` yields 162 passing tests when all its
+    files are selected, but the verdict must be about what the diff SELECTED —
+    failing here would punish a PR merely for touching a GPU-only file, the
+    exact breakage this policy removes.
+    """
+    record = _record("sim", passed=0, skips=["x requires CUDA"] * 6)
+    assert record.status == lane_report.STATUS_DECLARED_NOT_RUN
+    assert record.declared_skips == {"cuda": 6}
 
 
-def test_stale_gated_declaration_fails_so_it_cannot_rot() -> None:
-    # A gated lane that starts producing coverage must force the declaration to
-    # be removed, otherwise `gated_lanes` silently weakens over time.
-    record = _record("isaacsim", passed=3, skips=[])
+def test_lane_that_collected_nothing_at_all_fails() -> None:
+    # No passes and no skips means the lane collected no tests — broken, not
+    # gated. It must not masquerade as "no satisfiable coverage".
+    record = _record("sim", passed=0, skips=[])
     assert record.status == lane_report.STATUS_FAILED
-    assert "remove it from hosted_runner.gated_lanes" in (record.note or "")
+    assert "collected no tests" in (record.note or "")
 
 
 def test_failing_test_fails_the_lane() -> None:
@@ -285,11 +292,6 @@ def test_no_lane_is_declared_with_an_empty_glob_list() -> None:
     """
     empty = sorted(name for name, globs in CONFIG.requirement_globs.items() if not globs)
     assert empty == [], f"lanes declared with no globs can never run: {empty}"
-
-
-def test_every_gated_lane_is_a_real_lane() -> None:
-    unknown = sorted(set(CONFIG.hosted_runner.gated_lanes) - set(CONFIG.requirement_globs))
-    assert unknown == [], f"gated_lanes names no-such lane(s): {unknown}"
 
 
 def test_every_capability_gap_declares_how_it_could_be_satisfied() -> None:

--- a/tests/unit/test_lane_report.py
+++ b/tests/unit/test_lane_report.py
@@ -1,0 +1,301 @@
+"""Tests for the opt-in lane accounting tool (``tools/lane_report.py``).
+
+CLAUDE.md §1.11 — these run against the *real* ``tools/test_selection.toml``
+capability declarations, and the junit-parsing test drives a *real* pytest
+subprocess so the parser is proven against genuine pytest output rather than a
+hand-written approximation of it.
+
+The behaviour under test is the fix for issue #163: a lane that ran nothing
+must never be indistinguishable from a lane that ran everything and passed.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOLS = REPO_ROOT / "tools"
+CONFIG_PATH = TOOLS / "test_selection.toml"
+
+
+# `tools/` is not an installed package; import it the same way the tool itself
+# does at runtime (repo root on sys.path, `tools.` package form) so the test
+# exercises the real import path rather than a private copy of the modules.
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools import lane_report, select_tests  # noqa: E402
+
+CONFIG = select_tests.load_config(CONFIG_PATH)
+
+
+# --------------------------------------------------------------------------
+# Skip classification — the line between "cannot run here" and "is broken".
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("reason", "expected"),
+    [
+        # Every one of these was observed verbatim on a real hosted run
+        # (PR #153, run 32757769291).
+        ("ACT-ALOHA-full sim test requires CUDA", "cuda"),
+        ("GR00T NF4 requires a CUDA GPU", "cuda"),
+        ("MolmoAct2 NF4 requires CUDA", "cuda"),
+        ("LingBot-VLA 2.0 NF4 requires a CUDA GPU", "cuda"),
+        (
+            "SAPIEN rendering needs a working Vulkan driver: "
+            "vk::createInstanceUnique: ErrorIncompatibleDriver",
+            "vulkan",
+        ),
+        (
+            "Isaac Sim sidecar venv not provisioned (set OPENRAL_ISAAC_SIDECAR_PYTHON)",
+            "sidecar",
+        ),
+        ("RLBench/CoppeliaSim sidecar not provisioned", "sidecar"),
+        ("could not import 'rclpy': No module named 'rclpy'", "ros"),
+        ("panda.srdf not installed", "ros"),
+    ],
+)
+def test_declared_capability_gaps_are_attributed(reason: str, expected: str) -> None:
+    assert lane_report._classify_skip(reason, CONFIG.capability_gaps) == expected
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        # A missing *installable* package is a provisioning bug, not a hardware
+        # limit. It must stay undeclared so the lane stays red — this is the
+        # whole point of an allowlist rather than "tolerate every skip".
+        "mujoco not installed",
+        "robot_descriptions not installed",
+        "smolvla-libero rskill not present",
+        "LIBERO config not present on this branch",
+    ],
+)
+def test_undeclared_skips_are_not_excused(reason: str) -> None:
+    assert lane_report._classify_skip(reason, CONFIG.capability_gaps) is None
+
+
+# --------------------------------------------------------------------------
+# Lane policy.
+# --------------------------------------------------------------------------
+
+
+def _record(lane: str, *, passed: int, skips: list[str]) -> object:
+    return lane_report.build_record(
+        lane, passed=passed, failed=0, skip_reasons=skips, config=CONFIG
+    )
+
+
+def test_partly_gated_lane_still_passes_and_reports_the_gap() -> None:
+    # The exact shape that blocked PR #153: the `sim` lane genuinely ran 162
+    # tests and was failed anyway by 13 CUDA-gated skips.
+    record = _record("sim", passed=162, skips=["x requires CUDA"] * 13)
+    assert record.status == lane_report.STATUS_RAN
+    assert record.declared_skips == {"cuda": 13}
+    assert record.declared_total == 13
+
+
+def test_undeclared_skip_fails_the_lane() -> None:
+    record = _record("sim", passed=162, skips=["mujoco not installed"])
+    assert record.status == lane_report.STATUS_FAILED
+    assert "undeclared skip" in (record.note or "")
+
+
+def test_fully_gated_lane_is_declared_not_run_never_silently_green() -> None:
+    record = _record("isaacsim", passed=0, skips=["Isaac Sim sidecar venv not provisioned"] * 21)
+    assert record.status == lane_report.STATUS_DECLARED_NOT_RUN
+    # It is reported, not absent: the gap is named and counted.
+    assert record.declared_skips == {"sidecar": 21}
+
+
+def test_undeclared_lane_with_no_passing_tests_fails() -> None:
+    # `sim` is NOT in gated_lanes, so zero coverage there is a failure even
+    # though every skip is individually excused.
+    record = _record("sim", passed=0, skips=["x requires CUDA"] * 4)
+    assert record.status == lane_report.STATUS_FAILED
+    assert "no passing tests" in (record.note or "")
+
+
+def test_stale_gated_declaration_fails_so_it_cannot_rot() -> None:
+    # A gated lane that starts producing coverage must force the declaration to
+    # be removed, otherwise `gated_lanes` silently weakens over time.
+    record = _record("isaacsim", passed=3, skips=[])
+    assert record.status == lane_report.STATUS_FAILED
+    assert "remove it from hosted_runner.gated_lanes" in (record.note or "")
+
+
+def test_failing_test_fails_the_lane() -> None:
+    record = lane_report.build_record("sim", passed=5, failed=1, skip_reasons=[], config=CONFIG)
+    assert record.status == lane_report.STATUS_FAILED
+
+
+def test_exit_code_only_lane_is_judged_on_its_exit_code() -> None:
+    # simpler-env / robocasa-gr1 run their pytest inside verify_test_envs.py.
+    ok = lane_report.build_record(
+        "simpler-env",
+        passed=0,
+        failed=0,
+        skip_reasons=[],
+        config=CONFIG,
+        exit_code=0,
+        from_exit_code=True,
+    )
+    assert ok.status == lane_report.STATUS_RAN
+    bad = lane_report.build_record(
+        "simpler-env",
+        passed=0,
+        failed=0,
+        skip_reasons=[],
+        config=CONFIG,
+        exit_code=2,
+        from_exit_code=True,
+    )
+    assert bad.status == lane_report.STATUS_FAILED
+
+
+# --------------------------------------------------------------------------
+# junit parsing, against real pytest output.
+# --------------------------------------------------------------------------
+
+
+def test_reads_real_pytest_junit_including_module_level_skip(tmp_path: Path) -> None:
+    """A collection skip hides its reason in the element TEXT, not ``message``.
+
+    pytest writes ``message="collection skipped"`` for a module-level
+    ``importorskip`` and puts the real reason in the body. Reading only
+    ``message`` would classify every such skip as undeclared and redden the
+    lane — so parse a real report and assert the reason survives.
+    """
+    (tmp_path / "test_modskip.py").write_text(
+        "import pytest\npytest.importorskip('rclpy')\ndef test_never(): assert True\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "test_mixed.py").write_text(
+        "import pytest\n"
+        "def test_ok(): assert True\n"
+        "def test_gated(): pytest.skip('SmolVLA LIBERO sim test requires CUDA')\n",
+        encoding="utf-8",
+    )
+    xml = tmp_path / "report.xml"
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(tmp_path),
+            "-q",
+            "-p",
+            "no:cacheprovider",
+            f"--junit-xml={xml}",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+    )
+    passed, failed, reasons = lane_report.read_junit([xml])
+    assert (passed, failed) == (1, 0)
+    assert any("requires CUDA" in r for r in reasons)
+    # The module-level skip's real reason, recovered from the element text.
+    assert any("rclpy" in r for r in reasons)
+    # And both classify as declared gaps rather than undeclared noise.
+    assert {lane_report._classify_skip(r, CONFIG.capability_gaps) for r in reasons} == {
+        "cuda",
+        "ros",
+    }
+
+
+# --------------------------------------------------------------------------
+# The anti-vacuity gate.
+# --------------------------------------------------------------------------
+
+
+def _attest(tmp_path: Path, *, full_run: str, lanes: dict[str, list[str]], records: list) -> int:
+    ledger = tmp_path / "ledger.jsonl"
+    ledger.write_text("".join(r.model_dump_json() + "\n" for r in records), encoding="utf-8")
+    selection = tmp_path / "selection.json"
+    selection.write_text(
+        json.dumps({"full_run": full_run, "requirement_targets_json": json.dumps(lanes)}),
+        encoding="utf-8",
+    )
+    return lane_report.main(
+        [
+            "--config",
+            str(CONFIG_PATH),
+            "--ledger",
+            str(ledger),
+            "attest",
+            "--selection-json",
+            str(selection),
+        ]
+    )
+
+
+def test_attest_fails_when_a_full_run_selects_no_lane(tmp_path: Path) -> None:
+    """The #163 regression guard, stated directly.
+
+    If ``select_tests.py`` ever stops expanding lanes on a blast-radius diff,
+    this is what catches it — instead of the job quietly reporting success
+    having executed nothing.
+    """
+    assert _attest(tmp_path, full_run="true", lanes={}, records=[]) == 1
+
+
+def test_attest_fails_when_a_selected_lane_produced_no_record(tmp_path: Path) -> None:
+    # "Selected but never executed" — vacuous green — is now a hard failure.
+    assert _attest(tmp_path, full_run="false", lanes={"sim": ["a.py"]}, records=[]) == 1
+
+
+def test_attest_passes_when_every_selected_lane_is_accounted_for(tmp_path: Path) -> None:
+    ran = _record("sim", passed=10, skips=["x requires CUDA"])
+    gated = _record("isaacsim", passed=0, skips=["Isaac Sim sidecar venv not provisioned"])
+    rc = _attest(
+        tmp_path,
+        full_run="true",
+        lanes={"sim": ["a.py"], "isaacsim": ["b.py"]},
+        records=[ran, gated],
+    )
+    assert rc == 0
+
+
+def test_attest_fails_on_a_failed_lane_record(tmp_path: Path) -> None:
+    bad = _record("sim", passed=1, skips=["mujoco not installed"])
+    assert _attest(tmp_path, full_run="false", lanes={"sim": ["a.py"]}, records=[bad]) == 1
+
+
+# --------------------------------------------------------------------------
+# Config hygiene.
+# --------------------------------------------------------------------------
+
+
+def test_no_lane_is_declared_with_an_empty_glob_list() -> None:
+    """A lane with no globs can never run, and says nothing when it doesn't.
+
+    `rldx` was declared with an empty list, so `run_lane rldx` returned at its
+    `[ -z "$targets" ]` guard on every run since it was added — a lane that was
+    configured, wired into the workflow, and structurally incapable of
+    executing. Indistinguishable in the log from a lane that simply had nothing
+    selected, which is the same silent-degradation shape as #163 itself.
+    """
+    empty = sorted(name for name, globs in CONFIG.requirement_globs.items() if not globs)
+    assert empty == [], f"lanes declared with no globs can never run: {empty}"
+
+
+def test_every_gated_lane_is_a_real_lane() -> None:
+    unknown = sorted(set(CONFIG.hosted_runner.gated_lanes) - set(CONFIG.requirement_globs))
+    assert unknown == [], f"gated_lanes names no-such lane(s): {unknown}"
+
+
+def test_every_capability_gap_declares_how_it_could_be_satisfied() -> None:
+    # A declared gap must say what WOULD satisfy it, so "declared-not-run" is
+    # an actionable statement rather than a shrug.
+    for name, gap in CONFIG.capability_gaps.items():
+        assert gap.summary.strip(), f"{name} has no summary"
+        assert gap.satisfied_by.strip(), f"{name} does not say what would satisfy it"
+        assert gap.skip_patterns, f"{name} declares no skip patterns"

--- a/tests/unit/test_select_tests.py
+++ b/tests/unit/test_select_tests.py
@@ -289,3 +289,46 @@ def test_unattributed_source_full_run_still_reports_isolated_targets() -> None:
     result = select_tests.select(REPO_ROOT, ["scripts/mystery_tool.py"], CONFIG)
     assert result.full_run
     assert _FORK_TEST in result.isolated_targets
+
+
+# --- issue #163: a blast-radius diff must run the lanes, not zero of them -----
+
+
+def test_full_run_expands_every_opt_in_lane() -> None:
+    """A blast-radius diff used to emit ``requirement_targets == {}``.
+
+    The consequence was the exact inversion of the intent: the WIDEST diffs got
+    the LEAST lane verification, and a red PR could be made green by also
+    touching `pyproject.toml`. A root `pyproject.toml` / `uv.lock` change is a
+    *dependency* change — precisely what the opt-in lanes exist to check.
+    """
+    result = select_tests.select(REPO_ROOT, ["pyproject.toml"], CONFIG)
+    assert result.full_run
+    assert result.requirement_targets, "a full run must select opt-in lanes (issue #163)"
+    # Every lane with at least one existing target file is expanded.
+    assert set(result.requirement_targets) == {
+        lane
+        for lane, globs in CONFIG.requirement_globs.items()
+        if select_tests._targets_matching_globs(REPO_ROOT, globs)
+    }
+
+
+def test_unattributed_source_full_run_also_expands_lanes() -> None:
+    # Same contract via the other full-run exit. An unattributed source file is
+    # by definition the case where the blast radius cannot be bounded, so it
+    # must get the widest verification, not the narrowest.
+    result = select_tests.select(REPO_ROOT, ["some/unknown/module.py"], CONFIG)
+    assert result.full_run
+    assert result.requirement_targets
+    # ...and it must still report the fork-isolated files (issue #24): omitted,
+    # they ran inside the broad `tests/unit/` process and crashed at teardown.
+    assert result.isolated_targets
+
+
+def test_full_run_lane_targets_all_exist_on_disk() -> None:
+    # A phantom target aborts the whole pytest session with "file or directory
+    # not found", so a stale glob must never reach a lane invocation.
+    result = select_tests.select(REPO_ROOT, ["uv.lock"], CONFIG)
+    for lane, targets in result.requirement_targets.items():
+        for target in targets:
+            assert (REPO_ROOT / target).exists(), f"{lane} lane target missing: {target}"

--- a/tools/lane_report.py
+++ b/tools/lane_report.py
@@ -1,0 +1,396 @@
+"""Opt-in lane accounting — decide, record and attest what a lane actually ran.
+
+Issue #163. The `test-selective` job used to report a lane's outcome by
+grepping pytest's terse summary for ``N passed`` / ``N skipped``. Two silent
+degradations lived in that scheme:
+
+1. A *blast-radius* diff expanded to zero lanes, so the step exited 0 having
+   executed nothing — indistinguishable from a run that executed every lane and
+   passed. (Fixed in ``select_tests.py``; this tool makes the difference
+   *visible* and *enforced*.)
+2. "Any skip fails the lane" is the right rule for anything a runner can
+   provide and the wrong rule for anything it cannot. A hosted ubuntu-24.04
+   runner has no CUDA GPU, no Vulkan ICD and no proprietary sidecars, so
+   CUDA/Vulkan/sidecar-gated tests skip forever and redden every PR that
+   selects them — while a genuinely fixable gap ("panda.srdf not installed")
+   looked exactly the same.
+
+The policy implemented here, driven by ``[capability_gaps]`` and
+``[hosted_runner]`` in ``tools/test_selection.toml``:
+
+* A skip explained by a DECLARED capability gap is *declared-not-run*: allowed,
+  attributed to the gap, and counted in the ledger. It is never called
+  "skipped" and never silently absent.
+* Any other skip still FAILS the lane. Matching is fail-closed — reword a skip
+  reason out of the declared patterns and the lane goes red, not green.
+* A lane must produce at least one passing test, unless it is declared in
+  ``hosted_runner.gated_lanes`` (zero satisfiable coverage here). A gated lane
+  that *does* produce passing tests also fails, so the declaration cannot go
+  stale and mask a lane that became satisfiable.
+* ``attest`` cross-checks the ledger against the selector's own output: every
+  selected lane must have produced a record. "Selected but never executed" is
+  the exact shape of #163 and is now a hard failure.
+
+Run::
+
+    python tools/lane_report.py lane --lane sim --junit-xml a.xml --junit-xml b.xml
+    python tools/lane_report.py attest --selection-json sel.json --summary "$GITHUB_STEP_SUMMARY"
+
+Example:
+    >>> _classify_skip("SmolVLA LIBERO sim test requires CUDA", _GAPS())
+    'cuda'
+    >>> _classify_skip("mujoco not installed", _GAPS()) is None
+    True
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from xml.etree import ElementTree
+
+from pydantic import BaseModel, Field
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+# Import the selector's config schema rather than restating it (CLAUDE.md
+# §1.13). Run as `python tools/lane_report.py`, sys.path[0] is `tools/`, so the
+# repo root has to go on the path for the `tools.` package form — which is also
+# the module name mypy resolves, keeping the real types instead of `Any`.
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.select_tests import CapabilityGap, SelectionConfig, load_config  # noqa: E402
+
+DEFAULT_CONFIG = REPO_ROOT / "tools" / "test_selection.toml"
+DEFAULT_LEDGER = REPO_ROOT / ".lane-ledger.jsonl"
+
+# Status vocabulary. Deliberately NOT "skipped": a lane is either coverage we
+# got, coverage we declared we cannot get here, or a failure.
+STATUS_RAN = "ran"
+STATUS_DECLARED_NOT_RUN = "declared-not-run"
+STATUS_FAILED = "failed"
+
+
+def _GAPS() -> dict[str, CapabilityGap]:  # noqa: N802  # reason: docstring-example helper
+    """The declared capability gaps (used by this module's doctest)."""
+    return load_config(DEFAULT_CONFIG).capability_gaps
+
+
+class LaneRecord(BaseModel):
+    """One lane's accounted outcome — the unit of the ledger."""
+
+    lane: str
+    status: str
+    passed: int = 0
+    failed: int = 0
+    declared_skips: dict[str, int] = Field(default_factory=dict)
+    undeclared_skips: list[str] = Field(default_factory=list)
+    note: str | None = None
+
+    @property
+    def declared_total(self) -> int:
+        """How many tests were not run because of a declared capability gap."""
+        return sum(self.declared_skips.values())
+
+
+def _classify_skip(reason: str, gaps: dict[str, CapabilityGap]) -> str | None:
+    """Return the capability gap explaining ``reason``, or ``None`` if undeclared."""
+    lowered = reason.lower()
+    for name, gap in gaps.items():
+        if any(fnmatch.fnmatch(lowered, pattern.lower()) for pattern in gap.skip_patterns):
+            return name
+    return None
+
+
+def _skip_reason(skipped: ElementTree.Element) -> str:
+    """Extract a skip's human reason from a junit ``<skipped>`` element.
+
+    pytest writes the reason two different ways and BOTH must be read: a normal
+    ``pytest.skip`` puts it in ``message=``, while a *collection* skip (a
+    module-level ``importorskip``) sets ``message="collection skipped"`` and
+    puts the real reason in the element text. Reading only ``message`` would
+    classify every module-level skip as undeclared — the sort of plausible
+    wrong answer this whole file exists to prevent.
+    """
+    message = (skipped.get("message") or "").strip()
+    text = (skipped.text or "").strip()
+    if message and message.lower() != "collection skipped":
+        return message
+    return text or message
+
+
+def read_junit(paths: list[Path]) -> tuple[int, int, list[str]]:
+    """Aggregate junit XML files into ``(passed, failed, skip_reasons)``.
+
+    A lane may emit several reports — one batched run plus one per
+    ``isolate_globs`` file — and they are summed into a single lane verdict.
+    Missing files are ignored: pytest writes no report when it never starts.
+    """
+    passed = 0
+    failed = 0
+    reasons: list[str] = []
+    for path in paths:
+        if not path.is_file():
+            continue
+        root = ElementTree.parse(path).getroot()
+        for case in root.iter("testcase"):
+            skipped = case.find("skipped")
+            if skipped is not None:
+                reasons.append(_skip_reason(skipped))
+            elif case.find("failure") is not None or case.find("error") is not None:
+                failed += 1
+            else:
+                passed += 1
+    return passed, failed, reasons
+
+
+def build_record(  # noqa: PLR0911  # reason: one explicit early return per lane verdict
+    lane: str,
+    *,
+    passed: int,
+    failed: int,
+    skip_reasons: list[str],
+    config: SelectionConfig,
+    exit_code: int | None = None,
+    from_exit_code: bool = False,
+) -> LaneRecord:
+    """Apply the lane policy to one lane's raw counts (see module docstring).
+
+    ``from_exit_code`` marks a lane with no junit evidence — ``simpler-env`` and
+    ``robocasa-gr1`` run their pytest inside ``verify_test_envs.py``, so the
+    exit code is all there is. Such a lane is judged solely on that code, and
+    the ledger says so rather than implying per-test accounting it never had.
+    """
+    gaps = config.capability_gaps
+    gated = lane in config.hosted_runner.gated_lanes
+
+    declared: Counter[str] = Counter()
+    undeclared: list[str] = []
+    for reason in skip_reasons:
+        name = _classify_skip(reason, gaps)
+        if name is None:
+            undeclared.append(reason)
+        else:
+            declared[name] += 1
+
+    record = LaneRecord(
+        lane=lane,
+        status=STATUS_RAN,
+        passed=passed,
+        failed=failed,
+        declared_skips=dict(sorted(declared.items())),
+        undeclared_skips=sorted(set(undeclared)),
+    )
+
+    if failed:
+        record.status = STATUS_FAILED
+        record.note = f"{failed} failing test(s)"
+        return record
+    if from_exit_code:
+        # No per-test evidence exists for this lane; the exit code is the whole
+        # verdict. Say that explicitly instead of applying rules to counts we
+        # never measured.
+        if exit_code:
+            record.status = STATUS_FAILED
+            record.note = f"verify_test_envs.py exited {exit_code}"
+        else:
+            record.note = "accounted by exit code only (verify_test_envs.py drives its own pytest)"
+        return record
+    if exit_code is not None and exit_code != 0 and passed == 0 and not skip_reasons:
+        # The lane never got as far as running tests (e.g. a provisioning step
+        # died). That is a failure, not an absence — do not let it look like a
+        # lane that simply had nothing to do.
+        record.status = STATUS_FAILED
+        record.note = f"lane exited {exit_code} without running any test"
+        return record
+    if undeclared:
+        record.status = STATUS_FAILED
+        record.note = (
+            f"{len(undeclared)} undeclared skip(s): "
+            f"{'; '.join(record.undeclared_skips[:3])}"
+            " — provision the missing env, or declare the capability in "
+            "[capability_gaps] if the runner genuinely cannot provide it"
+        )
+        return record
+    if passed == 0:
+        if gated:
+            record.status = STATUS_DECLARED_NOT_RUN
+            record.note = "declared in hosted_runner.gated_lanes; no satisfiable coverage here"
+            return record
+        record.status = STATUS_FAILED
+        record.note = (
+            "lane produced no passing tests and is not declared in hosted_runner.gated_lanes"
+        )
+        return record
+    if gated:
+        record.status = STATUS_FAILED
+        record.note = (
+            f"lane is declared fully gated but produced {passed} passing test(s) — "
+            "remove it from hosted_runner.gated_lanes so the zero-coverage "
+            "declaration cannot go stale"
+        )
+        return record
+    return record
+
+
+def _describe(record: LaneRecord, config: SelectionConfig) -> str:
+    """One-line human summary of a lane record."""
+    bits = [f"{record.passed} passed"]
+    if record.failed:
+        bits.append(f"{record.failed} failed")
+    for name, count in record.declared_skips.items():
+        gap = config.capability_gaps.get(name)
+        summary = gap.summary if gap else name
+        bits.append(f"{count} not run (needs {summary})")
+    if record.undeclared_skips:
+        bits.append(f"{len(record.undeclared_skips)} UNDECLARED skip(s)")
+    return ", ".join(bits)
+
+
+def _append_ledger(ledger: Path, record: LaneRecord) -> None:
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    with ledger.open("a", encoding="utf-8") as fh:
+        fh.write(record.model_dump_json() + "\n")
+
+
+def _read_ledger(ledger: Path) -> list[LaneRecord]:
+    if not ledger.is_file():
+        return []
+    return [
+        LaneRecord.model_validate_json(line)
+        for line in ledger.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _render_summary(
+    records: list[LaneRecord],
+    selected: list[str],
+    config: SelectionConfig,
+    problems: list[str],
+) -> str:
+    """Markdown lane ledger for the GitHub job summary."""
+    lines = ["## Opt-in dependency lane ledger", ""]
+    if not selected:
+        lines.append("No opt-in lane was selected by this diff — nothing to run.")
+        return "\n".join(lines) + "\n"
+
+    by_lane = {r.lane: r for r in records}
+    lines.append("| Lane | Status | Detail |")
+    lines.append("| --- | --- | --- |")
+    for lane in selected:
+        record = by_lane.get(lane)
+        if record is None:
+            lines.append(f"| `{lane}` | **NO RECORD** | selected but never executed |")
+            continue
+        lines.append(f"| `{lane}` | {record.status} | {_describe(record, config)} |")
+
+    declared = sorted({name for r in records for name in r.declared_skips})
+    if declared:
+        lines.extend(["", "### Declared-not-run — coverage this runner cannot provide", ""])
+        for name in declared:
+            gap = config.capability_gaps.get(name)
+            if gap is None:
+                continue
+            total = sum(r.declared_skips.get(name, 0) for r in records)
+            lines.append(
+                f"- **{name}** ({total} test(s)) — needs {gap.summary}. {gap.satisfied_by}"
+            )
+    if problems:
+        lines.extend(["", "### Problems", ""])
+        lines.extend(f"- {p}" for p in problems)
+    return "\n".join(lines) + "\n"
+
+
+def _cmd_lane(args: argparse.Namespace) -> int:
+    config = load_config(Path(args.config))
+    passed, failed, reasons = read_junit([Path(p) for p in args.junit_xml])
+    record = build_record(
+        args.lane,
+        passed=passed,
+        failed=failed,
+        skip_reasons=reasons,
+        config=config,
+        exit_code=args.exit_code,
+        from_exit_code=args.from_exit_code,
+    )
+    _append_ledger(Path(args.ledger), record)
+    detail = _describe(record, config)
+    if record.status == STATUS_FAILED:
+        print(f"::error::opt-in lane {record.lane}: {record.note} ({detail})")
+        return 1
+    if record.status == STATUS_DECLARED_NOT_RUN:
+        print(f"::notice::opt-in lane {record.lane} DECLARED-NOT-RUN — {record.note} ({detail})")
+    else:
+        print(f"opt-in lane {record.lane}: {detail}")
+    return 0
+
+
+def _cmd_attest(args: argparse.Namespace) -> int:
+    """Cross-check the ledger against the selection. This is the anti-vacuity gate."""
+    config = load_config(Path(args.config))
+    selection = json.loads(Path(args.selection_json).read_text(encoding="utf-8"))
+    full_run = str(selection.get("full_run", "false")).lower() == "true"
+    selected = sorted(json.loads(selection.get("requirement_targets_json") or "{}"))
+    records = _read_ledger(Path(args.ledger))
+
+    problems: list[str] = []
+    # Guard the #163 regression directly: a blast-radius diff that expands to no
+    # lane at all means the selector stopped emitting them again.
+    if full_run and not selected:
+        problems.append(
+            "full_run diff selected ZERO opt-in lanes — select_tests.py must expand "
+            "every requirement glob on a full run (issue #163)"
+        )
+    recorded = {r.lane for r in records}
+    for lane in selected:
+        if lane not in recorded:
+            problems.append(f"lane `{lane}` was selected but produced no ledger record")
+    for record in records:
+        if record.status == STATUS_FAILED:
+            problems.append(f"lane `{record.lane}` failed: {record.note}")
+
+    summary = _render_summary(records, selected, config, problems)
+    if args.summary:
+        with open(args.summary, "a", encoding="utf-8") as fh:
+            fh.write(summary)
+    print(summary)
+    for problem in problems:
+        print(f"::error::{problem}")
+    return 1 if problems else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns a process exit code."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG))
+    parser.add_argument("--ledger", default=str(DEFAULT_LEDGER))
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    lane = sub.add_parser("lane", help="account for one lane's junit report(s)")
+    lane.add_argument("--lane", required=True)
+    lane.add_argument("--junit-xml", action="append", default=[])
+    lane.add_argument("--exit-code", type=int, default=None)
+    lane.add_argument(
+        "--from-exit-code",
+        action="store_true",
+        help="lane produces no junit report; judge it by --exit-code alone",
+    )
+    lane.set_defaults(func=_cmd_lane)
+
+    attest = sub.add_parser("attest", help="cross-check the ledger against the selection")
+    attest.add_argument("--selection-json", required=True)
+    attest.add_argument("--summary", default=None)
+    attest.set_defaults(func=_cmd_attest)
+
+    args = parser.parse_args(argv)
+    result: int = args.func(args)
+    return result
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/lane_report.py
+++ b/tools/lane_report.py
@@ -15,18 +15,16 @@ degradations lived in that scheme:
    selects them — while a genuinely fixable gap ("panda.srdf not installed")
    looked exactly the same.
 
-The policy implemented here, driven by ``[capability_gaps]`` and
-``[hosted_runner]`` in ``tools/test_selection.toml``:
+The policy implemented here, driven by ``[capability_gaps]`` in
+``tools/test_selection.toml``:
 
 * A skip explained by a DECLARED capability gap is *declared-not-run*: allowed,
   attributed to the gap, and counted in the ledger. It is never called
   "skipped" and never silently absent.
 * Any other skip still FAILS the lane. Matching is fail-closed — reword a skip
   reason out of the declared patterns and the lane goes red, not green.
-* A lane must produce at least one passing test, unless it is declared in
-  ``hosted_runner.gated_lanes`` (zero satisfiable coverage here). A gated lane
-  that *does* produce passing tests also fails, so the declaration cannot go
-  stale and mask a lane that became satisfiable.
+* A lane whose every test is explained by a declared gap is *declared-not-run*
+  — reported, never silent. A lane that collected no tests at all still fails.
 * ``attest`` cross-checks the ledger against the selector's own output: every
   selected lane must have produced a record. "Selected but never executed" is
   the exact shape of #163 and is now a hard failure.
@@ -166,7 +164,6 @@ def build_record(  # noqa: PLR0911  # reason: one explicit early return per lane
     the ledger says so rather than implying per-test accounting it never had.
     """
     gaps = config.capability_gaps
-    gated = lane in config.hosted_runner.gated_lanes
 
     declared: Counter[str] = Counter()
     undeclared: list[str] = []
@@ -217,22 +214,26 @@ def build_record(  # noqa: PLR0911  # reason: one explicit early return per lane
         )
         return record
     if passed == 0:
-        if gated:
-            record.status = STATUS_DECLARED_NOT_RUN
-            record.note = "declared in hosted_runner.gated_lanes; no satisfiable coverage here"
+        if not skip_reasons:
+            # Nothing passed and nothing skipped: the lane collected no tests at
+            # all. That is a broken lane, not an absence of coverage.
+            record.status = STATUS_FAILED
+            record.note = "lane collected no tests at all"
             return record
-        record.status = STATUS_FAILED
-        record.note = (
-            "lane produced no passing tests and is not declared in hosted_runner.gated_lanes"
-        )
-        return record
-    if gated:
-        record.status = STATUS_FAILED
-        record.note = (
-            f"lane is declared fully gated but produced {passed} passing test(s) — "
-            "remove it from hosted_runner.gated_lanes so the zero-coverage "
-            "declaration cannot go stale"
-        )
+        # Every test the lane ran is accounted for by a DECLARED gap — the
+        # undeclared branch above has already returned. Nothing is hidden: the
+        # gap is named and counted here and printed by the attest step.
+        #
+        # Judged on what the diff SELECTED, not on the lane's full potential. A
+        # narrow diff can select a single fully-gated file out of an otherwise
+        # well-covered lane: `sim` yields 162 passing tests when all seven of
+        # its files are selected, but a diff touching only `rskills/act-aloha/**`
+        # selects just `test_aloha_bimanual_act_aloha.py`, whose six tests are
+        # all CUDA-gated (proof run 32815008771). Failing that would punish a PR
+        # for touching a GPU-only file — the exact class of breakage this policy
+        # exists to remove.
+        record.status = STATUS_DECLARED_NOT_RUN
+        record.note = "every selected test is gated by a declared capability gap"
         return record
     return record
 

--- a/tools/select_tests.py
+++ b/tools/select_tests.py
@@ -76,12 +76,6 @@ class CapabilityGap(BaseModel):
     skip_patterns: list[str] = Field(default_factory=list)
 
 
-class HostedRunnerPolicy(BaseModel):
-    """Lanes with no satisfiable coverage on a GitHub-hosted runner."""
-
-    gated_lanes: list[str] = Field(default_factory=list)
-
-
 class SelectionConfig(BaseModel):
     """Typed view of ``tools/test_selection.toml`` (CLAUDE.md §2 — Pydantic for config)."""
 
@@ -91,7 +85,6 @@ class SelectionConfig(BaseModel):
     extra_triggers: dict[str, list[str]] = Field(default_factory=dict)
     requirement_globs: dict[str, list[str]] = Field(default_factory=dict)
     capability_gaps: dict[str, CapabilityGap] = Field(default_factory=dict)
-    hosted_runner: HostedRunnerPolicy = Field(default_factory=HostedRunnerPolicy)
 
 
 class SelectionResult(BaseModel):
@@ -381,7 +374,7 @@ def select(
     #    get the least lane verification, and a red PR could be turned green just
     #    by also touching `pyproject.toml`. The lanes a hosted runner cannot
     #    satisfy are handled downstream by the declared capability gaps in
-    #    `[capability_gaps]` / `[hosted_runner]`, not by selecting nothing here.
+    #    `[capability_gaps]`, not by selecting nothing here.
     for rel in changed_files:
         for glob in config.full_run_globs:
             if fnmatch.fnmatch(rel, glob):

--- a/tools/select_tests.py
+++ b/tools/select_tests.py
@@ -62,6 +62,26 @@ _IMPORT_RE = re.compile(r"^\s*(?:from|import)\s+(openral_[a-z_]+)", re.MULTILINE
 _DEP_RE = re.compile(r"openral-[a-z-]+")
 
 
+class CapabilityGap(BaseModel):
+    """A capability the CI runner provably cannot provide (issue #163).
+
+    A skip whose reason matches ``skip_patterns`` is *declared-not-run* — named
+    and counted in the lane ledger — rather than a lane failure. Every other
+    skip still fails the lane, so a real provisioning gap (``panda.srdf not
+    installed``) can never hide behind a hardware excuse.
+    """
+
+    summary: str
+    satisfied_by: str
+    skip_patterns: list[str] = Field(default_factory=list)
+
+
+class HostedRunnerPolicy(BaseModel):
+    """Lanes with no satisfiable coverage on a GitHub-hosted runner."""
+
+    gated_lanes: list[str] = Field(default_factory=list)
+
+
 class SelectionConfig(BaseModel):
     """Typed view of ``tools/test_selection.toml`` (CLAUDE.md §2 — Pydantic for config)."""
 
@@ -70,6 +90,8 @@ class SelectionConfig(BaseModel):
     isolate_globs: list[str] = Field(default_factory=list)
     extra_triggers: dict[str, list[str]] = Field(default_factory=dict)
     requirement_globs: dict[str, list[str]] = Field(default_factory=dict)
+    capability_gaps: dict[str, CapabilityGap] = Field(default_factory=dict)
+    hosted_runner: HostedRunnerPolicy = Field(default_factory=HostedRunnerPolicy)
 
 
 class SelectionResult(BaseModel):
@@ -317,6 +339,34 @@ def _requirement_targets(
     return out
 
 
+def _full_run_result(
+    repo_root: Path,
+    config: SelectionConfig,
+    *,
+    reason: str,
+    isolate_files: list[str],
+) -> SelectionResult:
+    """Build the ``full_run`` verdict, WITH every opt-in lane expanded.
+
+    Issue #163: both full-run exits used to leave ``requirement_targets`` empty,
+    so a blast-radius diff ran zero opt-in lanes and reported success
+    indistinguishably from a diff that ran them all and passed. The widest diffs
+    got the least verification, and a red PR could be turned green by also
+    touching a full-run glob. A blast-radius change (root ``pyproject.toml``,
+    ``uv.lock``) is precisely a dependency change — the thing the lanes exist to
+    check — so it gets every lane, and the ones a hosted runner cannot satisfy
+    are declared, reported and accounted for rather than silently skipped.
+    """
+    return SelectionResult(
+        full_run=True,
+        full_run_reason=reason,
+        isolated_targets=isolate_files,
+        requirement_targets=_requirement_targets(
+            repo_root, config, set(), isolate_files, full_run=True
+        ),
+    )
+
+
 def select(
     repo_root: Path,
     changed_files: list[str],
@@ -326,26 +376,20 @@ def select(
     isolate_files = _isolate_files(repo_root, config)
 
     # 1. Blast radius — any match forces a full run. The full-suite invocation
-    #    still collects the isolate files, so report them for separate execution.
-    #
-    #    KNOWN GAP (issue #163): `requirement_targets` is left EMPTY here, so a
-    #    blast-radius diff runs ZERO opt-in dependency lanes — the widest diffs
-    #    get the least lane verification, and a failing PR can go green merely
-    #    by also touching `pyproject.toml`. The `if full_run:` branch in
-    #    `_requirement_targets` exists to expand every glob for exactly this
-    #    case and is currently unreachable. It is NOT switched on here because
-    #    the lanes it would then run include several the hosted GPU-less runner
-    #    cannot satisfy (isaacsim / robotwin / gr00t sidecars, CUDA- and
-    #    Vulkan-gated tests), which would make every blast-radius PR permanently
-    #    red. That needs a per-lane host-requirement concept first — see #163.
-    #    Written down rather than left silent (CLAUDE.md §1.4).
+    #    still collects the isolate files, so report them for separate execution,
+    #    and EVERY opt-in lane is expanded (issue #163): the widest diffs used to
+    #    get the least lane verification, and a red PR could be turned green just
+    #    by also touching `pyproject.toml`. The lanes a hosted runner cannot
+    #    satisfy are handled downstream by the declared capability gaps in
+    #    `[capability_gaps]` / `[hosted_runner]`, not by selecting nothing here.
     for rel in changed_files:
         for glob in config.full_run_globs:
             if fnmatch.fnmatch(rel, glob):
-                return SelectionResult(
-                    full_run=True,
-                    full_run_reason=f"{rel} matches full-run glob {glob!r}",
-                    isolated_targets=isolate_files,
+                return _full_run_result(
+                    repo_root,
+                    config,
+                    reason=f"{rel} matches full-run glob {glob!r}",
+                    isolate_files=isolate_files,
                 )
 
     dir_imports = package_dir_import_names(repo_root)
@@ -378,16 +422,15 @@ def select(
             direct_tests.add(key)
             reasons[key].append(f"test file {rel} changed")
         elif kind == "unattributed-source":
-            return SelectionResult(
-                full_run=True,
-                full_run_reason=f"unattributed source change: {rel}",
-                # Must be reported like the blast-radius return above: the
-                # full-suite step `--ignore`s these and reruns each alone.
-                # Omitted, they ran INSIDE the broad `tests/unit/` process and
-                # reintroduced issue #24 — a non-zero exit after an all-pass
-                # summary. (`requirement_targets` stays empty here for the same
-                # reason as the blast-radius return — issue #163.)
-                isolated_targets=isolate_files,
+            # Same contract as the blast-radius return above, lanes included:
+            # an unattributed source file is *by definition* the case where we
+            # cannot bound the blast radius, so it gets the widest verification,
+            # not the narrowest (issue #163).
+            return _full_run_result(
+                repo_root,
+                config,
+                reason=f"unattributed source change: {rel}",
+                isolate_files=isolate_files,
             )
 
     affected = transitive_dependents(graph, changed_pkgs)

--- a/tools/test_selection.toml
+++ b/tools/test_selection.toml
@@ -217,10 +217,14 @@ skip_patterns = [
 # The list is fail-closed in BOTH directions: a lane listed here that starts
 # producing passing tests ALSO fails, telling you to remove it, so the
 # declaration cannot quietly go stale and mask a lane that became satisfiable.
+#
+# Membership is EVIDENCE-BASED, from observed hosted runs: these three are the
+# lanes that reported "produced no passing tests" on every run. `rlbench` is
+# deliberately NOT here — it yields 6 passing tests plus one CoppeliaSim-sidecar
+# skip, so it is a partly-gated lane that must keep proving those 6.
 gated_lanes = [
   "gr00t",
   "isaacsim",
-  "rlbench",
   "robotwin",
 ]
 

--- a/tools/test_selection.toml
+++ b/tools/test_selection.toml
@@ -153,8 +153,8 @@ isolate_globs = [
 # the capabilities the runner provably lacks, allow exactly the skips those
 # capabilities explain, and keep failing on every other skip. A skip for an
 # undeclared reason is still a red lane, because it is still a real gap — e.g.
-# "panda.srdf not installed" is a provisioning bug, not a hardware limit, and
-# must stay red.
+# "mujoco not installed" is a provisioning bug, not a hardware limit, and must
+# stay red.
 #
 # `skip_patterns` are fnmatch globs matched case-insensitively against a skip's
 # reason. BOTH spellings pytest emits are checked: the `message` attribute of a
@@ -201,10 +201,14 @@ skip_patterns = [
   "*ros2 binary not on PATH*",
   # `/opt/ros/jazzy/share/moveit_resources_panda_moveit_config/config/panda.srdf`
   # — a MoveIt *resource package*, i.e. part of the ROS underlay, not something
-  # the `lowering` dependency group could ever install. Named narrowly rather
-  # than widening the pattern to "*not installed*", which would swallow real
-  # missing-package skips like "mujoco not installed".
-  "panda.srdf not installed",
+  # the `lowering` dependency group could ever install. Two call sites word it
+  # differently ("panda.srdf not installed" and "moveit_resources panda.srdf
+  # not installed"): the exact-string form matched only the first, and run
+  # 32815922208 correctly reddened `lowering` for the second rather than
+  # letting an unrecognised reason through. The glob now spans both while still
+  # naming the specific asset — deliberately NOT widened to "*not installed*",
+  # which would swallow real missing-package skips like "mujoco not installed".
+  "*panda.srdf not installed*",
 ]
 
 [capability_gaps.hf-cache]

--- a/tools/test_selection.toml
+++ b/tools/test_selection.toml
@@ -207,6 +207,21 @@ skip_patterns = [
   "panda.srdf not installed",
 ]
 
+[capability_gaps.hf-cache]
+summary = "a pre-populated Hugging Face model cache"
+satisfied_by = "a host that already snapshotted the checkpoint, or a CI warm step that fetches it before the lane runs"
+# `tests/integration/test_act_onnx.py` loads the real
+# `gabrycina/so101-passing-pen-policy` and deliberately does NOT download it —
+# it skips unless a snapshot is already in `~/.cache/huggingface/hub`. On a
+# hosted runner that cache is always empty, so the test can never run there.
+# Declaring it makes that permanent absence VISIBLE in the ledger (named, with
+# the reason) instead of it silently reading as a passing lane. The pattern is
+# anchored to this exact phrasing so it cannot become a general "any missing
+# model" excuse; pre-fetching the checkpoint would remove the gap entirely.
+skip_patterns = [
+  "*not in the local HF cache*",
+]
+
 [hosted_runner]
 # Lanes with ZERO satisfiable coverage on a hosted runner: every test they own
 # is gated behind a capability above, so the lane legitimately produces no

--- a/tools/test_selection.toml
+++ b/tools/test_selection.toml
@@ -222,27 +222,6 @@ skip_patterns = [
   "*not in the local HF cache*",
 ]
 
-[hosted_runner]
-# Lanes with ZERO satisfiable coverage on a hosted runner: every test they own
-# is gated behind a capability above, so the lane legitimately produces no
-# passing tests there. They are reported as "declared-not-run" — named, with
-# the gap, in the job summary — never as a silent pass and never as an absent
-# lane. Every OTHER lane must still produce at least one passing test.
-#
-# The list is fail-closed in BOTH directions: a lane listed here that starts
-# producing passing tests ALSO fails, telling you to remove it, so the
-# declaration cannot quietly go stale and mask a lane that became satisfiable.
-#
-# Membership is EVIDENCE-BASED, from observed hosted runs: these three are the
-# lanes that reported "produced no passing tests" on every run. `rlbench` is
-# deliberately NOT here — it yields 6 passing tests plus one CoppeliaSim-sidecar
-# skip, so it is a partly-gated lane that must keep proving those 6.
-gated_lanes = [
-  "gr00t",
-  "isaacsim",
-  "robotwin",
-]
-
 # Selected tests matching these globs need an opt-in dependency group. The
 # default selective lane still runs them in the cheap env (where they may skip);
 # CI then reruns the matching targets with the named group installed so a

--- a/tools/test_selection.toml
+++ b/tools/test_selection.toml
@@ -140,6 +140,90 @@ isolate_globs = [
 "rskills/*libero*/**" = ["tests/sim/test_franka_panda_smolvla_libero.py"]
 "rskills/*robotwin*/**" = ["tests/sim/test_aloha_agilex_smolvla_robotwin.py"]
 
+# ---------------------------------------------------------------------------
+# Hosted-runner capability policy (issue #163).
+# ---------------------------------------------------------------------------
+# An opt-in lane is judged "zero-skip": a skip means the lane env was
+# under-provisioned. That rule is right for anything a runner CAN provide and
+# wrong for anything it CANNOT — a GitHub-hosted ubuntu-24.04 runner has no
+# NVIDIA GPU, no Vulkan ICD, and no proprietary simulator sidecars, so tests
+# gated on those skip forever and redden every PR that selects them.
+#
+# The honest resolution is neither "fail" nor "tolerate every skip": DECLARE
+# the capabilities the runner provably lacks, allow exactly the skips those
+# capabilities explain, and keep failing on every other skip. A skip for an
+# undeclared reason is still a red lane, because it is still a real gap — e.g.
+# "panda.srdf not installed" is a provisioning bug, not a hardware limit, and
+# must stay red.
+#
+# `skip_patterns` are fnmatch globs matched case-insensitively against a skip's
+# reason. BOTH spellings pytest emits are checked: the `message` attribute of a
+# normal `pytest.skip`, and the element TEXT of a collection skip (a
+# module-level `importorskip` sets message="collection skipped" and puts the
+# real reason in the body). Matching is FAIL-CLOSED: reword a skip reason out
+# of these patterns and the lane goes red, never quietly green.
+[capability_gaps.cuda]
+summary = "an NVIDIA CUDA GPU"
+satisfied_by = "a self-hosted runner with a GPU, or a dev host where `nvidia-smi` resolves (CLAUDE.md §1.12)"
+skip_patterns = [
+  "*requires CUDA*",
+  "*requires a CUDA GPU*",
+  "*needs CUDA*",
+  "*needs a local GPU*",
+  "*requires a local NVIDIA GPU*",
+  "*no NVIDIA GPU visible to nvidia-smi*",
+  "*nvidia-smi not on PATH*",
+]
+
+[capability_gaps.vulkan]
+summary = "a working Vulkan driver/ICD"
+satisfied_by = "a runner with a GPU and a Vulkan ICD (SAPIEN rendering; hosted images ship none)"
+skip_patterns = [
+  "*needs a working Vulkan driver*",
+  "*ErrorIncompatibleDriver*",
+]
+
+[capability_gaps.sidecar]
+summary = "an externally provisioned simulator/model sidecar venv"
+satisfied_by = "a host with the sidecar provisioned — see PROVISIONED_GROUPS in tools/verify_test_envs.py and its `--include-provisioned` flag"
+skip_patterns = [
+  "*sidecar venv not provisioned*",
+  "*sidecar not provisioned*",
+  "*needs a provisioned * sidecar venv*",
+]
+
+[capability_gaps.ros]
+summary = "a sourced ROS 2 Jazzy underlay"
+satisfied_by = "a runner with ROS 2 installed and `install/setup.bash` sourced (covered by the `test-ros2` workflow, not this one)"
+skip_patterns = [
+  "*could not import 'rclpy'*",
+  "*ros2 CLI not on PATH*",
+  "*ros2 binary not on PATH*",
+  # `/opt/ros/jazzy/share/moveit_resources_panda_moveit_config/config/panda.srdf`
+  # — a MoveIt *resource package*, i.e. part of the ROS underlay, not something
+  # the `lowering` dependency group could ever install. Named narrowly rather
+  # than widening the pattern to "*not installed*", which would swallow real
+  # missing-package skips like "mujoco not installed".
+  "panda.srdf not installed",
+]
+
+[hosted_runner]
+# Lanes with ZERO satisfiable coverage on a hosted runner: every test they own
+# is gated behind a capability above, so the lane legitimately produces no
+# passing tests there. They are reported as "declared-not-run" — named, with
+# the gap, in the job summary — never as a silent pass and never as an absent
+# lane. Every OTHER lane must still produce at least one passing test.
+#
+# The list is fail-closed in BOTH directions: a lane listed here that starts
+# producing passing tests ALSO fails, telling you to remove it, so the
+# declaration cannot quietly go stale and mask a lane that became satisfiable.
+gated_lanes = [
+  "gr00t",
+  "isaacsim",
+  "rlbench",
+  "robotwin",
+]
+
 # Selected tests matching these globs need an opt-in dependency group. The
 # default selective lane still runs them in the cheap env (where they may skip);
 # CI then reruns the matching targets with the named group installed so a
@@ -201,8 +285,13 @@ sidecar-wire = [
   "tests/unit/test_robotwin_backend.py",
   "tests/unit/test_sidecar_identity_and_layout.py",
 ]
-rldx = [
-]
+# NB: there is deliberately no `rldx` lane. It existed with an EMPTY glob list,
+# so `run_lane rldx` returned at its `[ -z "$targets" ]` guard on every run
+# since it was added — a lane that could never execute, indistinguishable in
+# the log from one that had nothing selected. The RLDX adapter's real test
+# (`tests/unit/test_rldx_adapter_auto_spawn.py`) is covered by `sidecar-wire`,
+# which is the group its deps come from (`rldx` just includes `sidecar-wire`).
+# `tests/unit/test_lane_report.py` now fails any lane declared with no globs.
 dataset = [
   "tests/unit/test_cli_dataset_from_bag.py",
   "tests/unit/test_cli_replay_record_profile.py",

--- a/uv.lock
+++ b/uv.lock
@@ -3294,6 +3294,7 @@ dev = [
     { name = "types-pyyaml" },
 ]
 gr00t = [
+    { name = "bitsandbytes" },
     { name = "lerobot", extra = ["groot"] },
 ]
 isaacsim = [
@@ -3451,7 +3452,10 @@ dev = [
     { name = "types-protobuf", specifier = ">=7.34.1.20260518" },
     { name = "types-pyyaml", specifier = ">=6" },
 ]
-gr00t = [{ name = "lerobot", extras = ["groot"] }]
+gr00t = [
+    { name = "bitsandbytes", specifier = ">=0.45" },
+    { name = "lerobot", extras = ["groot"] },
+]
 isaacsim = [
     { name = "msgpack", specifier = ">=1" },
     { name = "pyzmq", specifier = ">=25" },


### PR DESCRIPTION
Closes #163.

Two **independent** defects let `select-and-test` report success while failing or testing nothing. They are not variants of each other and are fixed in separate commits.

---

# Finding 1 — the strict-lane gate has been advisory for every lane but the last

**This is the more serious of the two, and it is not part of #163.**

`run_lane()` assigned `rc=0` without `local`, and the caller accumulates into a variable of the same name:

```bash
rc=0
run_lane sim  "$SIM_TARGETS"  || rc=1   # rc=1
run_lane clip "$CLIP_TARGETS" || rc=1   # run_lane's own `rc=0` wipes it
```

So the step's `exit $rc` reflected **only the last non-empty lane**. Every earlier lane's failure was silently discarded. Reproduced minimally:

```bash
run_lane() { rc=0; [ "$1" = bad ] && rc=1; return "$rc"; }
rc=0
run_lane bad  || rc=1   # rc=1
run_lane good || rc=1   # rc=0  <-- failure lost
exit $rc                # 0
```

**Five runs reported SUCCESS while carrying 12–13 `::error::opt-in lane …` messages in their logs**, because `lowering` happened to run last and pass: 32624877346, 32646323789, 32647641634, 32655994733, 32656309517.

The zero-skip lane gate — the thing the workflow header advertises as stopping "selected but skipped" from being a green PR — has therefore been **decorative for every lane except the final one**, and for longer than #163 has existed. Fixed in `29f60e1` by scoping the function's own state with `local`.

---

# Finding 2 — a blast-radius diff ran ZERO lanes (#163)

`select()` returned early on a `full_run_globs` match with `requirement_targets` left at `{}`. Every `*_TARGETS` output was empty, all 20 `run_lane` calls returned at their `[ -z "$targets" ]` guard, and the step exited 0 having executed nothing. The `if full_run:` branch in `_requirement_targets`, written for exactly this case, was unreachable. The unattributed-source exit had the same hole, and also dropped `isolated_targets` (reintroducing issue #24).

The effect was the inverse of the intent: the **widest** diffs got the **least** verification, and a red PR could be turned green by also touching `pyproject.toml`. **This is live right now:** #166's `select-and-test` is green having run zero lanes (run 32814602786 — full suite + isolated targets, not one `group=` line).

## Why it could not simply be switched on

Because the rule it feeds could not survive it. "A lane must produce passing tests and must not skip **at all**" is right for anything a hosted runner can provide and wrong for anything it cannot. The `sim` lane ran **162 passing tests** on #153 and was failed anyway by 13 `requires CUDA` skips.

## Lane classification (from real hosted runs)

| Class | Lanes |
| --- | --- |
| Satisfiable, clean green | `robocasa`, `sidecar-wire`, `dataset`, `onnx-export`, `clip`, `opencv` |
| Partly gated — real coverage + a declared gap | `sim`, `libero`, `maniskill3`, `lowering`, `rlbench`, `locateanything`, `qwen-vlm`, `omdet` |
| Zero satisfiable coverage → **declared-not-run** | `gr00t`, `isaacsim`, `robotwin` |
| Provisioned via `verify_test_envs.py`, exit-code-only | `robocasa-gr1`, `simpler-env` |
| **Dead — removed** | `rldx` (empty glob list; `run_lane` returned at its guard on every run since it was added) |

The safety-kernel colcon build is **not** in this set: `cpp/**` is in `ignore_globs`, covered by `test-ros2`. Nothing here bears on #166's need for a CI colcon confirmation.

## Policy: run every satisfiable lane, declare the rest

Rejected: *run nothing but say so* annotates the hole instead of closing it, and a `uv.lock` diff is precisely when lanes matter most. *Gate behind a self-hosted label* is right long-term but no such runner is registered, and a required check waiting on a label that never appears sits `Expected` forever and blocks the merge — the trap already documented twice in this workflow.

- `[capability_gaps]` names each capability the runner provably lacks (`cuda`, `vulkan`, `sidecar`, `ros`, `hf-cache`), what **would** satisfy it, and the skip-reason patterns indicating it.
- A matching skip is **declared-not-run** — allowed, attributed, counted, printed. Never "skipped", never silently absent.
- **Every other skip still fails the lane.** Matching is **fail-closed**, exercised for real: run 32815922208 reddened `lowering` because `moveit_resources panda.srdf not installed` did not match the exact-string pattern for `panda.srdf not installed`. Fixed by declaring the variant, not by widening the rule — `mujoco not installed` stays red.
- A lane whose **every selected test** is gated is `declared-not-run`; one that collected **no tests at all** still fails. There is deliberately **no** hand-kept list of "lanes that can't run here" — a second source of truth that rots is how this class of bug persists.

## Vacuous green becomes impossible

`tools/lane_report.py` parses each lane's **junit XML** into a `LaneRecord`, appends it to a ledger, and a new `Attest lane coverage` step cross-checks the ledger against the selector's own output. It fails when a `full_run` diff expands to zero lanes (the #163 regression, guarded directly), when a selected lane produced **no record**, or on any failed record.

Two junit details were **verified against real pytest output**, not assumed: a module-level `importorskip` sets `message="collection skipped"` and puts the real reason in the element **text**; and `simpler-env`/`robocasa-gr1` have no report at all and are recorded as exit-code-only rather than credited with accounting they never had.

---

# Proof the lanes genuinely ran

**Targeted `workflow_dispatch` — run [32815927729](https://github.com/OpenRAL/openral/actions/runs/32815927729), SUCCESS, 12 min.** Base `origin/fix/full-run-lane-policy`, head a one-line `rskills/act-aloha/README.md` change, so **not** a full run: `Run full suite` is **skipped** and the lanes are what executes.

```
| clip           | ran               | 5 passed
| dataset        | ran               | 20 passed
| locateanything | ran               | 13 passed, 1 not run (sidecar)
| lowering       | ran               | 6 passed
| omdet          | ran               | 15 passed, 1 not run (cuda)
| onnx-export    | ran               | 1 passed
| opencv         | ran               | 21 passed
| qwen-vlm       | ran               | 8 passed, 1 not run (sidecar)
| sidecar-wire   | ran               | 57 passed
| sim            | declared-not-run  | 0 passed, 6 not run (cuda)
```

That `sim` row is why the rule changed. The **first** proof run (32815008771) *failed* it under my own "must have a passing test" rule — a PR punished merely for touching a GPU-only file. I followed the failing run rather than adjusting the rule to pass, and removed `gated_lanes` outright (`1a75d13`).

**Full-run path — on this PR's own diff, which touches two `full_run_globs`: all 19 lanes ran, vs zero before.** `sim` 162 passed, `libero` 21, `robocasa` 18, `sidecar-wire` 57, `rlbench` 6, `omdet` 15, `opencv` 21, `dataset` 20, `clip` 5 …; `gr00t`/`isaacsim`/`robotwin` declared-not-run with their capability named.

---

# Other lane defects fixed

- `a81cdc5` — `gr00t` skipped at `importorskip("bitsandbytes")`. That package is installable, so the lane was **under-provisioned**, not hardware-limited: fixed by adding it to the group rather than excusing it. The `hf-cache` gap was resolved in the opposite direction — `test_act_onnx.py` deliberately never downloads, so its permanent absence is declared and named.

# Merge order

Rebased onto `cf9bc8d`. #169 fixed #155, so the `lowering` failure I previously reported as known-red is **gone** — verified by running the lane, not inferred: **29 passed, 0 failed**.

That removes the deadlock. The dependency is now one-way: **#153 needs this PR** (all its lane failures are the declared gates), while this PR needs nothing from #153. **Merge this first, then #153** (whose `xfail(strict=True)` markers for #155 should be dropped, since #169 makes them XPASS).

#166 is unblocked *as a check that means something*: its green currently ran zero lanes; after this it runs all 19 for real.

# How tested

`just lint` clean (ruff + `mypy --strict` on packages and `tools/`); `just test` — **4955 passed, 117 skipped, 0 failed**. New `tests/unit/test_lane_report.py` drives a **real pytest subprocess** for junit parsing and asserts the classifier against skip reasons observed verbatim on run 32757769291.

No dependency guard was weakened, and nothing was made to pass by being made not to run — this change strictly **increases** what executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUhD1uz93qMFJQsNxyTEM5