### PR TITLE
docs(collision): record the post-#200 battery, both arms

### DIFF
--- a/docs/reference/collision-validation-evidence.md
+++ b/docs/reference/collision-validation-evidence.md
@@ -1265,6 +1265,26 @@ margin than the pre-Path-A reading suggested. Three of the A-on stops name
 a stop class that could not exist before #200 gave the kernel the declared
 target's bodies.
 
+**Correction (same day): two of these verdicts are instrument artifacts, not
+findings.** The `false-positive` count above is 2 with the band off and 1 with it
+on, and the `sink_cup` `panda_link5`↔`panda_link7` stop appears in both arms. It
+is **not** a false positive. The adjudicator had no link-vs-link path at all:
+`tools/validation_matrix.py` branched on `involves_payload` rather than on
+`stop.kind` and fell through to the world-stop comparison, and the ground-truth
+producer excludes the whole robot from the far side, so a link-vs-link pair is
+structurally impossible for it to produce. The `nearest_tripping_party_m` of
+0.212 m it reported is `panda_link5` measured against a kitchen island.
+
+Replayed offline against the real narrow phase, the pair genuinely
+interpenetrates by ~1.5 mm at the recorded configuration — the hull-vs-hull GJK
+#202 introduced did run, and #202's own 86.38 % / 6.60 % table reproduces byte
+for byte. So the stop was correct and this round's 44 %/65 % contact-phase
+figures, which count payload stops, are unaffected. What changes is the verdict
+column: those two re-derive as `unadjudicated`. Fix and the full replay are on
+`fix/link5-link7-phantom-self-collision`; the earlier framing that −31.97 mm
+"sits inside the false population" was also wrong — it lies between the two
+populations, in neither.
+
 **What this round does NOT establish, and one thing it takes back.** Task
 success was **5/20** on 2026-08-26 and is **1/20** here in both arms. Neither
 path predicts that and neither arm explains it; the commits differ by far more

--- a/docs/reference/collision-validation-evidence.md
+++ b/docs/reference/collision-validation-evidence.md
@@ -1209,6 +1209,72 @@ at −14.6 mm, because the attested patch is bounded to the payload's own
 footprint on the attested plane and that cell lies outside it. Three rounds of
 one scene settle nothing about rates either way.
 
