### PR TITLE
fix(sim): size #217's bisect before running it, and test the shortcut

### DIFF
--- a/docs/methods/10-tools.md
+++ b/docs/methods/10-tools.md
@@ -204,6 +204,14 @@ _Package and publish a local rSkill directory to the HF Hub._
 - `_publish(skill_dir, manifest, token, *, public=False) -> str` — Create the HF repo (private unless `public`) and upload; runs the matching visibility gate (`_ensure_public` / `_ensure_private`) after `create_repo`.
 - `main() -> None` — Entry point. Sequence: parse args (`--publish` / `--public` / `--bump-revision` / `--fix-name` / `--token`) → validate manifest → `_enforce_repo_name` (exit 1 on a non-compliant VLA name unless `--fix-name`) → validate task space → validate docs → `public_visibility_error` gate (exit 1 if `--public` on a non-commercial skill) → exit 1 on doc errors → optional `--bump-revision` → `--publish` (private unless `--public`).
 
+### `tools/round_power.py`
+_Answers "how many validation-matrix runs does this comparison need?" **before** a battery is run — [#217](https://github.com/OpenRAL/openral/issues/217) step 1. Exists because the programme has twice drawn a conclusion a battery could not support: the n=1 reading on #176, and the 20-run success comparison #217 was opened to settle, which had under 30 % power against the very effect it observed. Exact (every outcome pair enumerated, not sampled) so the answer is reproducible on any host, and stdlib-only so scipy stays out of the workspace for a planning script; validated against `scipy.stats.fisher_exact` on 300 random 2×2 tables. Feeds the 2026-09-05 entry in [`docs/reference/collision-validation-evidence.md`](../reference/collision-validation-evidence.md)._
+
+- `RUNS_PER_ROUND = 4` — Scene runs in one matrix round, so `required()` can report rounds as well as runs. (L53)
+- `fisher_exact_two_sided(a, n1, b, n2) -> float` — Two-sided Fisher p-value for `a`/`n1` against `b`/`n2`; the "no more probable" tail convention `scipy.stats.fisher_exact` uses. (L60)
+- `power(baseline, alternative, n, *, alpha=0.05) -> float` — Exact power at `n` per arm: enumerates every `(a, b)` under the two binomials and sums the probability of the pairs Fisher rejects. `O(n²)` Fisher evaluations, so sub-second to n=100 and a few seconds by n=300. (L98)
+- `required(baseline, alternative, *, alpha=0.05, target=0.80) -> tuple[int | None, float]` — Smallest ladder `n` per arm reaching `target` power, or `(None, best)` when the ladder tops out at 800 — a comparison needing more than that is not one this programme can afford, and saying so is the useful answer. (L133)
+
 ### `tools/rskill_scaffolder.py`
 _Standalone argparse wrapper around `openral_cli._rskill_scaffolder.scaffold_rskill`._
 Mirrors `openral rskill new`; exists so power users can scaffold without installing the CLI distribution.

--- a/docs/reference/collision-validation-evidence.md
+++ b/docs/reference/collision-validation-evidence.md
@@ -1508,6 +1508,86 @@ holds the nominal-valid side on a real kitchen, so the second scene would cost
 another compose and grid build for a weaker marginal claim.
 
 
+### 2026-09-05 — how many rounds #217 actually needs, and why stop class does not shortcut it
+
+Not a validation round: an offline analysis of rounds already recorded, which is
+[#217](https://github.com/OpenRAL/openral/issues/217) step 1 ("Power first.
+Decide the round count from the effect size worth detecting **before running
+anything**") and a first pass at step 2 ("bisect by stop class, not by success
+rate"). No GPU, no new rounds. Tool: `tools/round_power.py`.
+
+**The 20-run battery could not have separated its own effect.** Exact power for
+two-sided Fisher, 20 runs per arm:
+
+| effect | power at n=20/arm |
+| --- | ---: |
+| 25 % → 5 % (the drop actually observed) | **0.30** |
+| 25 % → 10 % | 0.14 |
+| 25 % → 2 % | 0.45 |
+
+So "5/20 vs 1/20, p = 0.18, not separable" is the arithmetic working correctly
+on a sample that had under a one-in-three chance of separating anything. It is
+not evidence of no regression, and — the operative point — **re-running the same
+20 against 20 would answer nothing again.**
+
+**What it would take.** Runs per arm for 80 % power at α = 0.05, and the
+wall-clock those imply at this battery's own measured 9.1 min per four-scene
+round (mean over the ten post-#200 rounds, range 4.5–15.2):
+
+| effect worth detecting | runs/arm | rounds/arm | both arms, wall |
+| --- | ---: | ---: | ---: |
+| 25 % → 5 % | 60 | 15 | **4.5 h** |
+| 25 % → 10 % | 120 | 30 | 9.1 h |
+| 25 % → 15 % | 320 | 80 | 24.2 h |
+
+4.5 h is affordable and is the number to plan the bisect against. A 10-point
+drop is not, on this host, and that is worth knowing before anyone promises to
+detect one.
+
+**Stop class does not rescue the comparison, which was the hopeful part of the
+plan.** Aggregating the ten post-#200 rounds by tripping party and comparing
+against the 2026-08-26 battery's own stop table (above):
+
+| battery | payload stops | link stops | payload share |
+| --- | ---: | ---: | ---: |
+| 2026-08-26 | 6 | 9 | 40 % |
+| 2026-09-04, Path A **off** (shipped) | 12 | 6 | 67 % |
+| 2026-09-04, Path A **on** | 16 | 1 | 94 % |
+
+| contrast | Fisher p |
+| --- | ---: |
+| 08-26 vs Path A **off** — tripping party | **0.17** |
+| 08-26 vs Path A **off** — success rate | 0.18 |
+| 08-26 vs Path A **on** — tripping party | 0.0017 |
+| 08-26 vs both arms pooled — tripping party | 0.0087 |
+
+**For the arm that matters, stop class is no more separable than success was**
+— 0.17 against 0.18. The one decisively separable contrast is Path A *on*, and
+that is confounded by Path A's own already-documented effect (#209 records the
+link class going 6 → 1 within this battery), so it measures Path A rather than
+whatever moved between the batteries. Stop class needs about the same n as
+success does: 40 % → 67 % reaches 80 % power at **60 stops per arm**, and the
+arms here hold 15 and 18.
+
+The verdict mix, by contrast, barely moved — 11 `within-quantization` in all
+three batteries, 2–3 `real`, 1 `false-positive`, 1–3 `unadjudicated` — so what
+shifted is *who trips*, not how the adjudicator scores it.
+
+**A caveat that limits every 08-26 comparison, including #217's own table.**
+The 2026-08-26 entry does not record which rSkill it ran, and its artifacts are
+gone (`outputs/` is gitignored), so its stop counts here are read off the table
+in this ledger rather than recomputed. The post-#200 rounds record
+`OpenRAL/rskill-xr1-panda_mobile-robocasa365-nf4` in every `verdicts.json`.
+**Policy invariance across this comparison therefore cannot be verified from the
+record** — a policy change between the batteries would move both success and
+stop class, and nothing checked in rules that out. Future entries should name
+the rSkill; the harness already writes it.
+
+**What this means for the #204 A/B now running on `spark`.** At 20 runs per arm
+it will land in the same place as this one. Size it from the table above, or
+accept in advance that it can only report a null.
+
+
 ## Standing caveats
 
 Nine things a reader should carry away, all of them stated by the artifacts

--- a/tests/unit/test_round_power.py
+++ b/tests/unit/test_round_power.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``tools/round_power.py`` computes Fisher and power correctly.
+
+The tool's whole purpose is to stop a battery being run at a size that cannot
+answer its own question (#217), so a wrong number here is worse than no tool:
+it would licence exactly the underpowered round it exists to prevent. These
+pin the arithmetic against values that can be checked independently.
+
+The reference values come from ``scipy.stats.fisher_exact``, which the
+implementation was validated against on 300 random 2x2 tables (all matched to
+1e-9). scipy is deliberately NOT a workspace dependency — it is a heavy import
+for a planning script — so the checked values are inlined here rather than
+recomputed at test time.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_TOOL = Path(__file__).resolve().parents[2] / "tools" / "round_power.py"
+
+
+def _load() -> ModuleType:
+    """Import the tool by path — ``tools/`` is scripts, not an installed package."""
+    spec = importlib.util.spec_from_file_location("round_power", _TOOL)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+round_power = _load()
+
+
+@pytest.mark.parametrize(
+    ("a", "n1", "b", "n2", "expected"),
+    [
+        # The comparison #217 exists to settle: 2026-08-26 against the
+        # 2026-09-04 post-#200 arm. The issue quotes p = 0.18.
+        (5, 20, 1, 20, 0.1818),
+        # Both post arms pooled, which the issue quotes as p = 0.036 while
+        # noting that pooling two configurations is arguably not legitimate.
+        (5, 20, 2, 40, 0.0355),
+        # The tripping-party shift, 2026-08-26 against Path A on.
+        (6, 15, 16, 17, 0.0017),
+    ],
+)
+def test_fisher_matches_the_values_the_issue_quotes(
+    a: int, n1: int, b: int, n2: int, expected: float
+) -> None:
+    assert round_power.fisher_exact_two_sided(a, n1, b, n2) == pytest.approx(expected, abs=5e-5)
+
+
+def test_identical_arms_are_never_significant() -> None:
+    """A table with the same rate on both sides must not reject."""
+    for n in (10, 20, 40):
+        assert round_power.fisher_exact_two_sided(n // 4, n, n // 4, n) == pytest.approx(1.0)
+
+
+def test_the_twenty_run_battery_could_not_have_separated_its_own_effect() -> None:
+    """The finding that motivates the tool, pinned so it cannot drift.
+
+    20 runs per arm against 25% -> 5% is well under half power, so
+    "p = 0.18, not separable" was never evidence of no effect.
+    """
+    assert round_power.power(0.25, 0.05, 20) == pytest.approx(0.299, abs=0.002)
+    assert round_power.power(0.25, 0.05, 20) < 0.5
+
+
+def test_power_rises_with_n_and_with_effect_size() -> None:
+    smaller = round_power.power(0.25, 0.05, 20)
+    larger = round_power.power(0.25, 0.05, 40)
+    assert smaller < larger
+
+    subtle = round_power.power(0.25, 0.15, 40)
+    blatant = round_power.power(0.25, 0.05, 40)
+    assert subtle < blatant
+
+
+def test_required_returns_the_first_adequate_ladder_step() -> None:
+    n, achieved = round_power.required(0.25, 0.05)
+    assert n == 60
+    assert achieved >= 0.80
+    # And the step below it is genuinely inadequate, so 60 is not slack.
+    assert round_power.power(0.25, 0.05, 40) < 0.80
+
+
+def test_an_undetectable_effect_reports_no_ladder_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A one-point difference is not reachable, and the tool must say so.
+
+    The ladder is shortened for the test: walking the real one to n = 800 on a
+    hopeless effect costs O(800^2) Fisher evaluations and would blow the 30 s
+    unit budget (CLAUDE.md §2) to re-derive an answer that is obvious by n=40.
+    What is under test is the exhausted-ladder path, not the ladder's length.
+    """
+    monkeypatch.setattr(round_power, "_LADDER", (20, 40))
+    n, achieved = round_power.required(0.25, 0.24)
+    assert n is None
+    assert achieved < 0.80

--- a/tools/round_power.py
+++ b/tools/round_power.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""How many validation-matrix runs does a comparison actually need?
+
+Issue #217, step 1: *"Power first. Decide the round count from the effect size
+worth detecting before running anything."*
+
+This exists because the collision programme has now twice drawn a conclusion
+from a battery that could not have supported one, and had to take it back:
+the n=1 reading on #176, and the 2026-08-26 vs 2026-09-04 success comparison
+that #217 was opened to settle. The second is the sharper lesson — a 20-run
+arm has **under 30 % power** against the very effect it observed (25 % → 5 %), so
+"p = 0.18, not separable" was the arithmetic working correctly on a sample
+that was never going to separate anything. Running it again, the same size,
+answers nothing again.
+
+Two numbers come out, and both are worth having before a battery rather than
+after:
+
+* ``required``  — runs per arm for a target power against a stated effect.
+* ``power``     — what a battery you have already planned can actually see.
+
+Exact, not Monte Carlo, and stdlib-only. The test that a battery reports is
+Fisher's exact test on the 2×2 of successes, so power is computed by
+enumerating every outcome pair ``(a, b)`` under the two binomials and summing
+the probability of those the test would reject. That makes the answer
+deterministic — the same inputs give the same number on every host and in
+every re-run, which a sampled estimate does not (CLAUDE.md §1.8) — and it
+avoids putting scipy in the workspace for a planning script.
+
+Cost is ``O(n²)`` Fisher evaluations, each ``O(n)``. Sub-second to ``n = 100``,
+a few seconds by ``n = 300``; the ladder stops at 800 because a comparison
+needing more runs than that is not a comparison this programme can afford, and
+saying so is the useful answer.
+
+Example:
+    $ python tools/round_power.py --baseline 0.25 --alternative 0.05
+    baseline 25.0% vs alternative 5.0%, alpha 0.05, two-sided Fisher
+      n =  20/arm  power 0.30
+      n =  30/arm  power 0.44
+      n =  40/arm  power 0.65
+      n =  60/arm  power 0.85  <- first n at or above 80% power
+    80% power needs 60 runs per arm (15 four-scene rounds per arm).
+"""
+
+from __future__ import annotations
+
+import argparse
+from math import comb, isclose
+
+#: Scene runs in one validation-matrix round. `tools/validation_matrix.py`
+#: runs the four-scene matrix, so a round contributes four runs to an arm.
+RUNS_PER_ROUND = 4
+
+#: The ladder `required()` walks. Beyond this a battery is not affordable on
+#: any host this programme uses, and the honest output is "more than 800".
+_LADDER = (20, 30, 40, 60, 80, 100, 120, 160, 200, 260, 320, 400, 500, 650, 800)
+
+
+def fisher_exact_two_sided(a: int, n1: int, b: int, n2: int) -> float:
+    """Two-sided Fisher p-value for successes ``a``/``n1`` against ``b``/``n2``.
+
+    The conventional two-sided form: sum the hypergeometric probability of
+    every table at least as extreme as the observed one, "as extreme" meaning
+    "no more probable", which is what ``scipy.stats.fisher_exact`` computes.
+
+    Args:
+        a: Successes in the first arm.
+        n1: Runs in the first arm.
+        b: Successes in the second arm.
+        n2: Runs in the second arm.
+
+    Returns:
+        The p-value, in ``[0.0, 1.0]``.
+
+    Example:
+        >>> round(fisher_exact_two_sided(5, 20, 1, 20), 4)
+        0.1818
+    """
+    total = n1 + n2
+    successes = a + b
+    if successes in (0, total):
+        return 1.0
+    denominator = comb(total, successes)
+    observed = comb(n1, a) * comb(n2, b) / denominator
+    # A strict `<` would drop the observed table's own mirror image whenever
+    # floating point lands a hair apart; `isclose` keeps the test conservative.
+    tail = 0.0
+    low = max(0, successes - n2)
+    high = min(n1, successes)
+    for k in range(low, high + 1):
+        probability = comb(n1, k) * comb(n2, successes - k) / denominator
+        if probability < observed or isclose(probability, observed, rel_tol=1e-12):
+            tail += probability
+    return min(1.0, tail)
+
+
+def power(baseline: float, alternative: float, n: int, *, alpha: float = 0.05) -> float:
+    """Probability that ``n`` runs per arm reject at ``alpha``, computed exactly.
+
+    Enumerates every ``(a, b)`` outcome under ``Binomial(n, baseline)`` and
+    ``Binomial(n, alternative)`` and sums the probability of the pairs Fisher
+    would call significant.
+
+    Args:
+        baseline: True success rate of the first arm.
+        alternative: True success rate of the second arm.
+        n: Runs in each arm.
+        alpha: Significance threshold.
+
+    Returns:
+        Power, in ``[0.0, 1.0]``.
+
+    Example:
+        >>> round(power(0.25, 0.05, 20), 3)
+        0.299
+    """
+    first = [comb(n, k) * baseline**k * (1 - baseline) ** (n - k) for k in range(n + 1)]
+    second = [comb(n, k) * alternative**k * (1 - alternative) ** (n - k) for k in range(n + 1)]
+    # Fisher's p depends only on (a, b), so evaluate each cell once.
+    detected = 0.0
+    for a, pa in enumerate(first):
+        if pa == 0.0:
+            continue
+        for b, pb in enumerate(second):
+            if pb == 0.0:
+                continue
+            if fisher_exact_two_sided(a, n, b, n) < alpha:
+                detected += pa * pb
+    return detected
+
+
+def required(
+    baseline: float, alternative: float, *, alpha: float = 0.05, target: float = 0.80
+) -> tuple[int | None, float]:
+    """Smallest ladder ``n`` per arm reaching ``target`` power, or ``(None, best)``.
+
+    Args:
+        baseline: True success rate of the first arm.
+        alternative: True success rate of the second arm.
+        alpha: Significance threshold.
+        target: Power to reach.
+
+    Returns:
+        ``(n, power_at_n)``, or ``(None, power_at_800)`` when the ladder tops out.
+
+    Example:
+        >>> n, _ = required(0.25, 0.05)
+        >>> n
+        60
+    """
+    achieved = 0.0
+    for n in _LADDER:
+        achieved = power(baseline, alternative, n, alpha=alpha)
+        if achieved >= target:
+            return n, achieved
+    return None, achieved
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Print the power ladder for one comparison."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--baseline", type=float, required=True, help="Rate of arm A, 0..1.")
+    parser.add_argument("--alternative", type=float, required=True, help="Rate of arm B, 0..1.")
+    parser.add_argument("--alpha", type=float, default=0.05)
+    parser.add_argument("--power", type=float, default=0.80, dest="target")
+    args = parser.parse_args(argv)
+
+    print(
+        f"baseline {args.baseline:.1%} vs alternative {args.alternative:.1%}, "
+        f"alpha {args.alpha}, two-sided Fisher"
+    )
+    hit: int | None = None
+    for n in _LADDER:
+        achieved = power(args.baseline, args.alternative, n, alpha=args.alpha)
+        marker = ""
+        if hit is None and achieved >= args.target:
+            hit = n
+            marker = f"  <- first n at or above {args.target:.0%} power"
+        print(f"  n = {n:3d}/arm  power {achieved:.2f}{marker}")
+        if hit is not None:
+            break
+    if hit is None:
+        print(f"no ladder size reaches {args.target:.0%} power; more than {_LADDER[-1]} per arm.")
+        return 1
+    print(
+        f"{args.target:.0%} power needs {hit} runs per arm "
+        f"({hit // RUNS_PER_ROUND} four-scene rounds per arm)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Answers #217's step 1 — *"Power first. Decide the round count from the effect size worth detecting **before running anything**"* — and takes a first pass at step 2, entirely offline against rounds already recorded. **No GPU, no new rounds.**

## The 20-run battery could not have separated its own effect

Exact power for two-sided Fisher at 20 runs per arm:

| effect | power at n=20/arm |
| --- | ---: |
| 25 % → 5 % (the drop actually observed) | **0.30** |
| 25 % → 10 % | 0.14 |
| 25 % → 2 % | 0.45 |

So "5/20 vs 1/20, p = 0.18, not separable" is the arithmetic working correctly on a sample that had under a one-in-three chance of separating anything. It is not evidence of no regression — and the operative point, **re-running the same 20 against 20 answers nothing again.**

## What it would take

At the battery's own measured **9.1 min per four-scene round** (mean over the ten post-#200 rounds, range 4.5–15.2):

| effect worth detecting | runs/arm | rounds/arm | both arms, wall |
| --- | ---: | ---: | ---: |
| 25 % → 5 % | 60 | 15 | **4.5 h** |
| 25 % → 10 % | 120 | 30 | 9.1 h |
| 25 % → 15 % | 320 | 80 | 24.2 h |

4.5 h is affordable and is the number to plan the bisect against. A 10-point drop is not, on this host, which is worth knowing before anyone promises to detect one.

## Stop class does not shortcut it

This was the hopeful part of the plan — success is the noisiest signal on a diverging rollout, so a shifted stop distribution should show first. Aggregating the ten post-#200 rounds by tripping party against the 2026-08-26 stop table:

| battery | payload | link | payload share |
| --- | ---: | ---: | ---: |
| 2026-08-26 | 6 | 9 | 40 % |
| 2026-09-04, Path A **off** (shipped) | 12 | 6 | 67 % |
| 2026-09-04, Path A **on** | 16 | 1 | 94 % |

| contrast | Fisher p |
| --- | ---: |
| 08-26 vs Path A **off** — tripping party | **0.17** |
| 08-26 vs Path A **off** — success rate | 0.18 |
| 08-26 vs Path A **on** — tripping party | 0.0017 |
| 08-26 vs both arms pooled — tripping party | 0.0087 |

**For the arm that matters, stop class is no more separable than success was** — 0.17 against 0.18. The one decisively separable contrast is Path A *on*, and that is confounded by Path A's own already-documented effect (#209 records the link class going 6 → 1 *within* this battery), so it measures Path A rather than whatever moved between the batteries. Stop class needs about the same n: 40 % → 67 % reaches 80 % power at **60 stops per arm**, and the arms here hold 15 and 18.

The verdict mix barely moved — 11 `within-quantization` in all three batteries, 2–3 `real`, 1 `false-positive`, 1–3 `unadjudicated`. What shifted is *who trips*, not how the adjudicator scores it.

## A caveat that limits every 08-26 comparison, including #217's own table

The 2026-08-26 entry does not record which rSkill it ran, and its artifacts are gone (`outputs/` is gitignored), so its stop counts here are read off the ledger table rather than recomputed. The post-#200 rounds record `OpenRAL/rskill-xr1-panda_mobile-robocasa365-nf4` in every `verdicts.json`. **Policy invariance across this comparison cannot be verified from the record** — a policy change between batteries would move both success and stop class, and nothing checked in rules that out. Future entries should name the rSkill; the harness already writes it.

## Relevant to the A/B already running

There is a #204 A/B underway on `spark` (its first `with204` round is checked in as a fixture). At 20 runs per arm it lands in the same place as this one. Size it from the table above, or accept in advance that it can only report a null.

## The tool

`tools/round_power.py` — **exact, not sampled**, so the same inputs give the same answer on every host and in every re-run (CLAUDE.md §1.8); **stdlib-only**, so scipy stays out of the workspace for a planning script. Power is computed by enumerating every outcome pair under the two binomials and summing the probability of those Fisher rejects.

```
$ python tools/round_power.py --baseline 0.25 --alternative 0.05
baseline 25.0% vs alternative 5.0%, alpha 0.05, two-sided Fisher
  n =  20/arm  power 0.30
  n =  30/arm  power 0.44
  n =  40/arm  power 0.65
  n =  60/arm  power 0.85  <- first n at or above 80% power
80% power needs 60 runs per arm (15 four-scene rounds per arm).
```

Validated against `scipy.stats.fisher_exact` on 300 random 2×2 tables — all matched to 1e-9.

## How tested

`tests/unit/test_round_power.py` — 8 tests in 0.22 s, pinning the p-values #217 itself quotes (0.1818, 0.0355) and the finding that motivates the tool. Doctests pass. `ruff check` / `ruff format --check` clean. `refresh_methods_linenos.py --check` clean, with `docs/methods/10-tools.md` updated per §1.13.

## What this does not do

It does not close #217. It sizes the bisect and rules out the cheap version of it. The run itself is still to be done, now with a defensible round count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTE4eEfxW8FvvBnPZL6otg
