### PR TITLE
fix(test): skip the tight-geometry check when trimesh is absent, don't error

### DIFF
--- a/tests/unit/test_collision_tight_geometry.py
+++ b/tests/unit/test_collision_tight_geometry.py
@@ -221,6 +221,14 @@ def test_the_declared_geometry_reproduces_from_the_mesh(panda: RobotDescription)
     remembering to invoke it.
     """
     gen = _mesh_tools()
+    # Only THIS test reaches the generator's `check` path, which is the one
+    # that imports trimesh (`generate_tight_geometry._mesh_outside_dop_mm`).
+    # Guarded here rather than in `_mesh_tools` so the four containment tests
+    # that need no mesh loader keep running on a host without the `lowering`
+    # group. Without it the whole test errors with a bare ModuleNotFoundError
+    # instead of skipping, which CLAUDE.md §1.11 asks for on an unavailable
+    # dependency -- and it does so only off-CI, where the group is installed.
+    pytest.importorskip("trimesh", reason="trimesh loads the URDF collision meshes")
     for manifest in (PANDA_MANIFEST, VSLAM_MANIFEST):
         assert gen.main(["check", "--robot", str(manifest)]) == 0, manifest
 


### PR DESCRIPTION
## What changed

`tests/unit/test_collision_tight_geometry.py::test_the_declared_geometry_reproduces_from_the_mesh` now `importorskip`s `trimesh`.

## Why

`_mesh_tools()` already guards `numpy`, `mujoco`, `robosuite` and `scipy`. It does not guard `trimesh`, which `tools/generate_tight_geometry.py::_mesh_outside_dop_mm` imports on the `check` path that this test drives. `trimesh` lives in the optional `lowering` dependency group, so on a host without that group the test dies with a bare

```
ModuleNotFoundError: No module named 'trimesh'
```

instead of skipping — which is what CLAUDE.md §1.11 asks for on an unavailable dependency ("Unavailable dependency → `pytest.skip(reason=...)`, never faked"). `_mesh_tools()`'s own docstring already states the intent: *"Import the generator + its mesh dependencies, or skip."*

It is invisible on CI, where the group is installed, so it surfaces only as a failing local suite that reads like a broken checkout. Found while running `tests/unit/` on a worktree synced to the `robocasa` group.

## Why in the test and not in `_mesh_tools()`

Only this test reaches the generator's `check` path. Guarding the shared helper would also skip the four containment tests that need no mesh loader (`..._inside_every_declared_dop`, `..._inside_every_declared_hull`, `..._tightening_is_real_and_measured`, and the manifest-boundary cases), losing real coverage on exactly the hosts this fix is for.

## How tested

Verified in both directions, because a guard that always skips is worse than the error it replaces:

| condition | result |
| --- | --- |
| without `trimesh` | **14 passed, 1 skipped** — `SKIPPED [1] ...:231: trimesh loads the URDF collision meshes` |
| with `trimesh` (`uv run --with trimesh`) | the test still **runs and passes**, 117 s |

`ruff format` + `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ME3kZxwnAFJX2acjJmoKi8