### PR TITLE
test(safety): isolate the kernel lifecycle tests from every other DDS participant

### DIFF
--- a/cpp/openral_safety_kernel/README.md
+++ b/cpp/openral_safety_kernel/README.md
@@ -1023,6 +1023,18 @@ bundled here — see hazard-log Entry 025's open item.
 
 ## Testing & verification
 
+**The lifecycle tests isolate their own DDS process** (#222). `LifecycleKernelTest::SetUp`
+sets `ROS_AUTOMATIC_DISCOVERY_RANGE=OFF` before `rclcpp::init`, so no participant
+outside the test process — another test run, a second worktree, a live
+`openral deploy sim` — can reach the nodes under test. This is not hygiene: the
+kernel subscribes to `/openral/estop`, a global topic, and a concurrent sim on
+the default domain asserted an E-stop that latched the node under test and failed
+`StateUnavailableDropAndRecoveryPublishSafetyStatus` with a
+`DROP_EXTERNAL_ESTOP` the test never sent (19/20 on the shared domain with that
+sim live; 20/20 with discovery off). The fixture overwrites a caller's value on
+purpose. Debugging a test with external tools needs the opposite setting; do it
+locally, never by weakening the fixture.
+
 Three tiers, all driving the **real** `safety_kernel_node` (no mocks):
 
 - **C++ unit** (`just safety-kernel-test`) — `test_validator.cpp`,

--- a/cpp/openral_safety_kernel/test/test_lifecycle_kernel.cpp
+++ b/cpp/openral_safety_kernel/test/test_lifecycle_kernel.cpp
@@ -13,6 +13,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <future>
 #include <memory>
 #include <mutex>
@@ -44,7 +45,23 @@ namespace {
 
 class LifecycleKernelTest : public ::testing::Test {
 protected:
-  void SetUp() override { rclcpp::init(0, nullptr); }
+  void SetUp() override {
+    // Isolate this process from every other DDS participant on the host
+    // (#222). The kernel subscribes to `/openral/estop`, a global topic, and
+    // nothing else pins a domain: a concurrent `openral deploy sim` on the
+    // default domain asserted an E-stop and latched the node under test,
+    // failing `StateUnavailableDropAndRecoveryPublishSafetyStatus` with a
+    // `DROP_EXTERNAL_ESTOP` the test never sent. Measured 19/20 pass on the
+    // shared domain with that sim live, 20/20 with discovery off.
+    //
+    // OFF is stronger than a per-process ROS_DOMAIN_ID: every node these
+    // tests need lives in this process, and OFF removes the domain-uniqueness
+    // gamble entirely rather than shrinking it. Overwrites a caller's value
+    // on purpose — a test that can be contaminated by the environment is the
+    // defect, not the environment.
+    setenv("ROS_AUTOMATIC_DISCOVERY_RANGE", "OFF", 1);
+    rclcpp::init(0, nullptr);
+  }
   void TearDown() override { rclcpp::shutdown(); }
 
   /// Minimal envelope parameter overrides for a 3-DoF toy robot. Mirrors


### PR DESCRIPTION
Closes #222.

## What looked like a flake was a live sim E-stopping the node under test

`StateUnavailableDropAndRecoveryPublishSafetyStatus` failed once on clean `master` with what read as a corrupted byte:

```
Which is: 'j' (106, 0x6A)
Which is: '\xFF' (255)
```

**106 is `DROP_EXTERNAL_ESTOP`**, a legitimate code — gtest printed the `uint8` as a char. The run's own log says why:

```
[WARN] [kernel_status_unavail]: safety.external_estop_received: latching kernel
```

The kernel under test received a real external E-stop. **The test never sends one.**

**Where it came from.** The kernel subscribes to `/openral/estop`, a global un-namespaced topic. The fixture's `SetUp` was a bare `rclcpp::init`, and nothing in CMake or CI pins a domain. A concurrent `openral deploy sim` on this host — kernel, HAL, Nav2, the human-E-stop node — was on the same default domain. When it asserted an E-stop, every kernel on the domain latched, including mine. I had run the test in isolation, one process per run, so it cannot be another test in the binary.

## Measured, not inferred

Same binary, one test per process, 20 runs each, sim live throughout:

| environment | pass | fail | crash |
| --- | ---: | ---: | ---: |
| domain 0, shared (as shipped) | 19 | 1 | **1 segfault** |
| `ROS_DOMAIN_ID=87` + `ROS_LOCALHOST_ONLY=1` | 20 | 0 | 0 |
| `ROS_AUTOMATIC_DISCOVERY_RANGE=OFF` on domain 0 | **20** | **0** | **0** |

Zero runs in either isolated configuration saw an external E-stop.

## The fix

`LifecycleKernelTest::SetUp` sets `ROS_AUTOMATIC_DISCOVERY_RANGE=OFF` before `rclcpp::init`.

**Why OFF rather than a per-process domain id.** Every node these tests need lives in one process, and OFF — verified empirically, same-process pub/sub still works under it — removes the domain-uniqueness gamble entirely instead of shrinking it to one-in-a-hundred. A per-process `ROS_DOMAIN_ID` would still collide if two test processes happened to pick the same number.

**It overwrites a caller's value on purpose.** A test that the environment can contaminate is the defect, not the environment. Debugging a test with external tools needs the opposite setting; the README now says to do that locally, never by weakening the fixture.

## Verified end to end

The **full 40-test binary**, run three times on the shared domain with the sim still live and **no env vars from the shell** — the fixture has to do it alone: **3/3 pass, 0 crash.** The `external_estop_received` lines that remain in those logs are from the three tests that publish `/openral/estop` themselves (`ExternalEstopLatchesStatusAndResetClearsIt`, `LateSubscriberReceivesTheLatchedSafetyStatus`, `ResetServiceRespectsCooldown`) — attributed by name, not assumed. All four kernel binaries pass under `ctest`.

## Not established

The segfault did not reproduce in either isolated configuration. That is consistent with a teardown race under foreign-participant discovery, but there is one sample and no backtrace — "did not reproduce," not "was caused by."

## Scope

`test_lifecycle_kernel.cpp` is the only `rclcpp` fixture under `cpp/`, and nothing else in the tree sets either variable. Two files, no kernel code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uGhzhAromBsMtXa9to2yy