### PR TITLE
ci(ros2): add the colcon+ctest workflow the selector already claims exists

### DIFF
--- a/.github/workflows/test-ros2.yml
+++ b/.github/workflows/test-ros2.yml
@@ -1,0 +1,131 @@
+name: test-ros2
+# colcon build + ctest for the C++ / ROS 2 half of the workspace — the packages
+# `tools/test_selection.toml` deliberately excludes from the Python selector.
+#
+# That exclusion is correct (a `cpp/**` change genuinely selects no Python
+# tests), but its comment named THIS workflow as the thing that covers them and
+# this file did not exist. So `cpp/openral_safety_kernel` — the safety kernel —
+# had no CI coverage of any kind: a kernel-only PR gets a green
+# `select-and-test` that ran zero tests. This file is that missing half.
+#
+# Auto-triggers disabled: out of GitHub Actions credits, matching hal.yml,
+# test-python.yml and docs.yml. Re-enable PR/push triggers once billing is
+# restored — see "Re-enabling on PRs" below. Until then this is the documented,
+# reproducible way to run the kernel suite in CI on demand, and the local
+# equivalent is `just ros2-build && just ros2-test`.
+#
+# Cost, measured rather than guessed. On a 16-core dev host, a cold
+# `--packages-up-to openral_safety_kernel openral_octomap_bridge` is 4 packages
+# in 2 min 21 s: openral_msgs 29 s, openral_octomap_bridge 29 s,
+# opentelemetry_cpp_vendor 1 min 2 s, openral_safety_kernel 1 min 19 s. Expect
+# meaningfully longer on a 4-core hosted runner, but this is minutes, not tens
+# of minutes — cheaper than assumed when the credits freeze was applied.
+#
+# `opentelemetry_cpp_vendor` git-clones and builds upstream otel-cpp from source
+# via ExternalProject_Add (there is no `ros-jazzy-opentelemetry-cpp-vendor`
+# binary package to shortcut it), so this job needs NETWORK during the build
+# step, not just during checkout — hence git + ca-certificates below.
+#
+# It deliberately builds a SUBSET, not `just ros2-build`'s full 28 packages:
+# these two are the ones the Python selector cannot cover. Widen via the
+# `packages` input when a run needs more.
+#
+# Re-enabling on PRs — replace the `on:` block with:
+#     on:
+#       workflow_dispatch:
+#       pull_request:
+#         branches: [master]
+# and add `test-ros2` to the `required_status_checks` of the
+# protect_default_branch ruleset, or a kernel PR still merges unverified.
+on:
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: "colcon --packages-up-to targets (space-separated)"
+        required: false
+        default: "openral_safety_kernel openral_octomap_bridge"
+
+permissions:
+  contents: read
+
+jobs:
+  ros2:
+    name: "colcon build + ctest — Jazzy"
+    runs-on: ubuntu-24.04
+    env:
+      # Via env, never interpolated straight into a `run:` block — a dispatch
+      # input reaching the shell directly is a script-injection surface even
+      # when only write-access holders can trigger it.
+      PACKAGES: ${{ inputs.packages || 'openral_safety_kernel openral_octomap_bridge' }}
+    # ros:jazzy-ros-base pins the distro rather than relying on apt keyring
+    # setup on a bare runner, and matches the Jazzy the Justfile targets.
+    container:
+      image: ros:jazzy-ros-base
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      # `ros-base` omits these. octomap/octomap-msgs are octomap_bridge's build
+      # deps; octomap-server is what sim_e2e.launch.py spawns at runtime.
+      # protobuf-{dev,compiler} are opentelemetry_cpp_vendor's — without them
+      # its otel-cpp ExternalProject fails to configure, which has previously
+      # been misread as a protobuf VERSION conflict. It is not: it is absence.
+      # See docs/reference/world-map-fidelity.md.
+      - name: Install build dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential \
+            git ca-certificates \
+            libprotobuf-dev protobuf-compiler \
+            nlohmann-json3-dev \
+            ros-jazzy-octomap ros-jazzy-octomap-msgs ros-jazzy-octomap-server
+          rm -rf /var/lib/apt/lists/*
+
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      # The colcon build points -DPython3_EXECUTABLE at this venv, so it has to
+      # exist before the build, not just before the tests.
+      - name: Sync the Python environment
+        run: uv sync --frozen --all-packages || uv sync --all-packages
+
+      - name: Declared-dependency check
+        run: bash scripts/check_ros_build_deps.sh
+
+      # CMAKE_POLICY_VERSION_MINIMUM=3.10 mirrors the Justfile: Jazzy's bundled
+      # gtest_vendor declares cmake_minimum_required(VERSION 3.5), which CMake
+      # >= 3.27 deprecates loudly through colcon on every package with tests.
+      - name: colcon build
+        run: |
+          . /opt/ros/jazzy/setup.sh
+          colcon build --merge-install --symlink-install \
+            --base-paths packages cpp \
+            --packages-up-to ${PACKAGES} \
+            --cmake-args -DPython3_EXECUTABLE="$(pwd)/.venv/bin/python" \
+                         -DCMAKE_C_COMPILER=/usr/bin/gcc \
+                         -DCMAKE_CXX_COMPILER=/usr/bin/g++ \
+                         -DCMAKE_POLICY_VERSION_MINIMUM=3.10
+
+      # `colcon test` exits 0 even when tests fail — the failure lives in the
+      # per-package result files. `colcon test-result --verbose` is what turns a
+      # failing suite into a failing job, so it is NOT optional here. This is
+      # the same class of hole as #164 (a lane reporting success over failure).
+      - name: colcon test
+        run: |
+          . /opt/ros/jazzy/setup.sh
+          . install/setup.sh
+          colcon test --merge-install \
+            --packages-select ${PACKAGES}
+          colcon test-result --verbose
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: colcon-test-results
+          path: |
+            build/**/test_results/**
+            log/latest_test/**
+          if-no-files-found: warn


### PR DESCRIPTION
## What changed

Adds `.github/workflows/test-ros2.yml` — colcon build + ctest for the C++ / ROS 2
packages. **Dispatch-only**, matching `hal.yml` / `test-python.yml` / `docs.yml`.

## Why

`tools/test_selection.toml` excludes `cpp/**` from the Python selector, and says
why:

```toml
# They are covered by their own workflows: cpp/ by `test-ros2`
# (colcon) and the safety-kernel ctest, packages/**/*.cpp likewise.
ignore_globs = [
  "cpp/**",
]
```

**`.github/workflows/test-ros2.yml` did not exist.** The toml names it in three
places (lines 25, 32, 197). No workflow in this repo runs `colcon test` or
`ctest` at all — the only other colcon mention is `docker-build.yml`, which
triggers on push to master under `docker/inference/**` paths and builds an image
without testing anything.

So **the C++ safety kernel has had no CI coverage of any kind.**

The exclusion itself is correct — a `cpp/**` change genuinely selects no Python
tests. What was missing is its counterpart. The failure mode is a kernel-only PR
going green on

```
##[notice]No code paths affected by this diff — no tests selected.
```

which is the selector behaving *correctly* against a workflow that isn't there.

**#179 is exactly that shape.** Its entire diff is `cpp/openral_safety_kernel/**`
plus docs. It reports three green checks having executed **zero** of its own
tests. Same class as #164 (a lane reporting success over failure), landing on the
one package where CLAUDE.md §3 requires *"tests proving the new behavior is at
least as conservative."*

## Why dispatch-only

`hal.yml`, `test-python.yml` and `docs.yml` all carry:

```
# Auto-triggers disabled: out of GitHub Actions credits.
# Re-enable PR/push triggers once billing is restored.
```

This matches that posture. It makes the kernel suite **runnable and documented**
now, and flips to PR-triggered with the two-line change recorded in the file
header once billing is restored.

**It does not by itself close the gap**, and the header says so plainly. Until it
is PR-triggered and added to `required_status_checks`, a kernel PR still merges
unverified.

## How tested

The workflow is dispatch-only so it cannot self-demonstrate on this PR. I ran its
exact equivalent locally on **#179's tree (`fec669e`)**, ROS 2 Jazzy:

```
colcon build --merge-install --symlink-install --base-paths packages cpp \
  --packages-up-to openral_safety_kernel openral_octomap_bridge
  Summary: 4 packages finished [2min 21s]

colcon test --merge-install \
  --packages-select openral_safety_kernel openral_octomap_bridge
colcon test-result --verbose
  Summary: 253 tests, 0 errors, 0 failures, 0 skipped
```

Verified from the gtest XML rather than the summary line, so the suites are known
present rather than silently absent:

| suite | tests |
| --- | ---: |
| `PlaceAdvisoryBand` | 8 |
| `OrientedGrid` | 2 |

That is the first actual execution of #179's content against its rebased tree.

## Three things worth a reviewer's eye

1. **`colcon test-result --verbose` is a separate, non-optional step.** `colcon
   test` exits 0 even when tests fail — the failure lives in the per-package
   result files. Without that step this workflow would reproduce the exact hole
   it exists to close.
2. **The dispatch input goes through `env:`,** never interpolated straight into a
   `run:` block — a script-injection surface even when only write-access holders
   can trigger it.
3. **`git` + `ca-certificates` are installed deliberately.**
   `opentelemetry_cpp_vendor` git-clones and builds upstream otel-cpp from source
   via `ExternalProject_Add` (there is no `ros-jazzy-opentelemetry-cpp-vendor`
   binary package — checked), so the job needs network during the **build** step,
   not just at checkout, and `ros-base` does not guarantee git.

## A correction I am carrying in the header

I originally asserted this would be the most expensive job in the repo and that
that argued against enabling it. **Measured, it is 2 min 21 s cold** on a 16-core
host — `openral_msgs` 29 s, `openral_octomap_bridge` 29 s,
`opentelemetry_cpp_vendor` 1 min 2 s, `openral_safety_kernel` 1 min 19 s.
Meaningfully slower on a 4-core hosted runner, but minutes rather than tens of
minutes. The header now carries the per-package numbers instead of the adjective.

That materially weakens the cost argument for keeping it off. The credits freeze
is still real, so this ships dispatch-only — but the WG should know the price is
lower than assumed when deciding whether to re-enable.

## Scope

Builds a **subset** (`openral_safety_kernel`, `openral_octomap_bridge`) rather
than `just ros2-build`'s full 28 packages — these are the two the Python selector
cannot cover. Widen via the `packages` dispatch input.

Not a safety change: adds CI, touches no kernel code, so no §3 path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
