### PR TITLE
feat(docker): build the deploy image on aarch64 — openral:l4t

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -160,6 +160,16 @@ docker-build-x86:
     docker buildx build -f docker/inference/Dockerfile.x86 \
         -t openral:x86 .
 
+# Same Dockerfile, aarch64 tag. It is architecture-neutral (the CUDA base is
+# multi-arch and nothing in it is x86-specific), so this is a tag, not a fork —
+# a second Dockerfile would drift. Verified on a Jetson Thor: 13.7 GB, torch
+# 2.13.0+cu130 with sm_110, rclpy + openral import. openral-pro's
+# `docker/Dockerfile.l4t-pro` FROMs `openral:l4t` and layers DeepStream +
+# TensorRT + the NVMM fast path on top.
+docker-build-l4t:
+    docker buildx build -f docker/inference/Dockerfile.x86 \
+        -t openral:l4t .
+
 # The GStreamer/NVMM + DeepStream + TensorRT variant (`openral:x86-deepstream-latest`)
 # is built from openral-pro's `docker/Dockerfile.pro`, which FROMs the
 # gstreamer-free image `docker-build-x86` produces and installs the whole

--- a/docker/inference/Dockerfile.x86
+++ b/docker/inference/Dockerfile.x86
@@ -1,4 +1,12 @@
-# OpenRAL open deploy image — x86_64 + CUDA 13 + ROS 2 Jazzy. NO GStreamer.
+# OpenRAL open deploy image — CUDA 13 + ROS 2 Jazzy. NO GStreamer.
+#
+# Despite the filename this is **architecture-neutral** and builds unmodified on
+# linux/arm64: `nvidia/cuda:13.0.0-*-ubuntu24.04` is multi-arch, and nothing
+# below is x86-specific. Verified end to end on a Jetson Thor (L4T R38.4 /
+# JetPack 7) — `just docker-build-l4t` produces a 13.7 GB `openral:l4t` whose
+# torch is 2.13.0+cu130 with sm_110 in `get_arch_list()`, with rclpy and the
+# openral packages importing. The name is kept for continuity with the existing
+# `openral:x86` tag and CI; see the two `docker-build-*` recipes in the Justfile.
 #
 # THE open-repo deploy image (`openral:x86`). Builds the full open (non-Pro)
 # OpenRAL deploy graph — every colcon ROS package + the C++ safety kernel + the


### PR DESCRIPTION
## What

openral-pro's Jetson image (`docker/Dockerfile.l4t-pro`) had no base to layer
on: `Dockerfile.x86` is the only deploy image and its name says x86. That name
turns out to be the only x86-specific thing about it.

`nvidia/cuda:13.0.0-cudnn-runtime-ubuntu24.04` publishes `linux/arm64`, and the
Dockerfile contains no `x86_64`/`amd64` anywhere in its build logic — the sole
match in the file is the comment on line 1. So this adds a **tag, not a fork**;
a second Dockerfile would only drift from the first.

## Verified end to end on a Jetson Thor (L4T R38.4 / JetPack 7)

```
openral:l4t  13.7 GB
arch      : aarch64
torch     : 2.13.0+cu130   cuda: True
arch_list : ['sm_80','sm_90','sm_100','sm_110','sm_120']
rclpy     : imports OK
openral   : core/runner/rskill import OK
```

`sm_110` being in that list is why this sits **on top of #167**: under the
previous `cu128` pin the image builds fine and then fails on the first CUDA op.

Then openral-pro's `Dockerfile.l4t-pro` was built FROM it — 27.3 GB with
DeepStream 9.0 + TensorRT + the NVMM fast path — and its suite run inside the
container on the GPU:

```
236 passed, 15 skipped
```

## One thing found on the way, not fixed here

Two `tests/unit/test_pi05_export_compat.py` cases fail in that image. Not from
this change, and not architecture-specific: they assume lerobot **0.6.1**'s
module layout (`lerobot.policies.common.vla_utils`) while this repo's lock pins
**0.6.0**. The production resolver is fine — `PI05Pytorch._prepare_attention_masks_4d`
does exist in 0.6.0 and is found — it is the tests that lack a skip guard for
the version the repo actually pins. They pass on a 0.6.1 host, which is
presumably why this went unnoticed. Left for whoever owns #7 rather than
patched blind, since the right fix (skip vs. synthesize the 0.6.1 module)
depends on intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MsrXuAAJmrCcDXuPJsRWnv
