### PR TITLE
test(sim): make the RoboCasa suite an enforceable list

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -328,6 +328,22 @@ test-integration:
 test-ros-live *args:
     uv run bash scripts/ros_live_tests.sh -q {{args}}
 
+# The RoboCasa sim suite — the seven tests gated on a provisioned RoboCasa
+# kitchen backend. Needs the colcon overlay AND the 23 GB asset set, which is
+# why it has no CI lane at all (see scripts/robocasa_sim_tests.sh: hosted
+# runners lack the disk, and a self-hosted runner is not safe on a public
+# repo). No GPU. Narrow a busy machine with `-k`; extra args are appended, so
+# naming a path adds it to the list rather than selecting it.
+#
+#   source /opt/ros/jazzy/setup.bash && just ros2-build \
+#     && source install/setup.bash && just test-robocasa-sim
+#
+# A fresh venv may lack robocasa even after `just sync`; provision it with
+#   OPENRAL_AUTO_INSTALL_DEPS=1 uv run --no-sync python -c \
+#     "from openral_sim._deps import ensure_backend_deps; ensure_backend_deps('robocasa_kitchen')"
+test-robocasa-sim *args:
+    uv run bash scripts/robocasa_sim_tests.sh -q {{args}}
+
 # Subset by keyword
 # `-p no:launch_testing -p no:launch_ros`: same ROS-env workaround as
 # `just test` — the launch_testing pytest plugin silently aborts

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -187,6 +187,78 @@ publish — is deliberately excluded: it also needs PyGObject, which the open
 deploy image does not ship (the GStreamer media stack is OpenRAL Pro). `just
 test` runs it on a host that has the `gstreamer` extra installed.
 