+### 2026-09-04 — `post200-1..5` and `post200-aon-1..5`, the post-#200 battery, both arms
+
+Ten rounds on one commit — `aceeca6`, master with Path A (#198) and Path B
+(#200) both merged — same seed, same host (`q-laptop`, RTX 5070 Laptop), run
+through `tools/validation_matrix.py`. Forty scene runs in two arms of twenty.
+This is the first battery since 2026-08-26, which predates both paths.
+
+**The arm split, and why there are two.** The graded-velocity band #198 shipped
+is **off in the default configuration, deliberately**: `collision_scale_proximity_m`
+declares at `0.0` (`lifecycle_kernel.cpp:303`), zero disables the mechanism and
+reproduces the pre-#198 republish exactly, and the header states the reason —
+"this is a WG-gated enforcement surface and the A/B battery is what turns it
+on" (`lifecycle_kernel.hpp:358`). That is a design decision, not an oversight,
+but it has a consequence worth stating plainly: **a battery run on master
+measures Path B alone**, and any reading of §10's "A + B" gate from the default
+arm alone would be measuring one path and naming two. The second arm sets the
+band through the `OPENRAL_COLLISION_SCALE_PROXIMITY_M` seam
+(`sim_e2e.launch.py:126`) at the same `0.05 m / k=20 / min=0.1` the #188 A/B
+used, and `verdicts.json` records `collision_scale` per round so which arm a
+round belongs to is a recorded fact, not an operator's memory.
+
+| | A off (shipped default) | A on (0.05 m band) |
+| --- | ---: | ---: |
+| completed | 1/20 | 1/20 |
+| deadline | 1 (`no-grasp`) | 2 (**both `after-grasp`**) |
+| stops | 18 | 17 |
+| — payload | 12 | **16** |
+| — robot link | 6 | **1** |
+| — vs the declared place target | 2 | 3 |
+| — any party, with a live declaration | 9 | 12 |
+| — **payload**, with a live declaration | **8** | **11** |
+| depth median | 3.47 mm | 6.59 mm |
+| steps before the run ended, median | 336 | 486 |
+
+**Path A does what it claims and does not rescue completion.** The band is
+live in the second arm — 4 469 scaled republishes, scale floor 0.369, median
+active scale 0.592. The floor is the band's own arithmetic reproduced live:
+`lifecycle_kernel.cpp:300` predicts `exp(−k·proximity) = exp(−1.0) = 0.37` at
+the margin for this setting, and the measured minimum is 0.369. It moves the
+robot **45% further** before the run ends
+(336 → 486 steps median). It nearly eliminates the link-vs-world class (6 → 1).
+But **task success is 1/20 in both arms**: what the band converts is not stops
+into successes but stops into *timeouts*, and the two `deadline-after-grasp`
+outcomes are a class the off arm never produced. Slowing the approach spends
+the 420 s budget. That cost is not in §10's Path A description and should be.
+
+**The contact-phase class is now the majority, which is the gate §10 set for
+Path C.** A payload stop with a place declaration seen and armed is **8/18
+(44%)** with A off and **11/17 (65%)** with A on. On 2026-08-26 that same class
+was **2/15 (13%)**. The survey's sequencing condition — do C "only if A + B
+leave contact-phase stops on the table" — is **met**: they do, and by a wider
+margin than the pre-Path-A reading suggested. Three of the A-on stops name
+`place:` geometry directly (`cab_1_left_group_main`, `sink_island_group_main`),
+a stop class that could not exist before #200 gave the kernel the declared
+target's bodies.
+
+**What this round does NOT establish, and one thing it takes back.** Task
+success was **5/20** on 2026-08-26 and is **1/20** here in both arms. Neither
+path predicts that and neither arm explains it; the commits differ by far more
+than #198/#200 and the rollouts diverge at the first stop, so the five runs of a
+scene are five independent trajectories with no paired geometry — `task_success_steps`
+differs on every one. **This battery is not evidence that A or B caused the
+drop, and it is not evidence that they did not.** It is a flag for a separate
+bisect, not a verdict. Everything here is one seed on one host, and the
+per-scene rates measure nothing broader.
+
 ## Standing caveats
 
 Eight things a reader should carry away, all of them stated by the artifacts


### PR DESCRIPTION
## What changed

An evidence-ledger entry for ten validation-matrix rounds on `aceeca6` — forty scene runs in two arms of twenty. The first battery since 2026-08-26, which predates both Path A (#198) and Path B (#200).

## Why two arms

**#198's graded band ships at `collision_scale_proximity_m = 0.0`, which disables it** — deliberately, per its own header ("a WG-gated enforcement surface and the A/B battery is what turns it on"). That is a design decision, not an oversight, but it has a consequence worth stating: **a battery run on master measures Path B alone**, and reading survey §10's "A + B" gate off the default arm alone would be measuring one path and naming two.

The second arm sets the band through the documented `OPENRAL_COLLISION_SCALE_PROXIMITY_M` seam at the same `0.05 m / k=20 / min=0.1` the #188 A/B used. `verdicts.json` records `collision_scale` per round, so which arm a round belongs to is a recorded fact.

## Results

| | A off (shipped default) | A on |
| --- | ---: | ---: |
| completed | 1/20 | 1/20 |
| deadline | 1 (`no-grasp`) | 2 (**both `after-grasp`**) |
| stops | 18 | 17 |
| — payload | 12 | **16** |
| — robot link | 6 | **1** |
| — vs the declared place target | 2 | 3 |
| — **payload**, with a live declaration | **8** | **11** |
| depth median | 3.47 mm | 6.59 mm |
| steps before the run ended, median | 336 | 486 |

**The gate §10 set for Path C is met.** A payload stop inside a live declaration is 8/18 (44 %) with the band off and 11/17 (65 %) with it on, against **2/15 (13 %)** on 2026-08-26. The class grew rather than shrank. Filed as #193, implemented in #210.

**Path A does what it claims and does not rescue completion.** The band is live in the second arm — 4 469 scaled republishes, floor 0.369 against the 0.37 its own source comment predicts — and moves the robot 45 % further before the run ends, nearly eliminating the link-vs-world class (6 → 1). But success is 1/20 in **both** arms: what it converts is stops into *timeouts*, and the two `deadline-after-grasp` outcomes are a class the off arm never produced. That cost is not in §10's Path A description and should be.

## What this does NOT establish

Task success was **5/20** on 2026-08-26 and is **1/20** here in both arms. Neither path predicts that and neither arm explains it; the commits differ by far more than #198/#200 and the rollouts share no paired geometry. **Recorded as a flag for a separate bisect, not attributed to either path.** One seed, one host.

## Correction included

Two verdicts in this round are adjudicator artifacts rather than findings — the `sink_cup` `panda_link5`↔`panda_link7` stop, which re-derives as `unadjudicated`. Root cause and fix are in #208; the replay shows the stop was genuinely correct. The 44 %/65 % figures count payload stops and are unaffected.

## How tested

Documentation only. Every figure was re-derived from the recorded `verdicts.json` artifacts before commit.

## Note for reviewers

Touches `docs/reference/collision-validation-evidence.md`, which #208 also edits. Expect a conflict there; both edits are additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)