### PR TITLE
fix(docker): build openral_nav2_bringup, so the live Nav2 tests test something

### DIFF
--- a/docker/inference/Dockerfile.x86
+++ b/docker/inference/Dockerfile.x86
@@ -307,6 +307,17 @@ COPY scenes/ scenes/
 # targets. It is sourced BEFORE `set -u` because colcon's generated setup
 # scripts reference unbound variables.
 #
+# `openral_nav2_bringup` is in this list for a reason that is easy to undo:
+# it is an ament_cmake package, so its Python module reaches PYTHONPATH ONLY
+# via the `ament_python_install_package()` this build runs. The live-ROS step
+# below runs tests/integration/test_nav2_payload_footprint_live.py, which
+# spawns payload_scan_filter_node.py as its own process — without this package
+# built, that node dies at import (`No module named 'openral_nav2_bringup'`),
+# no scan is ever republished, and every costmap cell reads 0. Note that the
+# resulting failure is partly SILENT: the "carried object must not mark the
+# costmap" assertion passes vacuously when nothing reaches the costmap at all,
+# and only the released-object control catches it.
+#
 # `Python3_EXECUTABLE=/workspace/.venv/bin/python` is essential so the
 # ament-python packages resolve openral_* + structlog against the venv, not the
 # unconfigured system python. `--merge-install` collapses the trees into one
@@ -333,6 +344,7 @@ RUN bash -lc 'set -eo pipefail \
                           openral_rskill_ros \
                           openral_octomap_bridge \
                           openral_perception_ros \
+                          openral_nav2_bringup \
         --cmake-args -DPython3_EXECUTABLE=/workspace/.venv/bin/python \
                      -DCMAKE_C_COMPILER=/usr/bin/gcc \
                      -DCMAKE_CXX_COMPILER=/usr/bin/g++ \


### PR DESCRIPTION
## What changed

Adds `openral_nav2_bringup` to `docker/inference/Dockerfile.x86`'s `colcon build --packages-select`.

## Why

The image never built it, while the live-ROS step still ran `tests/integration/test_nav2_payload_footprint_live.py` — a file listed among this very workflow's path triggers.

It is an `ament_cmake` package, so its Python module reaches `PYTHONPATH` only through `ament_python_install_package()` at colcon-build time. Never built → never installed → never importable, so the test's

```python
subprocess.Popen([sys.executable, payload_scan_filter_node.py])
```

died at once on `ModuleNotFoundError: No module named 'openral_nav2_bringup'`. Running the file directly puts its *own* directory on `sys.path`, not the package parent, so the absolute self-import cannot resolve without the overlay entry.

With the filter dead nothing republishes `/scan`, the costmap has no observation source, every cell reads 0, and all three tests in that module fail.

## One of those failures was hiding

```python
assert max(costs) < lethal_threshold   # "the carried object didn't mark the costmap"
```

passes **vacuously** when nothing reaches the costmap at all. Phase 1 of `test_the_carried_object_never_becomes_a_costmap_obstacle` was green for precisely the wrong reason, and only its released-object control — the *identical* scan must mark the map once World State says the payload is released — converted the breakage into a visible failure.

That control is the entire reason this was diagnosable rather than a silent pass. Worth keeping in mind for anyone tempted to simplify that pairing.

## Why nothing else was needed

- The image already apt-installs `nav2-bringup` and `nav2-msgs` in **both** stages.
- The package's only build deps are `ament_cmake` + `ament_cmake_python`; everything else is an `exec_depend`.
- `--symlink-install` is deliberately dropped in this image, so the CMakeLists' warning about `install(PROGRAMS ...)` needing mode 100755 does not bite — an install that *copies* applies +x itself.

## On the comment placement

The explanatory comment sits **above** the `RUN`, not inside the package list. That block is a `bash -lc '...'` single-quoted string spanning backslash continuations; a `#` reaching the shell there would comment out the remainder of the build command.

## Scope

`openral_slam_bringup` is also absent from the image and is left that way — no test in the live-ROS step references it. This fixes a broken lane rather than widening the image.

## How tested

`docker-build` dispatched on this branch, which runs the full image build plus the live-ROS suite. A `workflow_dispatch` run never pushes to GHCR, so this is verification only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)