+#### The RoboCasa sim suite (manual — there is no CI lane, and there cannot be)
+
+Seven tests under `tests/sim/` are gated on `importorskip("robocasa")` and need
+three things at once: the colcon overlay (they spawn the real
+`safety_kernel_node`), MuJoCo, and a provisioned RoboCasa kitchen backend. They
+are the geometry-and-kernel evidence behind issues #102 and #108 — the layout
+pins, the certified distance instrument, the support-contact witness, the depth
+synth, and the HAL's camera / body-twist paths on a real kitchen.
+
+`scripts/robocasa_sim_tests.sh` holds the target list, and `just
+test-robocasa-sim` is its only caller:
+
+```bash
+source /opt/ros/jazzy/setup.bash && just ros2-build \
+  && source install/setup.bash && just test-robocasa-sim
+```
+
+A fresh venv may lack `robocasa` even after `just sync`. Provision it with:
+
+```bash
+OPENRAL_AUTO_INSTALL_DEPS=1 uv run --no-sync python -c \
+  "from openral_sim._deps import ensure_backend_deps; ensure_backend_deps('robocasa_kitchen')"
+```
+
+Run the suite before merging anything that touches the kernel, the
+`panda_mobile` manifest, the HAL sim bridge, or a `scenes/deploy/robocasa_*.yaml`
+pin. Narrow it with `-k` on a busy machine — a kitchen compose is memory-hungry
+and the whole suite in one pytest process has OOM-killed a 15 GB host. Extra
+args are appended to the pytest invocation, so naming a path *adds* it to the
+target list rather than selecting it: use `just test-robocasa-sim -k
+geom_distance`.
+
+**Why there is no CI lane.** Two independent reasons, both measured.
+
+*Disk.* RoboCasa's assets are 23 GB — `objects/aigen_objs` 13 GB,
+`objects/objaverse` 6.2 GB, `objects/lightwheel` 1.5 GB, `fixtures` 1.4 GB,
+`generative_textures` 1.2 GB, `textures` 521 MB — downloaded per-bundle from
+utexas.box.com with no sub-bundle granularity. The only hosted CI surface with
+a colcon overlay is the `docker-build` image, already 25.2 GB, building on a
+runner that has to `rm -rf` dotnet, android and CodeQL to reclaim its ~14 GB.
+Even a trimmed set (fixtures + textures + one object bundle, ~8 GB) is past
+that runner's whole disk. No GPU is needed, so the constraint is disk alone.
+
+*Security.* A self-hosted runner was built, registered, and then removed. It is
+not a safe option for this repository, and the reasoning is worth keeping
+because it is easy to get wrong: **a runner label is a routing request made by
+a workflow, not an access control enforced by the runner.** A repository-scoped
+self-hosted runner accepts jobs from *any* workflow in that repository naming
+its labels, and for a `pull_request` event GitHub executes the workflow
+definition from the **fork's** ref. `OpenRAL/openral` is public and has three
+fork-reachable `pull_request` workflows (`dco.yml`, `quality.yml`,
+`test-selective.yml`), so a fork PR can edit one to
+`runs-on: [self-hosted, <label>]` with arbitrary `run:` steps and execute code
+on the runner host — with that user's SSH keys, `gh` credentials and LAN access
+to the lab robots. Restricting a runner to selected workflows requires an
+organisation runner group, which this org's GitHub Free plan does not offer, so
+no native control makes the label mean anything.
+
+Note what does *not* help: giving the protected workflow safe triggers. The
+exposed asset is the runner, not the workflow. Reasoning about the triggers of
+the file you are adding is the mistake that makes this look safe.
+
+**What holds the suite together instead.** `tests/unit/test_robocasa_sim_targets.py`
+fails the unit suite if a RoboCasa-gated file is missing from `TARGETS`. With no
+CI lane, that list is the only definition of what the suite is, and that guard
+is the only thing that notices when a test drifts out of it — which is exactly
+what happened to `test_kernel_fridge_layout_pin_start_state.py` between #224 and
+#232.
+
+The rest of `tests/sim/` is manual by declared policy
+(`.github/workflows/test-selective.yml`).
+
 ### Sim evals (closed-loop, opt-in — needs HF weights ± GPU)
 
 ```bash

--- a/scripts/robocasa_sim_tests.sh
+++ b/scripts/robocasa_sim_tests.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# The RoboCasa sim suite — the one list that defines what it is.
+#
+# `just test-robocasa-sim` execs this file. There is no second caller, because
+# there is no CI lane: this suite runs on a developer host or it does not run.
+# That is a measured conclusion, not an omission, and it is written down here
+# so nobody re-derives it.
+#
+# WHY THERE IS NO CI LANE
+# -----------------------
+# These tests need three things at once: a colcon-built overlay (they spawn the
+# real `safety_kernel_node`), MuJoCo, and a provisioned RoboCasa kitchen
+# backend.
+#
+# The third rules out every GitHub-hosted runner. RoboCasa's assets are 23 GB
+# on disk — `objects/aigen_objs` 13 GB, `objects/objaverse` 6.2 GB,
+# `objects/lightwheel` 1.5 GB, `fixtures` 1.4 GB, `generative_textures` 1.2 GB,
+# `textures` 521 MB — downloaded per-bundle from utexas.box.com with no
+# sub-bundle granularity. The only hosted surface with a colcon overlay is the
+# `docker-build` image, already 25.2 GB, building on a runner that has to
+# `rm -rf` dotnet, android and CodeQL to reclaim its ~14 GB. Even a trimmed set
+# (fixtures + textures + one object bundle, ~8 GB) is past that runner's whole
+# disk. No GPU is needed, so the constraint is disk and nothing else.
+#
+# A self-hosted runner was built, registered and then REMOVED on security
+# grounds. `OpenRAL/openral` is a PUBLIC repository, and a runner label is a
+# routing request made by a workflow, not an access control enforced by the
+# runner: a repo-scoped runner accepts jobs from ANY workflow in the repo that
+# names its labels, and for a `pull_request` event GitHub executes the workflow
+# definition from the FORK's ref. This repo has three fork-reachable
+# `pull_request` workflows (`dco.yml`, `quality.yml`, `test-selective.yml`), so
+# a fork PR can simply edit one to `runs-on: [self-hosted, <label>]` and run
+# arbitrary code on the runner host — with that user's SSH keys, `gh`
+# credentials and LAN access to the lab robots. Restricting a runner to
+# selected workflows requires an organisation runner group, which this org's
+# GitHub Free plan does not provide, so there is no native control that makes
+# the label mean anything. The trigger config of the workflow being protected
+# is irrelevant: the exposed asset is the runner, not the workflow.
+#
+# So the suite is manual, `tests/unit/test_robocasa_sim_targets.py` is what
+# keeps this list honest, and the rest of `tests/sim/` is manual by declared
+# policy anyway (`.github/workflows/test-selective.yml`).
+#
+#   source /opt/ros/jazzy/setup.bash && just ros2-build \
+#     && source install/setup.bash && just test-robocasa-sim
+#
+# Run it before merging anything that touches the kernel, the panda_mobile
+# manifest, the HAL sim bridge, or a `scenes/deploy/robocasa_*.yaml` pin.
+#
+# MEMORY: a RoboCasa kitchen compose is heavy. The whole suite in one pytest
+# process OOM-killed a 15 GB host that was also running an editor and a
+# browser. Narrow it with `-k` when the machine is busy — extra args are
+# appended to the pytest invocation, so naming a path ADDS it to TARGETS
+# rather than selecting it:
+#   just test-robocasa-sim -k geom_distance
+#
+# NOT in TARGETS: anything needing HF weights or a GPU. This list is geometry
+# and kernel behaviour against a real kitchen.
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+TARGETS=(
+    # Issue #102's third acceptance item, both halves. The shipped
+    # `layout_ids: [47]` pin (#224) and the genuinely colliding pose at zero
+    # margin (#232) — the only place the kernel is shown refusing a real
+    # kitchen at its deployed standoff for a certified real reason.
+    tests/sim/safety/test_kernel_fridge_layout_pin_start_state.py
+    # The instrument the census and every adjudicated round depend on.
+    # `mj_geomDistance` is wrong on exactly this pair class under mujoco 3.8.0
+    # (+0.000 mm against a certified +0.148512 mm; -352 mm through a 48 mm
+    # panel), so this pins `openral_hal.convex_distance` on the census's own
+    # layout-9 state. If it regresses, every distance in the ledger is suspect.
+    tests/sim/safety/test_geom_distance_instrument_robocasa.py
+    # The support-contact witness against a real kitchen — the ADR-0092 D6
+    # attestation whose failure direction is a MISSING exemption.
+    tests/sim/safety/test_support_probe_instrument_robocasa.py
+    # The depth synth's multi-ray path against a real kitchen, which is what
+    # turns camera returns into the occupancy the kernel gates on.
+    tests/sim/safety/test_depth_multiray_equivalence_robocasa.py
+    # The HAL's side of the same kitchen: camera streams, BODY_TWIST on a
+    # translating base, and the layout pins the scenes ship.
+    tests/sim/test_panda_mobile_hal_robocasa_cameras.py
+    tests/sim/test_panda_mobile_hal_robocasa_body_twist.py
+    tests/sim/test_panda_mobile_hal_robocasa_layout_pin.py
+)
+# tests/unit/test_robocasa_sim_targets.py asserts every file gated on
+# `importorskip("robocasa")` appears above — a gated test missing from this
+# list runs on NO CI surface.
+
+exec python -m pytest "${TARGETS[@]}" "$@"

--- a/tests/sim/conftest.py
+++ b/tests/sim/conftest.py
@@ -3,6 +3,11 @@
 Pre-stubs the broken ``lerobot.policies.groot.modeling_groot`` module before
 any test imports ``lerobot.policies``. See ``openral_rskill._lerobot_compat``.
 
+Also pins every sim test to its own DDS domain — see the module-level
+``os.environ`` block below for why that is a correctness requirement here and
+not merely hygiene, and for the one neighbouring setting that must NOT be
+added alongside it.
+
 Also exposes :func:`compose_sim_env` — the test-side equivalent of
 ``openral sim run``'s ``_load_or_build_env`` helper. The on-disk YAMLs under
 ``scenes/sim/`` and ``scenes/benchmark/`` are :class:`SimScene` /
@@ -15,9 +20,51 @@ must compose the same way the CLI does. ``load_scene_strict`` accepts a
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import openral_rskill._lerobot_compat  # noqa: F401
+
+from tests.sim.safety._kernel_subprocess import isolated_domain_id
+
+# Confine every sim test to its own DDS graph, before any test module imports
+# rclpy — pytest loads this conftest first, which is the only moment early
+# enough to matter.
+#
+# This is a CORRECTNESS requirement, not hygiene. A sim test that inherits the
+# default domain sees every other ROS process on the host and, with domain 0's
+# subnet multicast, on the network: another worktree's leftover nodes, a live
+# `openral deploy sim`, a real robot. `SimSensorBridge` reads the graph to make
+# decisions — `_on_attachment_state_applied` arms its voxel-update wait from
+# `count_publishers("/openral/world_voxels")` — so a foreign publisher does not
+# merely add noise, it changes the verdict. Measured on `q-laptop`:
+# `test_bridge_masks_multiple_attached_objects_without_reset` failed against
+# seven orphaned `octomap_voxel_bridge` graphs left by another worktree, and
+# passed on domains 91 and 92, because the barrier waited for a voxel update
+# that only the foreign publisher could have sent.
+#
+# It lives here rather than in that test because every OTHER rclpy-using sim
+# test already isolates itself through `start_kernel`, and it was the single
+# file that did not. One place, and a file added tomorrow cannot repeat it.
+#
+# `setdefault` keeps the operator's own export authoritative — the same posture
+# `openral_cli._dds_scope.confine_sim_scope` and
+# `packages/openral_safety_watchdog/test/conftest.py` take. `isolated_domain_id`
+# is per-PID, so concurrent pytest runs do not collide either; it is imported
+# from the kernel helpers because that is where the convention already lives.
+#
+# The domain, and ONLY the domain. Do not also set
+# `ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST` here, however tempting the symmetry
+# with `confine_sim_scope` is: it was tried and it HANGS every
+# kernel-subprocess test. `start_kernel` spawns `safety_kernel_node` as a
+# separate process that the in-process test node has to discover, and under
+# that range the two never find each other — measured as
+# `test_kernel_fridge_layout_pin_start_state.py` blocked past 20 minutes at
+# ~93% idle CPU with no kernel process alive, against 91 s with the domain
+# alone. `confine_sim_scope` can set it because it launches a whole graph into
+# one environment; this conftest cannot, because it straddles a process
+# boundary the launcher does not own.
+os.environ.setdefault("ROS_DOMAIN_ID", str(isolated_domain_id()))
 from openral_core import (
     BenchmarkMetadata,
     SimEnvironment,

--- a/tests/unit/test_robocasa_sim_targets.py
+++ b/tests/unit/test_robocasa_sim_targets.py
@@ -1,0 +1,73 @@
+"""Guard: every RoboCasa-gated sim test is listed in robocasa_sim_tests.sh.
+
+The RoboCasa suite has **no CI surface and cannot be given one** — see
+``scripts/robocasa_sim_tests.sh`` for the asset arithmetic and for why a
+self-hosted runner was evaluated and rejected. That makes
+``scripts/robocasa_sim_tests.sh`` the only definition of what the suite *is*,
+and this test the only thing keeping it honest: a gated file missing from
+TARGETS is a test nobody will ever run again, and nothing else would say so.
+
+That is not hypothetical. ``test_kernel_fridge_layout_pin_start_state.py`` was
+added by #224 and sat outside any list until #232 went looking, which is how
+the gap was found at all.
+
+Sibling of :mod:`tests.unit.test_ros_live_targets`, same reasoning, different
+suite — except that one guards a list with a CI lane behind it and this one
+guards a list with only a human behind it, which makes it matter more, not
+less.
+
+Run with:
+    uv run pytest tests/unit/test_robocasa_sim_targets.py -v
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "robocasa_sim_tests.sh"
+_SIM = _REPO_ROOT / "tests" / "sim"
+
+#: The gate every RoboCasa test carries. robocasa (robosuite >=1.5) and libero
+#: (robosuite 1.4) are mutually exclusive dependency groups, so the backend is
+#: never merely optional — it is either provisioned or the test skips.
+_GATE = 'importorskip("robocasa")'
+
+
+def _script_targets() -> set[str]:
+    """The repo-relative paths inside the TARGETS=( … ) block."""
+    body = _SCRIPT.read_text(encoding="utf-8")
+    # Anchor the closing paren to its own line so a parenthesis inside an
+    # array comment can never truncate the parse.
+    block = re.search(r"TARGETS=\((.*?)^\)$", body, flags=re.DOTALL | re.MULTILINE)
+    assert block is not None, f"no TARGETS=() block in {_SCRIPT}"
+    return {
+        stripped
+        for line in block.group(1).splitlines()
+        if (stripped := line.strip()) and not stripped.startswith("#")
+    }
+
+
+def _gated_tests() -> set[str]:
+    """Every RoboCasa-gated test file under ``tests/sim/``, repo-relative."""
+    return {
+        str(path.relative_to(_REPO_ROOT))
+        for path in _SIM.rglob("test_*.py")
+        if _GATE in path.read_text(encoding="utf-8")
+    }
+
+
+def test_every_robocasa_gated_sim_test_is_in_targets() -> None:
+    gated = _gated_tests()
+    assert gated, f"no {_GATE} tests found under tests/sim/ — glob or gate string moved?"
+    missing = gated - _script_targets()
+    assert not missing, (
+        f"RoboCasa-gated tests missing from {_SCRIPT.relative_to(_REPO_ROOT)} TARGETS "
+        f"(they will run on NO CI surface): {sorted(missing)}"
+    )
+
+
+def test_targets_only_lists_files_that_exist() -> None:
+    stale = {t for t in _script_targets() if not (_REPO_ROOT / t).exists()}
+    assert not stale, f"TARGETS lists files that do not exist: {sorted(stale)}"


### PR DESCRIPTION
Two commits, the `fix` first per CLAUDE.md §1.15. Found while answering "does anything currently break?" after #232 — the answer turned out to be yes, and for a reason worth writing down.

## 1. `fix(sim)`: pin every sim test to its own DDS domain

`test_panda_mobile_hal_robocasa_cameras.py::test_bridge_masks_multiple_attached_objects_without_reset` **fails on `master`** on any host where something else is publishing `/openral/world_voxels`. It was failing on `q-laptop`, which had seven orphaned `octomap_voxel_bridge` graphs left over from another worktree, the oldest ~13 hours.

**It is not noise — it changes the verdict.** `SimSensorBridge` reads the graph to decide: `_on_attachment_state_applied` arms its voxel-update wait from `count_publishers("/openral/world_voxels") > 0` (`sim_sensor_bridge.py:3072`), so a foreign publisher makes the attachment barrier wait for an update only *that* publisher could send, and `attachment_action_ack_ready()` never goes true.

| domain | result |
| --- | --- |
| inherited (0, with the strays) | **failed** |
| 91 | passed |
| 92 | passed |

**Why the fix is in `tests/sim/conftest.py` and not in that file.** Every other rclpy-using test under `tests/sim/` already isolates itself — all fifteen kernel twins go through `start_kernel`, which sets `ROS_DOMAIN_ID` from `isolated_domain_id()`. This one file was the only exception. Putting it in the shared conftest means one place, evaluated before any test module imports rclpy, and a file added tomorrow cannot repeat the omission. `setdefault` keeps an operator's own export authoritative, matching `openral_cli._dds_scope.confine_sim_scope`.

**The domain, and only the domain.** Setting `ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST` alongside it — the obvious symmetry with `confine_sim_scope` — **hangs every kernel-subprocess test**. `start_kernel` spawns `safety_kernel_node` as a separate process the in-process test node must discover, and under that range they never find each other: measured at **>20 minutes blocked at ~93% idle CPU with no kernel process alive**, against 91 s with the domain alone. I tried it, it broke, I removed it, and the conftest records the measurement so it does not get re-added for symmetry's sake.

## 2. `test(sim)`: make the RoboCasa suite an enforceable list

Seven tests under `tests/sim/` are gated on `importorskip("robocasa")` and run on no CI surface. #232 went looking for one and found the gap is structural. **This does not fix that** — it makes the suite a defined thing a human can run and a guard can police, which is the most that is available.

- `scripts/robocasa_sim_tests.sh` — the target list, plus the written record of why there is no lane behind it
- `tests/unit/test_robocasa_sim_targets.py` — fails the unit suite when a gated file drifts out of that list
- `Justfile` — `just test-robocasa-sim`
- `docs/contributing/development.md` — how to run it, and both reasons it is manual

### Why no CI lane — two independent reasons, both measured

**Disk.** RoboCasa's assets are 23 GB:

| bundle | size |
| --- | ---: |
| `objects/aigen_objs` | 13 GB |
| `objects/objaverse` | 6.2 GB |
| `objects/lightwheel` | 1.5 GB |
| `fixtures` | 1.4 GB |
| `generative_textures` | 1.2 GB |
| `textures` | 521 MB |

Per-bundle from utexas.box.com with no sub-bundle granularity. The only hosted surface with a colcon overlay is the `docker-build` image, already 25.2 GB, on a runner that must `rm -rf` dotnet, android and CodeQL to reclaim its ~14 GB. A trimmed set (fixtures + textures + one object bundle) is still ~8 GB. No GPU is needed — the constraint is disk alone.

**Security.** A self-hosted lane *was* built in this branch and the runner registered on `q-laptop`; both were removed after review, and the runner is unregistered. The reasoning is kept in the script and docs because it is easy to get wrong:

> **A runner label is a routing request made by a workflow, not an access control enforced by the runner.**

A repository-scoped self-hosted runner accepts jobs from *any* workflow in the repo naming its labels, and a `pull_request` event executes the workflow definition from the **fork's** ref. `OpenRAL/openral` is public and has three fork-reachable `pull_request` workflows (`dco.yml`, `quality.yml`, `test-selective.yml`), so a fork PR can retarget one at the runner and run arbitrary code as the runner's user — SSH keys, `gh` credentials, LAN access to the lab robots. Fork-PR approval is set to `first_time_contributors`, so a returning contributor needs no approval at all. Restricting a runner to selected workflows requires an organisation runner group, which this org's **GitHub Free** plan does not offer.

Giving the *new* workflow safe triggers does not help, and believing it did was the error: the exposed asset is the runner, not the workflow.

## How tested

The full RoboCasa suite on `q-laptop`, one pytest process per file, **31 passed** — and re-verified after the conftest fix with `env -u ROS_DOMAIN_ID` while the offending publishers were still live on domain 0:

| file | result |
| --- | --- |
| `test_depth_multiray_equivalence_robocasa.py` | 8 passed |
| `test_geom_distance_instrument_robocasa.py` | 4 passed |
| `test_kernel_fridge_layout_pin_start_state.py` | 5 passed (91 s) |
| `test_support_probe_instrument_robocasa.py` | 5 passed |
| `test_panda_mobile_hal_robocasa_cameras.py` | 3 passed *(was 1 failed, 2 passed)* |
| `test_panda_mobile_hal_robocasa_body_twist.py` | 2 passed |
| `test_panda_mobile_hal_robocasa_layout_pin.py` | 4 passed |

Guards: `test_robocasa_sim_targets.py`, `test_ros_live_targets.py`, `test_dds_scope_guard.py` — 16 passed. `ruff check` and `ruff format --check` clean.

Note the fridge run is what proves the conftest change does not disturb the subprocess path, and the camera run is what proves it fixes the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTE4eEfxW8FvvBnPZL6otg
