### PR TITLE
fix(reward): build the NF4 shells on meta — a 3.2 GB checkpoint was taking 14.3 GB of RAM

### DIFF
--- a/tests/unit/test_robometer_nf4_shells_on_meta.py
+++ b/tests/unit/test_robometer_nf4_shells_on_meta.py
@@ -1,0 +1,68 @@
+"""`install_linear4bit_shells` must leave its shells on the meta device.
+
+The shells exist only so `install_prequantized` has somewhere to drop the
+checkpoint's packed NF4 tensors — every one of them is overwritten. Built on
+the default device instead, each costs host RAM proportional to the **dense**
+layer, which is the materialization NF4 exists to avoid: loading
+Robometer-4B peaked at 14.3 GB RSS and was OOM-killed before a single packed
+weight was read.
+
+The end-to-end proof is `test_reward_monitor_client.py::test_e2e_score_clip_in_process`,
+but that needs a local GPU and the Robometer deps, so it skips on CI. This test
+needs neither and pins the property directly. `openral_sim._quantization` guards
+its own `Linear4bit` constructor the same way, via `accelerate.init_empty_weights`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+from _robometer_quant import MIN_PARAMS, install_linear4bit_shells
+
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("bitsandbytes") is None,
+    reason="bitsandbytes not installed in this env",
+)
+
+
+class _Tree(nn.Module):
+    """One Linear above the NF4 size rule and one below it."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # 2048*2048 = 4.19M >= MIN_PARAMS (4M): quantized.
+        self.big = nn.Linear(2048, 2048, bias=False)
+        # 8*8 = 64: left alone.
+        self.small = nn.Linear(8, 8, bias=False)
+
+
+def test_shells_are_installed_on_meta_not_host_ram() -> None:
+    """The regression. A real-storage shell is what OOM-killed the 4B load."""
+    import bitsandbytes as bnb
+
+    tree = _Tree()
+    assert tree.big.weight.numel() >= MIN_PARAMS
+    replaced = install_linear4bit_shells(tree, torch.bfloat16)
+
+    assert replaced == 1, "only the Linear above MIN_PARAMS should be replaced"
+    assert isinstance(tree.big, bnb.nn.Linear4bit)
+    assert tree.big.weight.is_meta, (
+        "Linear4bit shell allocated real storage — on a 4B model this is "
+        "gigabytes of host RAM for a tensor install_prequantized overwrites"
+    )
+
+
+def test_small_linears_are_untouched_and_keep_real_weights() -> None:
+    """The size rule still selects, and a skipped Linear is not moved to meta."""
+    tree = _Tree()
+    install_linear4bit_shells(tree, torch.bfloat16)
+    assert isinstance(tree.small, nn.Linear)
+    assert not tree.small.weight.is_meta

--- a/tools/_robometer_quant.py
+++ b/tools/_robometer_quant.py
@@ -105,17 +105,28 @@ def install_linear4bit_shells(root: object, compute_dtype: object) -> int:
         nonlocal n
         for name, child in list(module.named_children()):
             if isinstance(child, torch.nn.Linear) and child.weight.numel() >= MIN_PARAMS:
-                setattr(
-                    module,
-                    name,
-                    bnb.nn.Linear4bit(
+                # ON META, like the skeleton these shells are installed into.
+                # `Linear4bit.__init__` allocates a real parameter for its
+                # weight, so on the default device each shell costs host RAM
+                # proportional to the DENSE layer -- the materialization NF4
+                # exists to avoid. Loading Robometer-4B peaked at 14.3 GB RSS
+                # and was OOM-killed before a single packed weight was read.
+                # `install_prequantized` overwrites every one of these from the
+                # checkpoint, so there is nothing here to preserve: "EMPTY
+                # shells" was always the intent and meta is what makes them
+                # empty. `openral_sim._quantization` guards its own Linear4bit
+                # constructor the same way (via `accelerate.init_empty_weights`);
+                # this path is the one that missed it. Same device the caller
+                # meta-builds the skeleton on in `_robometer_scorer`.
+                with torch.device("meta"):
+                    shell = bnb.nn.Linear4bit(
                         child.in_features,
                         child.out_features,
                         bias=child.bias is not None,
                         compute_dtype=compute_dtype,
                         quant_type="nf4",
-                    ),
-                )
+                    )
+                setattr(module, name, shell)
                 n += 1
             else:
                 _replace(child)


### PR DESCRIPTION
## What changed

`install_linear4bit_shells` constructs its `bnb.nn.Linear4bit` shells inside `with torch.device("meta")`. One line, plus the comment saying why.

## Why

`bnb.nn.Linear4bit.__init__` allocates a real parameter for its weight. Built on the default device that is host RAM, proportional to the **dense** layer — precisely the materialization NF4 exists to avoid. The function's own docstring says "EMPTY `Linear4bit` shells" and "Used on a meta-device skeleton", and the caller in `_robometer_scorer._load_prequantized` does meta-build the skeleton — but the shell install runs *after* that `with` block has exited.

Measured on the reward path (Robometer-4B, a 3.2 GB pre-quantized checkpoint), peak RSS through `_Scorer.__init__`:

| step | before | after |
| --- | ---: | ---: |
| meta build | 712 MB | 712 MB |
| **nf4 shells** | **OOM-killed** | **792 MB** |
| safetensors → cuda | — | 3388 MB |
| processor built | — | 3388 MB |

Before, the process peaked at **14.3 GB RSS and was SIGKILLed by the OOM killer before a single packed weight was read**. `install_prequantized` overwrites every shell with the checkpoint's packed tensors on the target device, so there is nothing to preserve.

Not a small-host workaround — gigabytes of pointless allocation on any host. `openral_sim._quantization` already guards its own `Linear4bit` constructor this way (via `accelerate.init_empty_weights`, with a comment about "the placeholder-allocation saving"); this path is the one that missed it. The other `Linear4bit` call sites (`behavior_groot_sidecar`, `_lingbot_vla2_server`, `_verify_lingbot_nf4`, and `quantize_nf4_in_place` here) are the quantize-from-dense path — they assign a clone of a dense weight they already hold, a different shape, and are left alone.

## How tested

- New `tests/unit/test_robometer_nf4_shells_on_meta.py` — 2 cases pinning that the shell is on meta and that a Linear below `MIN_PARAMS` is neither replaced nor moved. **Verified it fails without the fix** (reverted the one line, saw `AssertionError` on `tree.big.weight.is_meta`, restored). GPU-free, so it guards this on CI where the e2e test cannot run.
- `tests/unit/test_reward_monitor_client.py` now passes **8/8**, including `test_e2e_score_clip_in_process`, which loads the real NF4 model and scores a clip — it was the OOM.
- The whole unit suite completes **in one process** for the first time on this host: **5244 passed, 72 skipped in 107 s**. Previously SIGKILLed at ~57%.
- `ruff` + `ruff format --check` clean; `mypy --strict` clean on `tools/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mpadAw5FxgQkAZGKx9FGJ