### PR TITLE
fix(sim,collision): re-pin the fridge kitchen against the kernel criterion, and measure the live world map

### DIFF
--- a/docs/reference/world-map-fidelity.md
+++ b/docs/reference/world-map-fidelity.md
@@ -427,7 +427,6 @@ it currently costs about one voxel of reach in every direction, on top of the
   **world**-voxel stop, so none of them is that self-collision — but a future
   round that adjudicates self-collision stops must not attribute them here.
 
-<!-- APPORTIONMENT -->
 
 ## What is not measured here
 

--- a/docs/reference/world-map-fidelity.md
+++ b/docs/reference/world-map-fidelity.md
@@ -1,0 +1,494 @@
+# The live world map, measured
+
+What is actually in `/openral/world_voxels`, how it differs from the
+geometrically ideal grid the collision studies score against, and how the three
+world-side terms apportion once the real map is in the loop.
+
+Companion to the [start-state census](robocasa-start-state-census.md) (which
+limb stops a kitchen) and to [tight link geometry](collision-tight-geometry.md)
+(what better link primitives could recover). Both score against a grid built
+from true surfaces and both flag that as unmeasured against the live octomap.
+**This page measures the live octomap.**
+
+## The question
+
+[PR #161](https://github.com/OpenRAL/openral/pull/161) closed on three
+world-side terms and asked for the third to be characterised:
+
+- **quantisation** — a 25 mm cell reaches up to 21.65 mm past the surface it was
+  built from;
+- **lattice phase** — a measured 20.3 mm swing in the kernel's reported distance
+  depending purely on where the grid's cells fall;
+- **map fidelity** — [PR #160](https://github.com/OpenRAL/openral/pull/160)
+  found two of four characterised stops sitting on cells containing nothing at
+  all, one with solid cabinet geometry a single cell away.
+
+The first two mean the grid is *right and coarse*. The third means the grid is
+*wrong*, and no link geometry helps. This page establishes how often each
+direction of wrongness occurs on the real map, and what that does to #161's
+finding that 45 of 72 stops lie beyond the reach of any link geometry.
+
+## The instrument, and what validates it
+
+Real components throughout (§1.11). One process holds the whole chain, so the
+map and the geometry that produced it are snapshotted at the same instant:
+
+- the production `ManifestHALLifecycleNode`, driven UNCONFIGURED → INACTIVE →
+  ACTIVE in-process, owning the real `SimAttachedHAL` + `SimSensorBridge` and
+  rendering depth from the real MuJoCo model;
+- the real `octomap_server_node` (`ros-jazzy-octomap-server`), parameterised
+  **verbatim** from `sim_e2e.launch.py`'s `hal_mode="sim"` branch — resolution
+  0.025 m, `occupancy_thres` 0.8, `sensor_model.miss` 0.4, `sensor_model.max`
+  0.85, `sensor_model.max_range` 4.0, `filter_speckles` true, frame `odom`;
+- the real `openral_octomap_bridge/octomap_voxel_bridge` — `base_link`, a 1.6 m
+  box, 0.025 m, publishing `/openral/world_voxels`.
+
+Nav2, SLAM, the detector and the policy are absent: none of them writes
+`/openral/world_voxels` (the world-state object-lift *subscribes* it), and a
+start-state measurement applies zero actions.
+
+The C++ safety kernel could **not** be built on this host — the vendored
+`opentelemetry_cpp_vendor` fails against the system protobuf, a pre-existing
+breakage unrelated to this work. Kernel verdicts are therefore a numpy port of
+`box_box_distance` (`collision.cpp:327`) treating each occupied cell as a
+12.5 mm-half-extent cube exactly as `check_voxel_collision`
+(`collision.cpp:625`) does. **The port was validated against the shipped C++,
+not assumed**: `collision.cpp` was compiled into a bare oracle and fed 4 000
+random OBB↔cell pairs — maximum disagreement **4.4 × 10⁻¹⁶ m**.
+
+Mesh distances are **densely sampled** (5 mm on both surfaces; boxes,
+cylinders, spheres and subdivided mesh triangles), never `mj_geomDistance`
+(standing caveat 8). Sampled point-to-point is an upper bound on the true
+surface gap with error bounded by the step.
+
+### Two instrument bugs, and one retraction
+
+Both silently invert results, and both are worth naming because any future
+reconstruction will hit them:
+
+1. **`robot_self_body_ids` needs the manifest's `sim_joint_name`s.** The
+   rollout exposes no such attribute; passing an empty sequence returns an
+   empty self-filter, after which every robot geom counts as "world" and each
+   link measures **itself** as its nearest obstacle at 0.000 mm.
+2. **The grid frame body must be resolved *with* the description.**
+   `resolve_base_frame_body_name(model, description=...)` gives
+   `mobilebase0_support` (world z = 0.700) — the body the live bridge uses.
+   Without the description it falls back to `mobilebase0_base` (world z = 0.000):
+   a silent **0.7 m** vertical offset applied to every cell.
+
+Under bug 2 this investigation briefly concluded that the live map was missing
+the freezer door the arm was touching by 464 mm, and that three of the seven
+kernel-checked links sat outside the checked volume. **Both were artefacts of
+the offset and are retracted.** With the frame corrected, every link's nearest
+solid surface *is* in the map, 10.2–20.2 mm from the nearest cell centre —
+inside the 21.65 mm half-diagonal, which is exactly what quantisation predicts.
+
+### Cross-validation against independently reported numbers
+
+Nothing below rests on the instrument alone:
+
+| quantity | measured here | independently reported | source |
+| --- | ---: | ---: | --- |
+| fridge, unpinned seed 1, live kernel min | **−24.75 mm** | −24.7 mm (`voxel_169769`) | #154 field round |
+| fridge at `layout_ids: [30]`, kernel min | **−23.47 mm** (live) | −23.47 mm (ideal grid) | census |
+| unpinned seed-1 draw | layout 29 / style 20 | layout 29 / style 20 | #154 |
+| `panda_link7` ↔ freezer door, mesh gap | **2.819 mm** | 2.5 mm | #154 ground truth |
+| `panda_link6` ↔ freezer door, mesh gap | **16.262 mm** | 16.1 mm | #154 ground truth |
+
+The two sampled mesh gaps also settle what the later `0.000 m` reading on that
+pair was: `mj_geomDistance`'s documented failure mode, not a touch.
+
+### A natural replicate: map size moves, the verdict does not
+
+Two independent live captures of the *identical* start state (fridge layout 30),
+in separate processes on separate ROS domains, integrating different numbers of
+depth frames:
+
+| capture | occupied cells | kernel verdict |
+| --- | ---: | --- |
+| A | 5 427 | `panda_link2` −23.47 mm |
+| B | 8 239 | `panda_link2` −23.47 mm |
+
+The map's **size** varies by 52 % with observation time; the **verdict** does not
+move at all. The surface that trips the kernel is seen early and stays. This is
+the check that a live measurement of this kind is worth making: it is not a
+sample of a noisy process.
+
+## The live map is *more* conservative than the ideal grid, not less
+
+61 live captures of `robocasa_fridge_drawer` — the scene that owns 56 of the
+census's 72 stops — each a real octomap built from real depth over ~22 s of
+observation, then scored with the validated port. 59 layouts have both a census
+verdict and a live verdict:
+
+| | census (ideal grid) stops | census clears |
+| --- | ---: | ---: |
+| **live map stops** | **55** | **2** |
+| **live map clears** | **0** | 2 |
+
+The live map reproduces **every** ideal-grid stop, adds two more, and on the 55
+shared stops reports a kernel minimum that is on median **13.04 mm more
+negative** than the ideal grid's (range −63.47 mm to +0.09 mm). 49 of the 55
+agree on the dominant link.
+
+This inverts the assumption both prior studies carry. The census states that the
+live map "can only ever be a *subset*" of the ideal grid, so the ideal grid
+bounds the live kernel from the conservative side. **It does not.** The live map
+contains cells the ideal grid cannot: the ideal grid is built from
+`contype`/`conaffinity`-bearing surfaces only, while the depth camera renders —
+and octomap therefore records — every *visible* geom, including the 713 of 1 714
+geoms in this scene that are non-collidable decoration. The bridge then dilates
+whatever the octree holds (below). Both terms add occupancy that no true-surface
+grid contains.
+
+So the ideal-grid census is not a conservative bound on live behaviour. On this
+population it is an *optimistic* one.
+
+## The fridge pin, re-decided against the live map
+
+The census recommended re-pinning `robocasa_fridge_drawer` away from
+`layout_ids: [30]`, which clears the *mesh* criterion (+37.0 mm) but not the
+kernel one (−23.47 mm), and named layouts **18, 21, 43, 47** as clearing the
+kernel on the ideal grid, with 18 and 21 also clearing the mesh criterion. It
+asked for a live round before acting. This is that round:
+
+| layout | live kernel min | verdict |
+| ---: | ---: | --- |
+| unpinned (29 / 20) | `panda_link7` −24.75 mm | STOPS — the original defect, reproduced |
+| **30** (shipped) | `panda_link2` **−23.47 mm** | **STOPS** — census reproduced exactly |
+| 18 | `panda_link2` −2.26 mm | **STOPS** — census called it clear |
+| 21 | `panda_link7` −10.96 mm | **STOPS** — census called it clear |
+| 43 | `panda_link7` +0.69 mm | clears by 3 % of one voxel |
+| **47** | `panda_link1` **+19.34 mm** | **clears** |
+
+**Layouts 18 and 21 are the trap.** They are exactly the two the census
+recommended, and the live map refutes both. Pinning either would have repeated
+#154's mistake in a new form — a pin verified against a criterion that does not
+hold where the robot actually runs. That is the concrete reason a live round was
+worth the cost.
+
+**Layout 47 is pinned.** It is the only candidate that clears on all three
+criteria and does not move when the map changes:
+
+- live kernel **+19.34 mm**, *identical* across two independent captures whose
+  maps held 5 435 and 9 112 occupied cells — 68 % more map, 0.00 mm of verdict
+  change;
+- mesh clearance **48.40 mm** (`panda_link1` vs
+  `fridgesidebyside_main_group_1_fridge_drawer3`, densely sampled), larger than
+  layout 30's 37.0 mm, so it satisfies the older criterion too and by more;
+- every kernel-checked link clears; the next worst is `panda_link7` at
+  +77.46 mm.
+
+Layout 43 was rejected deliberately: +0.69 mm is 3 % of one voxel, and it
+reproduced at +0.69 mm on a second, denser capture — stable, but with no
+headroom to spend. A pin is meant to buy margin, not to sit on the boundary.
+
+Two consequences that travel with the pin, both handled in the same commit:
+
+- `place_declaration.target_id` is **a function of the pin**. At layout 30 the
+  fridge was `fridge_main_group`; at layout 47 the scene composes to layout 47 /
+  style 32 and the fridge is `fridgesidebyside_main_group_1`, so the old target
+  named no body. The HAL fails closed on that, which means the symptom of
+  forgetting is a silently unarmed place phase, not an error.
+- Pinning changes the RNG **draw order**, so layout 47 pinned is not the kitchen
+  an unpinned run that drew 47 would produce. Both scene files already say so;
+  it is repeated here because it governs how the table above may be read.
+
+### The utensil scene
+
+`robocasa_drawer_utensil` keeps `layout_ids: [3]`, but its header's reasoning is
+corrected. It asserted that "43.3 mm clears the 25 mm occupancy grid, so the arm
+does NOT start inside the kernel's world model" — the same invalid inference
+#154 made, since `panda_link1` needs `53.40 + 21.65 = 75.05 mm`, not 25 mm. And
+at its shipped pin the live map puts it at **−1.94 mm**: it *does* take a
+marginal initial-configuration stop, which the ideal-grid census did not see.
+
+It is left pinned because that stop is **entirely link-side**: re-scored against
+the same live map with exact link geometry the state reads **+20.01 mm**. The
+staged tighter-primitive work ([#166](https://github.com/OpenRAL/openral/pull/166))
+removes it with no scene change, whereas a re-pin would churn the whole kitchen
+to work around a link-model artefact.
+
+## Why the live map holds cells no true-surface grid contains
+
+Two mechanisms, both in the shipped path, both measurable, neither previously
+costed.
+
+### 1. Non-collidable geometry is real to the camera
+
+The ideal grid is built from geoms with `contype` or `conaffinity` set. The
+depth camera has no such filter — `mj_multiRay` strikes whatever is visible, and
+the synthesised cloud back-projects it. In the fridge scene **713 of 1 714**
+world geoms are non-collidable decoration. Every one of them the camera can see
+becomes occupancy the kernel treats as an obstacle, and against which no
+collision can ever occur.
+
+This is a simulation-specific fidelity defect, and it is worth naming as such:
+on real hardware everything the depth camera sees *is* physical, so this term
+does not transfer. In sim it inflates the map with obstacles that are not there,
+and it is one of the two reasons the live map stops more often than the ideal
+grid.
+
+### 2. The octree→grid bridge dilates by up to one cell, by design
+
+`rasterize_octree_to_grid` (`octree_to_grid.cpp`) marks a base-frame cell when
+its cube **shares volume** with an occupied octree leaf's cube. The two lattices
+have the same resolution but an arbitrary relative phase — and, on a mobile
+base, an arbitrary relative yaw — so a single leaf generically overlaps up to
+eight base cells. The rule is deliberate and it is the safe direction: the
+comment above it records that the previous centre-sampling rule displaced
+surfaces by a whole voxel toward the robot. But it is not free, and it has never
+been costed alongside the 21.65 mm quantisation term and the 20.3 mm lattice
+swing.
+
+A cell whose **centre** lies inside no occupied octree leaf exists solely
+because of this rule. That is directly measurable by decoding
+`/octomap_binary` alongside the published grid, and the census below reports it.
+
+### What the whole map is made of
+
+Both mechanisms show up in a census of the map itself. A uniform sample of 1 200
+of the 9 667 occupied cells at the `robocasa_baguette` layout-7 state, each put
+to the 243-ray `voxel_backing_record` probe and independently checked against
+the octree:
+
+| what the cell contains | n | share | centre in an octree leaf |
+| --- | ---: | ---: | --- |
+| `solid_world` — real collidable geometry | 243 | 20.3 % | 180 / 243 |
+| `noncollidable_world` — visual-only geometry | 225 | 18.8 % | 198 / 225 |
+| `unbacked` — nothing at all | 731 | 60.9 % | 359 / 731 |
+| `self_occupancy_suspect` | 1 | 0.1 % | 0 / 1 |
+
+**463 of the 1 200 cells (38.6 %) have centres in no occupied octree leaf** —
+they are the bridge's dilation, present in the grid the kernel reads and absent
+from the octree it was built from.
+
+Read the 60.9 % carefully: it is **not** an error rate. A correct map of a solid
+surface necessarily contains cells that lie just behind that surface and so hold
+no surface themselves — an octree leaf is a cube, and the surface it was built
+from touches only part of it. What the whole-map census establishes is the
+*scale* of the two mechanisms; the tripping-cell analysis below is what
+establishes their *consequence*, because only cells a link can reach change a
+verdict.
+
+### What octomap's own thresholds can and cannot explain
+
+Analytic, from the shipped sim parameters — `prob_hit` 0.7, `prob_miss` 0.4,
+`occupancy_thres` 0.8, `sensor_model.max` 0.85:
+
+| event | log-odds | vs threshold 1.386 |
+| --- | ---: | --- |
+| one hit | 0.847 | below — not yet a safety voxel |
+| two hits | 1.694 | above — becomes one |
+| confirmed cell, then one clearing ray | 1.289 | below — free again |
+
+The thresholds behave exactly as their comment in `sim_e2e.launch.py` claims:
+two frames to create a safety voxel, one clearing ray to remove it. **So a
+persistent phantom cannot be a threshold artefact.** It can only survive where
+no ray ever passes — behind the first surface a ray strikes, or outside the
+frustum. That rules out the "spurious sensor noise" hypothesis for anything
+that lasts, and it rules out octomap's clearing behaviour as a cause.
+
+The bridge's payload-clearing path is likewise not implicated at a start state:
+nothing is attached, so `clear_attached_payload_cells` operates on an empty
+attachment set.
+
+## Apportioning a live stop
+
+#161 asked how the 45 world-held stops divide across quantisation, lattice
+phase and map fidelity. The apportionment below is done differently, and the
+difference matters: rather than reasoning about what *would* remain if link
+geometry were perfect, it **measures both verdicts against the same live map**.
+
+For each start state, two numbers on the same published occupancy array:
+
+- **OBB** — what the kernel computes today: `box_box_distance` between the
+  manifest's one box per link and each occupied cell cube.
+- **EXACT** — the minimum distance from the link's *own collision surface* to
+  each occupied cell cube. MuJoCo convexifies mesh collision geoms, so the
+  sampled surface is the convex hull's surface up to the sampling step: this is
+  the quantity #166's staged 26-DOP → exact-hull pipeline reaches, and for
+  `panda_link2` that PR measures the remaining support excess at 0.00 mm.
+
+The scan is a branch-and-bound — `box_box_distance` on a box containing the hull
+lower-bounds the exact hull distance, so cells are visited in increasing OBB
+distance and the scan stops when that bound exceeds the best exact distance
+found. It is exact, and it visits 2–46 cells instead of thousands.
+
+**A stop that EXACT clears is link-side. A stop that EXACT keeps is world-side
+by construction.**
+
+### The split
+
+Measured on **23 live stops** across all four scenes (27 states scored; a
+sample of the 62 stopping captures, not the full population):
+
+| | n | share |
+| --- | ---: | ---: |
+| **link-side** — exact geometry clears it | **6** | 26 % |
+| **world-side** — exact geometry still stops | **17** | 74 % |
+
+The link-side excess removed by exact geometry is large and matches the census's
+corner-slop analysis: median **28.72 mm**, and on `panda_link2` up to 42.56 mm
+against that link's 48.22 mm corner slop.
+
+### Splitting the world-side residue, and the mechanism behind it
+
+For each world-side stop, the cell that stops exact geometry was put to two
+independent tests: the repo's own `voxel_backing_record` at 243 rays, and
+whether its **centre** lies inside an occupied leaf of the octree the bridge
+rasterised (decoded from the same capture's `/octomap_binary`).
+
+The two agree on **17 of 17**, and that agreement is the finding:
+
+| tripping cell | n | centre in an octree leaf? | nearest real solid surface |
+| --- | ---: | --- | --- |
+| `solid_world` — real collidable geometry inside it | **5** | **always** (5/5) | ≤ 13.59 mm |
+| no world geometry inside it | **12** | **never** (0/12) | 16.64–299.28 mm, median 21.03 |
+
+`voxel_backing_record` ranks `solid_world` above `self_occupancy_suspect`, so
+the second row means *no world geom passes through that cell at all* — the ray
+fan finds only the robot's own link, which is there because the link has reached
+into the cell. Yet every one of those 12 cells sits **16.17–30.52 mm from an
+occupied octree leaf**, and 11 of the 12 sit within two half-diagonals of a real
+surface.
+
+**Those are not sensor phantoms. They are the octree→grid bridge's own
+dilation.** `rasterize_octree_to_grid` marks every base cell whose cube shares
+volume with an occupied leaf's cube; the two lattices share a resolution but not
+a phase, so a leaf holding a real surface also marks cells up to one full cell
+away from it. A cell whose centre is inside no leaf can only have come from that
+rule — and 12 of 12 are exactly that.
+
+The single exception is worth its own line. On `robocasa_fridge_drawer` layout
+7 the tripping cell contains nothing but `robot0_link3`/`link4`, has an occupied
+octree leaf 17.25 mm away, and has **no collidable surface within 299 mm** — and
+the 243-ray fan finds no non-collidable geom in it either. That one is a genuine
+map defect in the sense #160 raised: octomap believes something is there and
+nothing is.
+
+So the world-side residue divides:
+
+| world-side term | n | of world-side | of all stops |
+| --- | ---: | ---: | ---: |
+| **quantisation** — grid right and coarse; surface genuinely in the cell | 5 | 29 % | 22 % |
+| **bridge rasterisation dilation** — cell holds nothing, is in no leaf, real surface ≈ one cell away | 11 | 65 % | 48 % |
+| **sensor-side phantom** — nothing real within 0.29 m | 1 | 6 % | 4 % |
+
+### What this says about the three terms #161 named
+
+- **Quantisation** is real and is the smaller half of the world-side residue
+  here: 2 of 7.
+- **Lattice phase** is not separately measured. This page scores the one phase
+  the bridge actually publishes rather than sweeping it, so #161's 20.3 mm swing
+  is carried forward unchanged and is folded into the "grid right, coarse"
+  reading. Marked unmeasured, not dismissed.
+- **Map fidelity** — in the sense #160 raised it, a cell that is *wrong* — is
+  confirmed to exist and to dominate the world-side residue, but its cause is
+  **not** what the framing supposed. Taking the three hypotheses in turn:
+  - **stale?** No. Nothing has moved: every capture is a start state with zero
+    actions applied, and the arm cannot have written the cells itself (the depth
+    self-filter makes robot bodies transparent).
+  - **spurious sensor noise?** No, and it cannot be: octomap needs two hits to
+    lift a cell over `occupancy_thres` and one clearing ray to drop it back, so
+    noise cannot persist anywhere a ray passes.
+  - **displaced?** Yes — by exactly one cell, and *deterministically*. It is not
+    a residue of a frame-alignment bug but a **dilation introduced on purpose**
+    by the bridge, whose own comment records that the previous centre-sampling
+    rule was worse. #160's "empty cell with solid cabinet exactly one cell away"
+    is precisely this signature, and this is its mechanism.
+
+That reframes the engineering question #161 posed. The choice is **not** "map
+quality versus grid resolution". Nearly half the live stops in this sample
+(48 %) are held by a **rasterisation rule** — which is neither of those: it is a
+few lines of the bridge, adjustable without touching the kernel or the
+resolution. Genuine sensor-side map error accounts for 1 stop in 23.
+
+**Nothing here proposes changing that rule.** Narrowing it is a safety-relevant
+loosening — it would shrink the obstacle set the kernel sees — and it belongs on
+the safety-WG path with a hazard-log entry, not in a measurement PR. What the
+measurement does establish is that the rule is where the leverage is, and that
+it currently costs about one voxel of reach in every direction, on top of the
+21.65 mm quantisation term and #161's 20.3 mm lattice swing.
+
+### Caveats on this split
+
+- **n = 23 stops** over 27 states, sampled across all four scenes, not the full
+  62. The correlation between backing verdict and octree membership is 17/17,
+  but the population shares are sample estimates.
+- `exact_mm` bottoms out at 0.00 for a link whose surface reaches inside a cell;
+  it says the stop survives, not how deep it is.
+- The nearest-solid distances behind the 16.64–27.35 mm column are sampled at
+  10 mm, so they carry that error. They are used to say "about one cell", not to
+  resolve the 21.65 mm half-diagonal boundary.
+- `panda_link5`↔`panda_link7` are now known to genuinely interpenetrate at some
+  configurations while the shipped ACM exempts the pair
+  ([#169](https://github.com/OpenRAL/openral/pull/169)). Every stop here is a
+  **world**-voxel stop, so none of them is that self-collision — but a future
+  round that adjudicates self-collision stops must not attribute them here.
+
+<!-- APPORTIONMENT -->
+
+## What is not measured here
+
+- **Any state after `t = 0`.** Every capture is a start state with zero actions
+  applied. The four characterised live stops of the 2026-08-22 round happened
+  during motion and are not re-adjudicated here.
+- **Real hardware.** Mechanism 1 above is a simulation artefact and does not
+  transfer; how much of the apportionment survives on a real depth sensor is
+  unmeasured.
+- **The lattice-phase term in isolation.** The 20.3 mm figure is #161's, carried
+  forward unchanged. This page measures the map at the one phase the bridge
+  actually publishes (`base_link`, origin −0.8/−0.8/−0.3) rather than sweeping
+  it, so quantisation and lattice phase are reported together as one
+  "grid is right but coarse" share.
+- **Whether a cleared start state is a solvable task.** Layout 47 starts legal.
+  No rollout has been run on it.
+
+## Reproducing
+
+Measurement code is not checked in — §1.11 keeps fixtures for tests, not for
+studies — so the method is recorded here in enough detail to rebuild it.
+
+**Capture.** One Python process: construct `ManifestHALLifecycleNode`, set
+`robot_yaml`, `hal_mode=sim`, `sim_env_yaml=<scene>`, `viewer_enabled=false`,
+then `trigger_configure()` + `trigger_activate()`. Separately spawn
+`ros2 run octomap_server octomap_server_node` with `cloud_in` remapped to
+`/openral/cameras/front_depth/points` and the sim parameters listed above, and
+`ros2 run openral_octomap_bridge octomap_voxel_bridge`. Spin ~22 s, then record
+in one atomic snapshot: the `OccupancyVoxels` message, `/octomap_binary`, the
+`odom`→`base_link` transform, and `data.qpos` / `data.qvel` from the live
+`MjModel`. Holding the HAL in the same process is what makes the map and the
+geometry simultaneous.
+
+**Rebuild.** `openral_hal.sim_bringup.build_sim_env_from_yaml` on the same
+scene, then restore the recorded `qpos`/`qvel` and `mj_forward` — the idle
+stepper advances the sim, so the pose must be restored rather than re-derived.
+
+**Two things to get right or the results invert** (both cost this
+investigation a retracted conclusion):
+`scene_build.self_body_ids` must come from the manifest's `sim_joint_name`s, and
+the grid frame body must be `resolve_base_frame_body_name(model,
+description=...)` — `mobilebase0_support`, not `mobilebase0_base`.
+
+**Octree decoding.** `octomap_msgs/Octomap.data` is the raw
+`writeBinaryData()` stream, with no file header. Feed it straight to
+`octomap::OcTree::readBinaryData` (a ~20-line C++ tool linking `-loctomap
+-loctomath`); synthesising a `.bt` header round-trips to an empty tree.
+
+**Kernel port.** Mirror `box_box_distance` (`collision.cpp:327`) and the
+cell-cube treatment in `check_voxel_collision` (`collision.cpp:625`). Validate
+it by compiling `collision.cpp` into a standalone oracle and comparing on random
+OBB↔cell pairs; anything worse than ~1e-15 m means the rotation convention or
+the axis set is wrong.
+
+Run everything with per-state checkpointing. On a 16 GB host the surface-sampling
+passes are memory-bound and two of them in parallel will be OOM-killed.
+
+## Related
+
+- [RoboCasa start-state collision census](robocasa-start-state-census.md)
+- [Tight link geometry in the safety kernel](collision-tight-geometry.md)
+- [Collision-stack validation evidence](collision-validation-evidence.md)
+- `packages/openral_octomap_bridge/README.md` — the octree→grid bridge
+- `cpp/openral_safety_kernel/README.md` — the kernel geometry

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
     - Collision primitives, in pictures: reference/collision-primitive-images.md
     - RoboCasa start-state collision census: reference/robocasa-start-state-census.md
     - Tight link geometry in the safety kernel: reference/collision-tight-geometry.md
+    - The live world map, measured: reference/world-map-fidelity.md
     - Design decisions: decisions.md
   - Contributing:
     - Development: contributing/development.md

--- a/scenes/deploy/robocasa_drawer_utensil.yaml
+++ b/scenes/deploy/robocasa_drawer_utensil.yaml
@@ -7,10 +7,12 @@
 # baguette's. Used to check that the attached-object collision stack is not
 # overfitted to the baguette scene.
 #
-# ── This scene has NO initial-configuration defect ─────────────────────────────
+# ── This scene's start state is LINK-model marginal, not base-placement broken ─
 #
-# Recorded here because it has twice been assumed to have one, by analogy with
-# the fridge scene. It does not. Measured on 2026-08-23 by resetting this file
+# Recorded here because it has twice been assumed to have the fridge scene's
+# defect, by analogy. It does not — but the "NO initial-configuration defect"
+# this block used to assert is too strong, and the reasoning under it was
+# invalid. See the CORRECTION below. Measured on 2026-08-23 by resetting this file
 # through the registered adapter and adjudicating the reset pose with
 # `openral_hal.sim_sensor_bridge.estop_ground_truth_snapshot` against
 # `robots/panda_mobile/robot.yaml`'s real collision model:
@@ -20,17 +22,42 @@
 #   stack_2_left_group_3_door_g2, 0 MuJoCo contacts, payload resting on the
 #   counter, end effector 0.63 m from it.
 #
-# 43.3 mm clears the 25 mm occupancy grid, so the arm does NOT start inside the
-# kernel's world model. That 43.3 mm is the same number the evidence ledger
-# already carries for the 2026-08-23 `utensil` stop — and that stop was a
-# false positive of the ADJUDICATION, not a scene defect: the kernel read
-# -17.3 mm because the comparison applied the 21.7 mm voxel term alone instead
-# of the full 88.2 mm admissible gap. #144 fixed that by publishing
-# `adjudication_budget`. See docs/contributing/validation-matrix.md §"the
-# kernel measures OBB-to-voxel".
+# That 43.3 mm is the same number the evidence ledger already carries for the
+# 2026-08-23 `utensil` stop — and that stop was a false positive of the
+# ADJUDICATION, not a scene defect: the kernel read -17.3 mm because the
+# comparison applied the 21.7 mm voxel term alone instead of the full 88.2 mm
+# admissible gap. #144 fixed that by publishing `adjudication_budget`. See
+# docs/contributing/validation-matrix.md §"the kernel measures OBB-to-voxel".
 #
-# So the pin below is for REPRODUCIBILITY, not for a defect. Do not describe
-# this scene as having a broken starting state.
+# ── CORRECTION (2026-08-25): 43.3 mm IS NOT A KERNEL CLEARANCE ────────────────
+#
+# This block used to conclude "43.3 mm clears the 25 mm occupancy grid, so the
+# arm does NOT start inside the kernel's world model". That inference is
+# invalid, and it is the same one #154 made for the fridge scene. The kernel
+# compares an OBB against voxel CUBES, so the gap a link needs is
+# `corner_slop(link) + 21.65 mm` — for `panda_link1`, 75.05 mm. 43.3 mm does not
+# reach it. Whether the UNPINNED draw stops is therefore unmeasured against the
+# right criterion, not established as clear.
+#
+# And at the shipped `layout_ids: [3]` pin, a live octomap round on 2026-08-25
+# measured the kernel at **-1.94 mm** on `panda_link1`: this scene does take an
+# initial-configuration stop on the real map, marginally. The start-state
+# census, scoring a geometrically ideal grid, reported no stop here; the live
+# map holds cells that grid does not (non-collidable decorative geometry the
+# depth camera renders, plus the octree->grid bridge's dilation), which is why
+# it is the harsher of the two. See docs/reference/world-map-fidelity.md.
+#
+# It is left pinned at 3 anyway, deliberately. The stop is entirely LINK-side:
+# re-scored against the same live map with exact link geometry instead of the
+# manifest OBB, the same state reads **+20.01 mm** and does not stop. The staged
+# tighter-primitive work (#166) therefore removes it with no scene change, while
+# a re-pin would churn the whole kitchen — pinning changes the draw ORDER — to
+# work around a link-model artefact that is already being fixed upstream.
+# Revisit if #166 stalls.
+#
+# So the pin below is for REPRODUCIBILITY. Do not describe this scene as having
+# the fridge scene's defect: its stop is a property of the link envelope, not of
+# where the base parks, and no layout change would address it.
 #
 # Run: openral deploy sim --config scenes/deploy/robocasa_drawer_utensil.yaml
 # Setup: just sync --group robocasa  +  uv pip install -e _external/robocasa --no-deps

--- a/scenes/deploy/robocasa_fridge_drawer.yaml
+++ b/scenes/deploy/robocasa_fridge_drawer.yaml
@@ -12,12 +12,18 @@
 #
 # ── KNOWN DEFECT: seed 1 spawns the arm inside the kernel's world model ────────
 #
-# Status: DIAGNOSED, and FIXED by the `layout_ids: [30]` pin below — do not
+# Status: DIAGNOSED, and FIXED by the `layout_ids: [47]` pin below — do not
 # remove it without reading the measurements at the end of this block. Unpinned,
 # seed 1 E-stops at sim t=4.85 s having applied zero action chunks — an
 # initial-configuration violation, named in the artifacts by the
 # `sim.estop_initial_configuration` line (telemetry.md). Do not read an unpinned
 # seed-1 run as a policy or margin failure.
+#
+# The pin was `[30]` from #154 until 2026-08-25. **Layout 30 did not fix the
+# defect.** It was chosen against the wrong criterion — mesh clearance — and a
+# live round has now confirmed what the start-state census predicted: at layout
+# 30 the kernel reports -23.47 mm and still refuses the scene. The replacement
+# and the measurements behind it are at the end of this block.
 #
 # What actually happens (upstream sources read at robocasa-kitchen
 # `robocasa/environments/kitchen/atomic/kitchen_pick_place.py:1300-1380`,
@@ -116,9 +122,54 @@
 # The other 34 sit at or below the grid resolution, 22 of them at exactly
 # 0.000 m. So ~85% of this task's kitchens spawn the arm inside the kernel's
 # world model at seed 1 — an unpinned run is far more likely to be testing the
-# spawn than the collision stack. Layout 18 has the most headroom of the six and
-# is the obvious fallback if 30 ever regresses upstream; 30 is pinned because it
-# is the value that was independently reported as known-good and it verified.
+# spawn than the collision stack.
+#
+# ── WHY THE PIN MOVED FROM 30 TO 47 (2026-08-25) ──────────────────────────────
+#
+# EVERY NUMBER ABOVE IS A MESH CLEARANCE, AND MESH CLEARANCE IS NOT THE
+# KERNEL'S CRITERION. The kernel does not compare meshes. It compares each
+# link's manifest OBB against 25 mm voxel cubes, so the gap a link must have to
+# survive is `corner_slop(link) + voxel_half_diagonal`, not `> 25 mm`.
+# `panda_link2`'s corner slop alone is 48.22 mm — more than the 37.0 mm layout
+# 30 was pinned for. The start-state census
+# (docs/reference/robocasa-start-state-census.md) computed the kernel's own
+# arithmetic and put layout 30 at **-23.47 mm**: still stopping.
+#
+# That was on a geometrically ideal grid, so it was CHECKED LIVE before acting
+# — the whole point of #154's mistake being repeatable. 61 live captures of this
+# scene, one per layout, each a real octomap built by the real
+# `octomap_server` + `openral_octomap_bridge` from the real depth stream, then
+# scored with the kernel's own `box_box_distance` (a numpy port validated
+# against the shipped C++ to 4.4e-16 m). Results, in mm of OBB-to-voxel:
+#
+#   layout   live kernel min   verdict
+#   ------   ---------------   -------------------------------------------
+#      30    -23.47            STOPS  (reproduces the census exactly)
+#      18     -2.26            STOPS  (census called this one clear)
+#      21    -10.96            STOPS  (census called this one clear)
+#      43     +0.69            clears by 3% of one voxel — not a pin
+#  >> 47    +19.34            CLEARS, and stays there                   <<
+#   unpinned -24.75            STOPS  (the original defect, reproduced)
+#
+# Layout 47 is pinned because it is the only candidate that clears on all
+# three criteria at once and does not move when the map gets denser:
+#
+#   * live kernel  +19.34 mm, IDENTICAL across two independent captures whose
+#     maps held 5,435 and 9,112 occupied cells — a 68% difference in map
+#     density moves the verdict by 0.00 mm;
+#   * mesh clearance 48.40 mm (`panda_link1` vs
+#     `fridgesidebyside_main_group_1_fridge_drawer3`, densely sampled at 5 mm
+#     on both surfaces) — larger than layout 30's 37.0 mm, so it also satisfies
+#     the older criterion, by more;
+#   * every one of the seven kernel-checked links clears: the next worst is
+#     `panda_link7` at +77.46 mm.
+#
+# Layouts 18 and 21 are the trap. The census named them as clearing the KERNEL
+# criterion, and they are exactly the two the live map refutes. Do not restore
+# either on the strength of a grid built from true surfaces: the live octomap
+# also records non-collidable decorative geometry the ideal grid omits, and the
+# octree->grid bridge dilates whatever it holds, so the live map stops MORE
+# often than the ideal one, not less (docs/reference/world-map-fidelity.md).
 #
 # Two caveats a future reader needs:
 #   * Pinning `layout_ids` CHANGES THE DRAW ORDER. Layout, style, fixtures,
@@ -149,22 +200,29 @@ scene:
     controller: OSC_POSE
     obj_groups: vegetable
     # DO NOT REMOVE — this is not tidy-up, it is the fix for an
-    # initial-configuration defect. Unpinned, seed 1 draws layout 29 (a
-    # side-by-side fridge) and spawns `robot0_link7_collision` at 0.000 m from
-    # the closed freezer door: the arm starts inside the safety kernel's world
-    # model, the run E-stops before applying a single action chunk, and the
-    # round tells you nothing about the collision stack. Layout 30 starts
-    # 37.0 mm clear of the nearest solid kernel-checked geometry, comfortably
-    # outside the 25 mm occupancy grid. The full measurement table, and why the
-    # bottom-freezer layouts this block used to recommend are all WORSE, are in
-    # the KNOWN DEFECT block at the top of this file.
-    layout_ids: [30]
+    # initial-configuration defect. Unpinned, seed 1 draws layout 29 / style 20
+    # (a side-by-side fridge) and parks `robot0_link7_collision` 2.8 mm from the
+    # closed freezer door; the kernel reports -24.75 mm, the run E-stops before
+    # applying a single action chunk, and the round tells you nothing about the
+    # collision stack.
+    #
+    # The pin is 47, NOT 30. Layout 30 was pinned by #154 against MESH
+    # clearance, which is not the criterion the kernel applies — it still stops,
+    # at -23.47 mm, and that has now been confirmed on a live octomap as well as
+    # on a reconstructed grid. Layout 47 clears the live kernel by +19.34 mm
+    # (unchanged across two captures whose maps differed by 68% in density) and
+    # has 48.40 mm of mesh clearance, so it satisfies the old criterion too.
+    # Layouts 18 and 21 look correct on a geometrically ideal grid and STOP live
+    # — do not "restore" either. Full measurement table in the KNOWN DEFECT
+    # block at the top of this file.
+    layout_ids: [47]
 
 # The seed alone does NOT pin the scene: RoboCasa draws layout/style, fixtures,
 # rack_index, door-open amounts and the robot spawn deviation from one shared
 # `env.rng`, so anything that changes a draw upstream reshuffles the kitchen.
 # `layout_ids` above pins the floor plan; `style_ids` is deliberately left open
-# (the draw lands on style 29, outside the task's EXCLUDE_STYLES) so the round
+# (at the `[47]` pin the draw lands on style 32, outside the task's
+# EXCLUDE_STYLES — it was style 29 under the old `[30]` pin) so the round
 # keeps one axis of visual variation. Pin it too if a specific style matters.
 seed: 1
 
@@ -180,23 +238,34 @@ seed: 1
 #   'sim:fridge_right_group_main' names no MuJoCo body; refused`, nothing armed,
 #   and the run behaved exactly as it does with no declaration at all.
 #
-#   Seed 1's fridge is `fridge_main_group`. That leaves a real CHOICE of target,
-#   and #142's reasoning ("declare the fridge; the drawer is in its subtree")
-#   picks the wrong side of it:
-#     * `fridge_main_group_main` (body 91) is the fixture root and its subtree
-#       covers everything — the fridge door, the freezer door and the freezer
-#       drawers included. Declaring it would make contact with the FRIDGE DOOR
-#       attestable as a place-phase witness and buy the payload the approach
-#       allowance against it. The door is not the receptacle, and on seed 1 it
-#       is precisely the geometry the arm is already crowding (see the KNOWN
-#       DEFECT block above).
-#     * `fridge_main_group_fridge_drawer0` (body 98) is the drawer the task
-#       actually places into. Its subtree is the drawer and nothing else, so
-#       it is the tighter and correct target: it licenses exactly the surface
-#       the vegetable comes to rest on.
+#   THE TARGET IS A FUNCTION OF THE PIN, and moving the pin moves it. Under the
+#   old `[30]` pin seed 1's fridge was `fridge_main_group`; under `[47]` the
+#   scene composes to layout 47 / style 32 and the fridge is
+#   `fridgesidebyside_main_group_1`. `sim:fridge_main_group_fridge_drawer0` no
+#   longer names any body, so it was re-resolved off the live MuJoCo body table
+#   at the new pin (bodies 173-183 carry the token `fridge`). Anyone changing
+#   `layout_ids` MUST re-resolve this field in the same commit; the HAL fails
+#   closed on a stale one, so the symptom is a silently unarmed place phase.
+#
+#   That leaves a real CHOICE of target, and #142's reasoning ("declare the
+#   fridge; the drawer is in its subtree") picks the wrong side of it:
+#     * `fridgesidebyside_main_group_1_main` (body 173) is the fixture root and
+#       its subtree covers everything — the fridge door, the freezer door and
+#       the freezer drawers included. Declaring it would make contact with the
+#       FRIDGE DOOR attestable as a place-phase witness and buy the payload the
+#       approach allowance against it. The door is not the receptacle.
+#     * `fridgesidebyside_main_group_1_fridge_drawer0` (body 176) is the drawer
+#       the task actually places into — the top fridge drawer `_setup_scene`
+#       opens to 80-100%. Its subtree is the drawer and nothing else, so it is
+#       the tighter and correct target: it licenses exactly the surface the
+#       vegetable comes to rest on.
 #   The declared body's whole subtree is what a witness may be attested against,
 #   so the rule is "smallest body that still contains the resting surface" — a
 #   parent chosen for convenience exempts its siblings too.
+#
+#   NOT verified end to end at this pin: the body exists and is the right one by
+#   the rule above, but no full rollout has yet placed a vegetable into it. That
+#   is a rollout question, not an initial-configuration one.
 #
 #   Read off the MuJoCo body table, NOT off `env.fixture_refs["fridge"]`: in the
 #   live env that value is a TUPLE with no `.name` attribute and a `None`
@@ -208,7 +277,7 @@ seed: 1
 #   120 s was derived from a benchmark horizon that does not bound a `deploy sim`
 #   goal, and the live baguette run consumed 92 s of it before the grasp.
 place_declaration:
-  target_id: "sim:fridge_main_group_fridge_drawer0"
+  target_id: "sim:fridgesidebyside_main_group_1_fridge_drawer0"
   object_id: ""
   timeout_s: 300.0
   stamp_ns: 0

--- a/tests/unit/test_deploy_scene_place_declaration.py
+++ b/tests/unit/test_deploy_scene_place_declaration.py
@@ -110,7 +110,15 @@ def test_no_declaration_at_all_is_still_valid() -> None:
 _DECLARING_SCENES = {
     "robocasa_baguette.yaml": "sim:cab_1_left_group_main",
     "robocasa_sink_cup.yaml": "sim:sink_island_group_main",
-    "robocasa_fridge_drawer.yaml": "sim:fridge_main_group_fridge_drawer0",
+    # The fridge target is a function of that scene's `layout_ids` pin, which
+    # moved 30 -> 47 once the pin was verified against the KERNEL criterion on a
+    # live octomap (layout 30 clears the mesh but stops at -23.47 mm). At layout
+    # 47 the kitchen composes to style 32 and the fixture is
+    # `fridgesidebyside_main_group_1`, so the old body no longer exists. Anyone
+    # changing that pin must re-resolve this in the same commit: the HAL fails
+    # closed on a stale target, so the symptom is a silently unarmed place phase
+    # rather than an error.
+    "robocasa_fridge_drawer.yaml": "sim:fridgesidebyside_main_group_1_fridge_drawer0",
 }
 
 #: Arm→grasp latency measured on `robocasa_baguette` at seed 1 (Spark,

--- a/tests/unit/test_robocasa_backend_options.py
+++ b/tests/unit/test_robocasa_backend_options.py
@@ -162,7 +162,7 @@ def test_xr1_state_layout_is_supported() -> None:
 @pytest.mark.parametrize(
     ("scene_file", "prebuilt_task", "expected_layout"),
     [
-        ("robocasa_fridge_drawer.yaml", "PickPlaceFridgeShelfToDrawer", 30),
+        ("robocasa_fridge_drawer.yaml", "PickPlaceFridgeShelfToDrawer", 47),
         ("robocasa_drawer_utensil.yaml", "PickPlaceCounterToDrawer", 3),
     ],
 )
@@ -172,11 +172,18 @@ def test_matrix_scene_ships_its_verified_layout_pin(
     """Both pinned matrix scenes carry the layout their header block justifies.
 
     The fridge pin is a *fix*: unpinned, seed 1 draws a side-by-side kitchen and
-    spawns ``robot0_link7_collision`` at 0.000 m from the closed freezer door,
-    so the run E-stops on the initial configuration before applying a chunk.
-    The utensil pin is a *reproducibility* pin — that scene starts 43.3 mm clear
-    unpinned and has no defect — but without it the kitchen is a free draw off
-    ``env.rng`` and two rounds at ``seed: 1`` are not comparable.
+    parks ``robot0_link7_collision`` 2.8 mm from the closed freezer door, so the
+    kernel reports -24.75 mm and the run E-stops on the initial configuration
+    before applying a chunk. The pinned value is **47**, not the 30 #154
+    shipped: layout 30 was chosen against MESH clearance, which is not the
+    criterion the kernel applies, and it still stops at -23.47 mm on a live
+    octomap. Layout 47 clears by +19.34 mm. See the scene's header block and
+    docs/reference/world-map-fidelity.md.
+
+    The utensil pin is a *reproducibility* pin — without it the kitchen is a
+    free draw off ``env.rng`` and two rounds at ``seed: 1`` are not comparable.
+    (Its start state is marginal on the live map at -1.94 mm, but that stop is
+    entirely link-side, so a re-pin is not the remedy; see its header block.)
 
     Either way the value must survive the prebuilt/procedural XOR: the
     scene-pool restrictors are deliberately independent of ``mode``, unlike the


### PR DESCRIPTION
## What changed

Two commits.

**1. `fix(sim)` — the fridge pin was verified against the wrong criterion, again.**

`layout_ids: [30]` was chosen in #154 against *mesh* clearance (37.0 mm vs the 25 mm grid). That is not the criterion the kernel applies: it compares each link's manifest OBB against voxel cubes, so the gap a link needs is `corner_slop(link) + 21.65 mm`, and `panda_link2`'s corner slop alone is 48.22 mm. The start-state census (#159) put layout 30 at **−23.47 mm** — still stopping — and recommended layouts 18, 21, 43 or 47, asking for a live round before acting.

This is that live round, and it changes the recommendation. Pin moved to **47**.

**2. `docs(collision)` — [`docs/reference/world-map-fidelity.md`](docs/reference/world-map-fidelity.md), the map-fidelity characterisation #161 asked for.**

## Why — Task 1's verdict

61 live captures of the fridge scene, one per layout, each a real octomap built by the real `octomap_server` + `openral_octomap_bridge` from the real depth stream, scored with the kernel's own `box_box_distance`:

| layout | live kernel min | verdict |
| ---: | ---: | --- |
| unpinned (29 / 20) | `panda_link7` −24.75 mm | STOPS — the original defect, reproduced (#154 saw −24.7) |
| **30** (shipped) | `panda_link2` **−23.47 mm** | **STOPS** — reproduces the census exactly |
| 18 | `panda_link2` −2.26 mm | **STOPS** — census called it clear |
| 21 | `panda_link7` −10.96 mm | **STOPS** — census called it clear |
| 43 | `panda_link7` +0.69 mm | clears by 3 % of one voxel |
| **47** | `panda_link1` **+19.34 mm** | **clears** |

**Layouts 18 and 21 are the trap** — the two the census recommended, both refuted live. Pinning either would have repeated #154's mistake in a new form.

Layout 47 is the only candidate clearing all three criteria without sitting on the boundary: **+19.34 mm identical across two captures whose maps held 5,435 and 9,112 cells** (68 % more map, 0.00 mm of verdict change), 48.40 mm mesh clearance, every link clear.

`place_declaration.target_id` is re-resolved in the same commit — it is a function of the pin, and the old body does not exist at layout 47.

## Why — Task 2's split

Each live stop was re-scored against the *same* map with exact link geometry (the quantity #166 reaches; it measures `panda_link2`'s residual excess at 0.00 mm). A stop exact geometry clears is link-side; one it keeps is world-side by construction.

Over **23 live stops**: **26 % link-side, 74 % world-side**. Splitting the world-side residue by what backs the tripping cell — the 243-ray `voxel_backing_record` probe and octree membership agree on **17 of 17**:

| world-side term | n | of all stops |
| --- | ---: | ---: |
| quantisation — real surface in the cell, cell in the octree | 5 | 22 % |
| **bridge cube-overlap dilation** — cell empty, in no octree leaf, real surface ≈ one cell away | **11** | **48 %** |
| sensor-side phantom — nothing real within 0.29 m | 1 | 4 % |

So the phantoms #160 found are **displaced, not stale or spurious** — deterministically, by one cell, by `rasterize_octree_to_grid`'s strict cube-overlap rule, which is deliberate and documented as the safe direction. octomap's thresholds are ruled out analytically (two hits to create a safety voxel, one clearing ray to remove it).

**This reframes #161's question.** The choice is not "map quality versus grid resolution": nearly half the live stops are held by a *rasterisation rule*, which is neither. Nothing here changes it — narrowing it is a safety-relevant loosening and belongs on the safety-WG path.

One more correction the live map forced: the census's stated assumption that the live map "can only ever be a subset" of the ideal grid is **false**. Over 59 fridge layouts the live map reproduces all 55 census stops, adds 2, and is on median 13.04 mm *more* negative.

## How tested

- numpy kernel port validated against `collision.cpp` compiled as an oracle: **max disagreement 4.4e-16 m** over 4,000 random OBB↔cell pairs.
- Mesh distances densely sampled at 5 mm, never `mj_geomDistance` (standing caveat 8). They reproduce #154's independently reported 2.5 mm / 16.1 mm for `panda_link7` / `link6` against the freezer door as **2.819 / 16.262 mm** — which also settles that the later `0.000 m` on that pair was `mj_geomDistance`'s failure mode.
- Live kernel minima reproduce two independently reported field numbers exactly (−24.75 vs −24.7; −23.47 vs −23.47).
- `just lint` clean; `mypy --strict` clean; full `tests/unit` green. The two unit tests that pin the fridge layout and place target are updated.

The page records **two instrument bugs that silently invert results** (an empty self-filter body set; a 0.7 m grid-frame offset from resolving `base_link` without the description) and **retracts** the conclusion the second one produced.

No kernel, threshold, resolution, manifest or bridge behaviour is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUhD1uz93qMFJQsNxyTEM5