### PR TITLE
test(hal): the powered gate for ADR-0102, and the transport it needs

### DIFF
--- a/docs/methods/12-tests-hil.md
+++ b/docs/methods/12-tests-hil.md
@@ -55,6 +55,30 @@ _Single-controller bridge. Used by UR5e, UR10e, Franka Panda, Sawyer._
 - `RosControlHILTransport(node, joint_names, *, command_topic, joint_state_topic)` — Subscribes to `joint_state_topic`, exposes `publish(_topic, msg)` for the HAL's outgoing trajectories and `state()` for the cached joint state. Helpers: `spin_once`, `wait_for_first_state`, `last_stamp`. (L68)
 - `make_hil_transport(node_name, joint_names, *, command_topic, joint_state_topic) -> tuple[Node, RosControlHILTransport, Callable[[], None]]` — Factory that initialises rclpy, creates the node, and returns a teardown callable. (L179)
 
+### `tests/hil/_openarm_ros_transport.py`
+_4-way fan-out bridge for the bimanual OpenArm v2 HAL — the only thing between `OpenArmRealHAL` and a physical arm._
+
+- `OpenArmHILTransport(node, joint_names, *, command_topics, joint_state_topic, time_from_start_s=0.8)` — Four `JointTrajectory` publishers plus one aggregated `JointState` subscriber. Simpler than the ALOHA bridge because ADR-0102 puts `joint_names` **in the message**, so the transport forwards them rather than keeping a second copy of the slice table that could drift. Build it from `OpenArmRealHAL.ros2_control_joint_names()` — the URDF namespace (`openarm_left_joint1`) that `/joint_states` is keyed by, **not** the manifest's (`left_joint1`). (L57)
+- `time_from_start_s` is a constructor argument, unlike the 100 ms the production transports hardcode. A `JointTrajectoryController` given an absolute target and a 100 ms deadline moves at `(target - current) / 0.1s`, so the rate is set by how wrong the command is. A longer window bounds it by construction; a test that cares about production timing passes 0.1.
+- `publish(topic, msg)` dispatches by topic match and raises on an unknown topic or a name/value width mismatch — silently dropping a command is the ADR-0102 failure mode itself. `state()` zero-fills joints it has never heard from; `missing_joints()` / `wait_for_every_joint()` are what let a caller tell that apart from a real pose.
+- Its own tests (`tests/hil/test_openarm_ros_transport.py`) need only a ROS install, not the cell: real publishers and real messages over DDS on an isolated domain with LOCALHOST discovery (#227 — a stray graph once reached a live OpenArm on another host, and this suite's whole subject is arm command topics).
+
+### `tests/hil/test_openarm_bringup_agreement.py`
+_`OpenArmRealHAL`'s controller/joint table vs `openarm_bringup`'s own YAML — no hardware, not even the CAN links._
+
+- The HAL's `_command_groups` is a hand-copied transcription of names that live in a **different repo** on a different cadence, and nothing compared the two. A `JointTrajectoryController` handed joints it does not own **rejects the whole message**: no publisher-side exception, nothing odd on `/joint_states`, the arm just does not move — indistinguishable from a policy holding still. Same failure shape ADR-0102 ended, one layer further out.
+- The gripper is the trap and the reason the file exists: bringup calls it `openarm_left_finger_joint1`, **not** `openarm_left_gripper`. Every plausible guess is wrong, so the config is the only safe source.
+- Four checks: every controller the HAL publishes to is declared; each is a `JointTrajectoryController` (a `ForwardCommandController` takes `Float64MultiArray` on `/commands`, so the HAL's topic and message type would both miss); the joint names match per controller; and the four lists concatenate to exactly the HAL's 16-DoF order, which is what the slice spans mean.
+- Gated on `openarm_bringup` being on the ament prefix path, so it skips cleanly off-rig. It answers **statically** what would otherwise need a powered cell: bringing the controllers up to look at them runs `OpenArmHW::on_activate` → `openarm_->enable_all()`, energising all sixteen motors. Reading the config energises nothing.
+
+### `tests/hil/test_openarm_slot_group_motion.py`
+_The one test in the tree that commands a real OpenArm to move._
+
+- Closes the last ADR-0102 gate: `test_openarm_restock_deploy_preflight.py` proves the composed 16-DoF vector reaches the four controllers correctly named and sliced, but never publishes, so it cannot see a sign flip, a scale error, or a joint the controller ignores. This one commands measured-pose + `0.02 rad` on **one** joint, holds the other fifteen at their measured values, and reads the physical result back off `/joint_states` — asserting the addressed joint arrived and every other joint stayed put.
+- Two independent gates, both explicit: `OPENRAL_OPENARM_ALLOW_MOTION=1` (this bench can move) and `OPENRAL_OPENARM_ATTENDED=1` (someone is at the E-stop right now). Separate on purpose, so a rig that leaves the first exported does not thereby become a rig that moves unattended.
+- Why a small number is not by itself a small motion: the wire format is an **absolute** position with a deadline, so travel is `(target - measured) / time_from_start` — set by how wrong the command is, which is the quantity under test. The bounds that do work are the measured-pose baseline, the 0.8 s window, and the refusal to start until all 16 joints have appeared on `/joint_states` (a partial state zero-fills into a plausible pose, and "measured + delta" on top of that is a command to slew the cell home).
+- Cases run gripper-first (1-DoF, lowest inertia, and the actuator ADR-0102 exists for) then the most distal arm joint, and each restores the measured pose before returning, so the suite is idempotent.
+
 ### `tests/hil/_aloha_ros_transport.py`
 _4-way fan-out bridge for the bimanual ALOHA HAL._
 

--- a/tests/hil/_openarm_ros_transport.py
+++ b/tests/hil/_openarm_ros_transport.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lab-runner-only ``rclpy`` bridge for the bimanual OpenArm v2 real-HW HAL.
+
+:class:`openral_hal.openarm_real.OpenArmRealHAL` fans one 16-DoF
+:class:`openral_core.Action` across **four** ``ros2_control`` controllers —
+left arm, left gripper, right arm, right gripper (``openarm_bringup``'s
+bimanual configuration). This is the HIL counterpart of
+:mod:`tests.hil._aloha_ros_transport` for that fan-out.
+
+Simpler than the ALOHA bridge, because the OpenArm HAL puts ``joint_names``
+**in the message it publishes** (ADR-0102). The ALOHA bridge has to carry its
+own slice table to know which joints each publisher owns; here the message
+says so, and the transport just forwards it. That also means the transport
+cannot silently disagree with the HAL about joint order — there is no second
+copy of the mapping to drift.
+
+Those names are in the **ros2_control namespace**
+(``openarm_left_joint1``), not the manifest's (``left_joint1``); the adapter
+translates, and ``/joint_states`` is keyed the same way. Build this transport
+from :meth:`OpenArmRealHAL.ros2_control_joint_names`, never from
+``description.joints``.
+
+``time_from_start`` is a **constructor argument** here, unlike the 100 ms the
+production transports hardcode. A ``JointTrajectoryController`` given an
+absolute target and a 100 ms deadline moves at ``(target - current) / 0.1s``,
+so on a first powered run the rate is set by how wrong the command is — which
+is the quantity under test. A longer window bounds the rate by construction.
+Tests that care about production timing must say so and pass 0.1.
+
+This module is HIL-only and shares the import-time ``rclpy`` guard from
+:mod:`tests.hil._ros_control_transport` (CLAUDE.md §1.11: real component or
+``pytest.skip`` — nothing in between).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import time
+from typing import Any
+
+if importlib.util.find_spec("rclpy") is None:  # pragma: no cover
+    raise RuntimeError(
+        "rclpy is not installed; this transport may only be imported by HIL "
+        "tests after they've confirmed rclpy is available."
+    )
+
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.node import Node
+from sensor_msgs.msg import JointState as RosJointState
+from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
+
+from tests.hil._ros_control_transport import _CONTROL_QOS, _make_trajectory_publisher
+
+__all__ = ["OpenArmHILTransport"]
+
+
+class OpenArmHILTransport:
+    """4-way ``rclpy`` bridge for the bimanual OpenArm HIL tests.
+
+    Owns one ``JointTrajectory`` publisher per controller plus one
+    ``JointState`` subscriber on the aggregated ``joint_state_topic``.
+    Dispatch is by topic-string match; an unknown topic raises so a HAL-side
+    contract drift fails loudly rather than dropping a command.
+
+    Args:
+        node: A live ``rclpy`` node owned by the caller (teardown is the
+            caller's responsibility).
+        joint_names: All 16 joint names in **ros2_control** order — i.e.
+            :meth:`OpenArmRealHAL.ros2_control_joint_names`, which is what
+            ``/joint_states`` is keyed by.
+        command_topics: The four controller command topics, from
+            :meth:`OpenArmRealHAL.command_topics`.
+        joint_state_topic: Aggregated ``sensor_msgs/JointState`` topic.
+        time_from_start_s: Trajectory deadline for every published point. See
+            the module docstring — this bounds the motion rate.
+
+    Example:
+        >>> OpenArmHILTransport.__name__
+        'OpenArmHILTransport'
+    """
+
+    def __init__(
+        self,
+        node: Node,
+        joint_names: list[str],
+        *,
+        command_topics: list[str],
+        joint_state_topic: str = "/joint_states",
+        time_from_start_s: float = 0.8,
+    ) -> None:
+        """Build the four publishers and the joint-state subscription."""
+        if len(joint_names) != 16:
+            raise ValueError(f"OpenArmHILTransport expects 16 joint names, got {len(joint_names)}.")
+        if len(command_topics) != 4:
+            raise ValueError(
+                f"OpenArmHILTransport expects 4 command topics, got {len(command_topics)}."
+            )
+        if time_from_start_s <= 0.0:
+            raise ValueError("time_from_start_s must be > 0.")
+        self._node = node
+        self._joint_names = list(joint_names)
+        self._time_from_start_s = float(time_from_start_s)
+        self._pubs = {t: _make_trajectory_publisher(node, t) for t in command_topics}
+
+        self._latest: dict[str, tuple[float, float, float]] = {}
+        self._last_stamp = 0.0
+        node.create_subscription(
+            RosJointState, joint_state_topic, self._on_joint_state, _CONTROL_QOS
+        )
+
+        # Bound to the NODE's context, not the default one. A HIL test runs on
+        # its own `rclpy.Context` so it cannot join the lab's live graph by
+        # accident, and bare `rclpy.spin_once(node)` would reach for the
+        # uninitialised default context and raise.
+        self._executor = SingleThreadedExecutor(context=node.context)
+        self._executor.add_node(node)
+
+    # -- Transport callables (injected into the HAL) --------------------------
+
+    def publish(self, topic: str, msg: dict[str, Any]) -> None:
+        """Forward one HAL command to its controller as a ``JointTrajectory``.
+
+        The message's own ``joint_names`` are used verbatim, so this cannot
+        misroute a value the HAL placed correctly.
+
+        Args:
+            topic: One of the four command topics.
+            msg: The HAL's command dict.
+
+        Raises:
+            ValueError: The topic is not one of the four (contract drift).
+        """
+        publisher = self._pubs.get(topic)
+        if publisher is None:
+            raise ValueError(f"OpenArmHILTransport: unknown topic {topic!r}")
+        names = msg.get("joint_names")
+        targets = msg.get("joint_targets")
+        if not isinstance(names, list) or not isinstance(targets, list) or not targets:
+            raise ValueError(f"OpenArmHILTransport: malformed command on {topic!r}: {msg!r}")
+        last_step = targets[-1]
+        if not isinstance(last_step, list) or len(last_step) != len(names):
+            raise ValueError(
+                f"OpenArmHILTransport: {topic!r} names {len(names)} joints but the "
+                f"chunk's last step has {len(last_step) if isinstance(last_step, list) else '?'} "
+                "values."
+            )
+        traj = JointTrajectory()
+        traj.joint_names = [str(n) for n in names]
+        point = JointTrajectoryPoint()
+        point.positions = [float(v) for v in last_step]
+        whole = int(self._time_from_start_s)
+        point.time_from_start.sec = whole
+        point.time_from_start.nanosec = int((self._time_from_start_s - whole) * 1e9)
+        traj.points.append(point)
+        publisher.publish(traj)
+
+    def state(self) -> dict[str, object]:
+        """Latest joint state in the transport's joint-name order."""
+        positions: list[float] = []
+        velocities: list[float] = []
+        efforts: list[float] = []
+        for name in self._joint_names:
+            p, v, e = self._latest.get(name, (0.0, 0.0, 0.0))
+            positions.append(p)
+            velocities.append(v)
+            efforts.append(e)
+        return {"position": positions, "velocity": velocities, "effort": efforts}
+
+    # -- Helpers --------------------------------------------------------------
+
+    def spin_once(self, timeout_sec: float = 0.05) -> None:
+        """Pump the node's callbacks once, on its own context's executor."""
+        self._executor.spin_once(timeout_sec=timeout_sec)
+
+    def spin_for(self, seconds: float) -> None:
+        """Pump callbacks for a wall-clock window."""
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            self.spin_once(timeout_sec=0.02)
+
+    def seen_joints(self) -> set[str]:
+        """Joint names that have actually appeared on ``/joint_states``."""
+        return set(self._latest)
+
+    def missing_joints(self) -> list[str]:
+        """Expected joints that ``/joint_states`` has never reported."""
+        return [n for n in self._joint_names if n not in self._latest]
+
+    def close(self) -> None:
+        """Release the executor. The node and context belong to the caller."""
+        self._executor.shutdown()
+
+    # -- Internal callbacks ---------------------------------------------------
+
+    def _on_joint_state(self, msg: Any) -> None:
+        """Record the latest position/velocity/effort per joint name.
+
+        ``/joint_states`` on the OpenArm is aggregated from four independently
+        publishing controllers with no ordering guarantee, so entries are
+        merged by name and never by index.
+        """
+        names = list(getattr(msg, "name", []))
+        positions = list(getattr(msg, "position", []))
+        velocities = list(getattr(msg, "velocity", []))
+        efforts = list(getattr(msg, "effort", []))
+        for i, name in enumerate(names):
+            self._latest[name] = (
+                positions[i] if i < len(positions) else 0.0,
+                velocities[i] if i < len(velocities) else 0.0,
+                efforts[i] if i < len(efforts) else 0.0,
+            )
+        self._last_stamp = time.monotonic()
+
+    @property
+    def last_stamp(self) -> float:
+        """Monotonic timestamp of the most recent ``/joint_states`` message."""
+        return self._last_stamp
+
+    def wait_for_every_joint(self, deadline_s: float = 5.0) -> bool:
+        """Block until every expected joint has been reported at least once.
+
+        Not "any message": :meth:`state` zero-fills an unreported joint, and
+        :class:`OpenArmRealHAL` builds a full 16-DoF vector regardless. A
+        partial ``/joint_states`` therefore reads as a *plausible pose* with
+        zeros in it, which is the one input a motion test must never act on.
+
+        Args:
+            deadline_s: How long to wait.
+
+        Returns:
+            True when all 16 have been seen.
+        """
+        start = time.monotonic()
+        while time.monotonic() - start < deadline_s:
+            self.spin_once(timeout_sec=0.05)
+            if not self.missing_joints():
+                return True
+        return False

--- a/tests/hil/test_openarm_bringup_agreement.py
+++ b/tests/hil/test_openarm_bringup_agreement.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+"""`OpenArmRealHAL` and `openarm_bringup` must agree, checked from the configs.
+
+The HAL names four controllers and the sixteen joints it hands them. Those
+names live in **`openarm_bringup`'s** controller YAML, in a different repo on
+a different release cadence. Nothing has ever compared the two: the HAL's
+table (`openarm_real._command_groups`) is a hand-copied transcription, and a
+rename upstream would leave it silently wrong.
+
+Silently is the operative word. A `JointTrajectoryController` handed joints it
+does not own **rejects the whole message**. There is no exception on the
+publisher side, nothing on `/joint_states` looks unusual, and the arm simply
+does not move — which is indistinguishable from a policy that chose to hold
+still. That is the same failure shape ADR-0102 was written to end, one layer
+further out.
+
+The gripper is where this is most likely to bite, and the reason this file
+exists: the bimanual bringup calls the gripper joint
+``openarm_left_finger_joint1``, **not** ``openarm_left_gripper``. Every
+plausible guess is wrong, so the only safe source is the config itself.
+
+Needs no hardware at all — not even the CAN links — only a host where
+``openarm_bringup`` is on the ament prefix path. It answers statically what
+would otherwise need a powered cell: bringing the controllers up to look at
+them calls ``OpenArmHW::on_activate`` → ``openarm_->enable_all()``, which
+energises all sixteen motors. Reading the config energises nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_CONTROLLER_CONFIG = Path("config") / "controllers" / "openarm_bimanual_controllers.yaml"
+
+
+def _bringup_controller_config() -> dict | None:
+    """The committed bimanual controller YAML, or None when bringup is absent."""
+    try:
+        from ament_index_python.packages import get_package_share_directory
+    except ImportError:
+        return None
+    try:
+        share = Path(get_package_share_directory("openarm_bringup"))
+    except Exception:  # reason: PackageNotFoundError, plus whatever ament raises off-rig
+        return None
+    path = share / _CONTROLLER_CONFIG
+    if not path.is_file():
+        return None
+    loaded = yaml.safe_load(path.read_text())
+    return loaded if isinstance(loaded, dict) else None
+
+
+_CONFIG = _bringup_controller_config()
+
+requires_bringup = pytest.mark.skipif(
+    _CONFIG is None,
+    reason=(
+        "openarm_bringup not on the ament prefix path — source the workspace "
+        "carrying openarm_ros2 to compare the HAL against its controller config"
+    ),
+)
+
+
+def _hal_groups() -> list[tuple[str, list[str]]]:
+    """``(command topic, joint names)`` per controller, straight from the HAL."""
+    from openral_hal.openarm_real import OpenArmRealHAL
+
+    hal = OpenArmRealHAL(require_can_links=False)
+    return [(topic, list(names)) for topic, _, names in hal._command_groups]
+
+
+def _controller_joints(controller: str) -> list[str]:
+    assert _CONFIG is not None
+    return list(_CONFIG[controller]["ros__parameters"]["joints"])
+
+
+@requires_bringup
+def test_every_controller_the_hal_commands_is_declared_by_bringup() -> None:
+    """A topic with no controller behind it publishes into the void."""
+    assert _CONFIG is not None
+    declared = set(_CONFIG["controller_manager"]["ros__parameters"]) - {"update_rate"}
+    for topic, _ in _hal_groups():
+        controller = topic.strip("/").split("/")[0]
+        assert controller in declared, (
+            f"the HAL publishes to {topic!r}, but openarm_bringup declares no "
+            f"controller named {controller!r}. Declared: {sorted(declared)}"
+        )
+
+
+@requires_bringup
+def test_each_controller_is_a_joint_trajectory_controller() -> None:
+    """The HAL's topic suffix and message type both assume it.
+
+    A ``ForwardCommandController`` takes ``Float64MultiArray`` on ``/commands``
+    — publishing a ``JointTrajectory`` at it reaches nothing.
+    """
+    assert _CONFIG is not None
+    declared = _CONFIG["controller_manager"]["ros__parameters"]
+    for topic, _ in _hal_groups():
+        controller = topic.strip("/").split("/")[0]
+        assert declared[controller]["type"] == (
+            "joint_trajectory_controller/JointTrajectoryController"
+        ), f"{controller} is a {declared[controller]['type']}, so {topic} is the wrong interface"
+
+
+@requires_bringup
+def test_the_joint_names_the_hal_sends_are_the_ones_the_controller_owns() -> None:
+    """The check that a wrong guess about the gripper would fail.
+
+    `openarm_bringup` calls it ``openarm_left_finger_joint1``; ``_gripper``,
+    ``_gripper_joint`` and ``_finger_joint`` are all wrong, and all of them
+    fail by the controller quietly rejecting the message.
+    """
+    for topic, hal_names in _hal_groups():
+        controller = topic.strip("/").split("/")[0]
+        assert hal_names == _controller_joints(controller), (
+            f"{controller}: the HAL sends {hal_names}, the controller owns "
+            f"{_controller_joints(controller)}. A JointTrajectory naming joints "
+            "the controller does not own is rejected whole — silently."
+        )
+
+
+@requires_bringup
+def test_the_four_controllers_cover_all_sixteen_joints_exactly_once() -> None:
+    """No joint commanded twice, none left out, and the HAL's order preserved."""
+    from openral_hal.openarm_real import OpenArmRealHAL
+
+    hal = OpenArmRealHAL(require_can_links=False)
+    fanned: list[str] = []
+    for topic, _ in _hal_groups():
+        fanned.extend(_controller_joints(topic.strip("/").split("/")[0]))
+    assert fanned == hal.ros2_control_joint_names(), (
+        "concatenating the four controllers' joints must reproduce the HAL's "
+        "16-DoF vector order exactly — that ordering is what the slice spans mean"
+    )
+    assert len(set(fanned)) == 16

--- a/tests/hil/test_openarm_ros_transport.py
+++ b/tests/hil/test_openarm_ros_transport.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The OpenArm HIL transport, checked without the cell.
+
+:class:`tests.hil._openarm_ros_transport.OpenArmHILTransport` is the only
+thing between :class:`OpenArmRealHAL` and a physical arm, so its own
+behaviour should not first be exercised on a powered robot. Everything here
+runs on any host with ROS 2: real publishers, a real subscriber, real
+messages over DDS — just no controllers on the other end.
+
+**The graph is confined to its own DDS domain with LOCALHOST discovery.**
+That is not ceremony for a test that publishes on
+``/*_controller/joint_trajectory``: on 2026-09-05 a sim left on domain 0 with
+subnet multicast reached a **live bimanual OpenArm on another host** (#227).
+A test whose whole subject is arm command topics is exactly the one that must
+not repeat it.
+
+The load-bearing case is :func:`test_a_partial_joint_state_is_reported_missing`:
+``state()`` zero-fills a joint it has never heard from, and ``OpenArmRealHAL``
+turns that into a full 16-DoF vector, so a half-populated ``/joint_states``
+reads downstream as a plausible pose with zeros in it. The motion test refuses
+to command anything until ``wait_for_every_joint`` passes, and this is what
+proves that gate actually detects the condition.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+rclpy = pytest.importorskip("rclpy", reason="the HIL transport needs a ROS 2 install")
+pytest.importorskip("trajectory_msgs", reason="the HIL transport needs trajectory_msgs")
+
+from openral_hal.openarm_real import OpenArmRealHAL  # noqa: E402
+from rclpy.node import Node  # noqa: E402
+from rclpy.qos import QoSProfile, QoSReliabilityPolicy  # noqa: E402
+from sensor_msgs.msg import JointState as RosJointState  # noqa: E402
+from trajectory_msgs.msg import JointTrajectory  # noqa: E402
+
+from tests.hil._openarm_ros_transport import OpenArmHILTransport  # noqa: E402
+
+_TEST_DOMAIN = "92"
+_QOS = QoSProfile(reliability=QoSReliabilityPolicy.RELIABLE, depth=10)
+
+
+@pytest.fixture
+def isolated_ros(monkeypatch: pytest.MonkeyPatch):
+    """A private DDS domain, LOCALHOST-only, torn down after the test."""
+    monkeypatch.setenv("ROS_DOMAIN_ID", _TEST_DOMAIN)
+    monkeypatch.setenv("ROS_AUTOMATIC_DISCOVERY_RANGE", "LOCALHOST")
+    context = rclpy.Context()
+    context.init()
+    yield context
+    context.try_shutdown()
+
+
+@pytest.fixture
+def rig(isolated_ros):
+    """A transport plus the HAL metadata it is built from."""
+    node = Node("openarm_transport_test", context=isolated_ros)
+    hal = OpenArmRealHAL(require_can_links=False)
+    transport = OpenArmHILTransport(
+        node,
+        hal.ros2_control_joint_names(),
+        command_topics=list(hal.command_topics()),
+        time_from_start_s=0.8,
+    )
+    yield transport, hal, node, isolated_ros
+    transport.close()
+    node.destroy_node()
+
+
+class TestConstruction:
+    def test_it_must_be_built_from_the_ros2_control_namespace(self, rig) -> None:
+        """16 names, and they are the URDF ones `/joint_states` is keyed by."""
+        _, hal, _, _ = rig
+        names = hal.ros2_control_joint_names()
+        assert len(names) == 16
+        assert names[0] == "openarm_left_joint1"
+
+    def test_a_wrong_joint_count_is_refused(self, isolated_ros) -> None:
+        node = Node("openarm_transport_bad", context=isolated_ros)
+        hal = OpenArmRealHAL(require_can_links=False)
+        try:
+            with pytest.raises(ValueError, match="16 joint names"):
+                OpenArmHILTransport(
+                    node, ["only", "three", "names"], command_topics=list(hal.command_topics())
+                )
+        finally:
+            node.destroy_node()
+
+    def test_a_zero_trajectory_window_is_refused(self, isolated_ros) -> None:
+        # time_from_start = 0 asks a JointTrajectoryController to teleport,
+        # which is the unbounded-rate command this transport exists to avoid.
+        node = Node("openarm_transport_bad2", context=isolated_ros)
+        hal = OpenArmRealHAL(require_can_links=False)
+        try:
+            with pytest.raises(ValueError, match="time_from_start_s"):
+                OpenArmHILTransport(
+                    node,
+                    hal.ros2_control_joint_names(),
+                    command_topics=list(hal.command_topics()),
+                    time_from_start_s=0.0,
+                )
+        finally:
+            node.destroy_node()
+
+
+class TestPublish:
+    def test_a_hal_command_crosses_dds_as_a_joint_trajectory(self, rig) -> None:
+        """The whole point: a HAL publish becomes a real message on the wire."""
+        transport, hal, node, _ = rig
+        topics = list(hal.command_topics())
+        names = hal.ros2_control_joint_names()
+
+        received: list[JointTrajectory] = []
+        node.create_subscription(JointTrajectory, topics[0], received.append, _QOS)
+
+        payload = [0.11, 0.22, 0.33, 0.44, 0.55, 0.66, 0.77]
+        deadline = 5.0
+        start = time.monotonic()
+        while not received and time.monotonic() - start < deadline:
+            transport.publish(topics[0], {"joint_names": names[0:7], "joint_targets": [payload]})
+            transport.spin_once(timeout_sec=0.05)
+        assert received, "no JointTrajectory crossed DDS within 5 s"
+
+        msg = received[-1]
+        assert list(msg.joint_names) == names[0:7]
+        assert [round(v, 6) for v in msg.points[0].positions] == payload
+        # The rate bound: 0.8 s, not the production 0.1 s.
+        assert msg.points[0].time_from_start.sec == 0
+        assert msg.points[0].time_from_start.nanosec == 800_000_000
+
+    def test_only_the_last_step_of_a_chunk_is_commanded(self, rig) -> None:
+        """A multi-step chunk collapses to its final target, as ALOHA's does."""
+        transport, hal, node, _ = rig
+        topics = list(hal.command_topics())
+        names = hal.ros2_control_joint_names()
+        received: list[JointTrajectory] = []
+        node.create_subscription(JointTrajectory, topics[1], received.append, _QOS)
+        start = time.monotonic()
+        while not received and time.monotonic() - start < 5.0:
+            transport.publish(
+                topics[1], {"joint_names": [names[7]], "joint_targets": [[0.1], [0.2], [0.3]]}
+            )
+            transport.spin_once(timeout_sec=0.05)
+        assert received, "no gripper JointTrajectory crossed DDS within 5 s"
+        assert [round(v, 6) for v in received[-1].points[0].positions] == [0.3]
+
+    def test_an_unknown_topic_raises_rather_than_dropping_the_command(self, rig) -> None:
+        # Silently dropping is the ADR-0102 failure mode all over again.
+        transport, _, _, _ = rig
+        with pytest.raises(ValueError, match="unknown topic"):
+            transport.publish("/not/a/controller", {"joint_names": [], "joint_targets": [[0.0]]})
+
+    def test_a_width_mismatch_raises(self, rig) -> None:
+        transport, hal, _, _ = rig
+        with pytest.raises(ValueError, match="names 2 joints"):
+            transport.publish(
+                next(iter(hal.command_topics())),
+                {"joint_names": ["a", "b"], "joint_targets": [[1.0]]},
+            )
+
+
+class TestStateGate:
+    def test_no_joint_state_means_every_joint_is_missing(self, rig) -> None:
+        transport, _, _, _ = rig
+        assert len(transport.missing_joints()) == 16
+        assert transport.wait_for_every_joint(deadline_s=0.4) is False
+
+    def test_state_zero_fills_an_unheard_joint(self, rig) -> None:
+        """Why the gate exists: absence is indistinguishable from 0.0 downstream."""
+        transport, _, _, _ = rig
+        assert transport.state()["position"] == [0.0] * 16
+
+    def test_a_partial_joint_state_is_reported_missing(self, rig) -> None:
+        """Half a `/joint_states` must not read as a complete pose.
+
+        This is the condition that would let the motion test compute
+        "measured + delta" against fiction and slew the cell toward home.
+        """
+        transport, hal, node, _ = rig
+        names = hal.ros2_control_joint_names()
+        pub = node.create_publisher(RosJointState, "/joint_states", _QOS)
+
+        partial = RosJointState()
+        partial.name = names[0:8]  # left side only — the right arm never reports
+        partial.position = [0.5] * 8
+
+        start = time.monotonic()
+        while transport.missing_joints() and time.monotonic() - start < 5.0:
+            pub.publish(partial)
+            transport.spin_once(timeout_sec=0.05)
+            if len(transport.seen_joints()) >= 8:
+                break
+        assert len(transport.seen_joints()) == 8, "the partial state should have landed"
+        assert transport.missing_joints() == names[8:16]
+        assert transport.wait_for_every_joint(deadline_s=0.4) is False, (
+            "a partial /joint_states must NOT satisfy the motion gate"
+        )
+        # …and the zero-fill that makes it dangerous:
+        assert transport.state()["position"][8:] == [0.0] * 8
+
+    def test_a_complete_joint_state_opens_the_gate(self, rig) -> None:
+        transport, hal, node, _ = rig
+        names = hal.ros2_control_joint_names()
+        pub = node.create_publisher(RosJointState, "/joint_states", _QOS)
+
+        full = RosJointState()
+        full.name = list(names)
+        full.position = [float(i) / 100.0 for i in range(16)]
+
+        start = time.monotonic()
+        opened = False
+        while not opened and time.monotonic() - start < 5.0:
+            pub.publish(full)
+            opened = transport.wait_for_every_joint(deadline_s=0.2)
+        assert opened, "a complete /joint_states should satisfy the gate"
+        assert transport.missing_joints() == []
+        assert transport.state()["position"][15] == pytest.approx(0.15)

--- a/tests/hil/test_openarm_slot_group_motion.py
+++ b/tests/hil/test_openarm_slot_group_motion.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HIL: one slot-dispatched tick actually MOVES the joint it addresses.
+
+The last unclosed gate on ADR-0102. `tests/hil/test_openarm_restock_deploy_preflight.py`
+proves the composed 16-DoF vector reaches the four controllers correctly
+named and correctly sliced — but it never publishes, so it cannot prove the
+values *arrive somewhere physical*. A sign flip, a scale error, or a joint the
+controller silently ignores is invisible to it. This is the test that closes
+that, and the only one in the tree that commands a real OpenArm to move.
+
+**It requires a person at the E-stop.** Two independent gates, both explicit:
+
+1. ``OPENRAL_OPENARM_ALLOW_MOTION=1`` — never set in CI or by ``just test``.
+2. ``OPENRAL_OPENARM_ATTENDED=1`` — the human attestation. Separate on purpose:
+   the first says "this bench can move", the second says "someone is watching
+   it right now". A rig that leaves gate 1 exported must not thereby become a
+   rig that moves unattended.
+
+Why an unattended "tiny step" is not a thing
+--------------------------------------------
+The wire format is ``trajectory_msgs/JointTrajectory``: an **absolute**
+position with a deadline, not a delta. Motion is
+``(target - measured) / time_from_start``, so the distance travelled is set by
+how wrong the command is — exactly the quantity under test. Picking a small
+number does not bound it. Three things bound it here instead:
+
+* every target is **measured pose + delta on one joint**, the other fifteen
+  held at their measured values, so a correct command is a near-no-op;
+* the run **refuses to start** unless all 16 joints have been seen on
+  ``/joint_states``. ``OpenArmRealHAL`` zero-fills unreported joints into a
+  full 16-DoF vector, so a partial state reads as a plausible pose containing
+  zeros — command "measured + delta" on top of that and the cell slews to
+  approximately home;
+* ``time_from_start`` is stretched to 0.8 s (production uses 0.1 s), bounding
+  the rate by construction. This test therefore does **not** validate the
+  production 100 ms deadline — only where the values land.
+
+Each case restores the joint to its measured pose before returning, so the
+test is idempotent (CLAUDE.md §2), and the teardown latches the HAL.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROBOT = REPO_ROOT / "robots" / "openarm" / "robot.yaml"
+RSKILL = REPO_ROOT / "rskills" / "rskill-pi05-openarm-restock_shelf-bf16" / "rskill.yaml"
+
+_CAN_LINKS = ("openarm_left", "openarm_right")
+
+#: Radians. ~1.15°, small enough to be unremarkable on a correct command and
+#: large enough to be unambiguous against encoder noise.
+_DELTA_RAD = 0.02
+
+#: A joint we did not address must not wander further than this. Generous
+#: enough for gravity sag and controller jitter, tight enough that a misrouted
+#: `_DELTA_RAD` (which would land a full delta on the wrong joint) trips it.
+_QUIET_TOL_RAD = 0.01
+
+#: How close the addressed joint must get to its target. A trajectory
+#: controller has steady-state error; this asserts arrival, not stiffness.
+_ARRIVAL_TOL_RAD = 0.015
+
+#: Seconds to let the 0.8 s trajectory finish and the state settle.
+_SETTLE_S = 2.5
+
+
+def _can_links_up() -> bool:
+    from openral_cli.autodetect import enumerate_can_interfaces
+
+    up = {i.name for i in enumerate_can_interfaces() if i.is_up}
+    return set(_CAN_LINKS) <= up
+
+
+requires_can = pytest.mark.skipif(
+    not _can_links_up(), reason="OpenArm CAN links are not both up — not on the cell"
+)
+requires_rclpy = pytest.mark.skipif(
+    importlib.util.find_spec("rclpy") is None, reason="rclpy not available"
+)
+requires_motion_optin = pytest.mark.skipif(
+    os.environ.get("OPENRAL_OPENARM_ALLOW_MOTION") != "1",
+    reason="motion gate closed — export OPENRAL_OPENARM_ALLOW_MOTION=1 to enable",
+)
+requires_attended = pytest.mark.skipif(
+    os.environ.get("OPENRAL_OPENARM_ATTENDED") != "1",
+    reason=(
+        "unattended — export OPENRAL_OPENARM_ATTENDED=1 only while someone is "
+        "physically at the E-stop"
+    ),
+)
+
+
+@requires_can
+@requires_rclpy
+@requires_motion_optin
+@requires_attended
+@pytest.mark.parametrize(
+    "joint_index,joint_label",
+    [
+        # The gripper first and by default: 1-DoF, lowest inertia, no reach —
+        # and the exact actuator ADR-0102 exists for, since the pre-0102 code
+        # dropped its command silently.
+        (15, "right_gripper"),
+        # Then the most distal arm joint, which proves an ARM slot lands on the
+        # right arm joint rather than only that the gripper slot works.
+        (14, "right_joint7"),
+    ],
+)
+def test_one_slot_dispatched_tick_moves_only_the_joint_it_addresses(
+    joint_index: int, joint_label: str
+) -> None:  # pragma: no cover
+    """Command measured-pose + delta on one joint; prove only that joint moved.
+
+    Drives the production path end to end — `_dispatch_slots` over the
+    committed manifest, into `OpenArmRealHAL`, out through four real
+    `JointTrajectory` publishers to `openarm_bringup`'s controllers — and then
+    reads the physical result back off `/joint_states`.
+    """
+    import numpy as np
+    import rclpy
+    from openral_core.exceptions import ROSEStopRequested
+    from openral_core.schemas import RobotDescription, RSkillManifest
+    from openral_hal.openarm_real import OpenArmRealHAL
+    from rclpy.node import Node
+
+    from tests.hil._openarm_ros_transport import OpenArmHILTransport
+
+    pytest.importorskip("openral_rskill_ros", reason="needs the built ROS overlay")
+    from openral_rskill_ros.rskill_runner_node import _dispatch_slots
+
+    robot = RobotDescription.from_yaml(str(ROBOT))
+    manifest = RSkillManifest.from_yaml(str(RSKILL))
+
+    context = rclpy.Context()
+    context.init()
+    node = Node("openarm_slot_motion_hil", context=context)
+    hal = None
+    try:
+        probe = OpenArmRealHAL(robot, require_can_links=False)
+        transport = OpenArmHILTransport(
+            node,
+            probe.ros2_control_joint_names(),
+            command_topics=list(probe.command_topics()),
+            time_from_start_s=0.8,
+        )
+        hal = OpenArmRealHAL(robot, publish_fn=transport.publish, state_fn=transport.state)
+        hal.connect()
+
+        # Gate on a COMPLETE joint state. A partial one zero-fills into a
+        # plausible-looking pose, and "measured + delta" on top of that is a
+        # command to slew the whole cell home.
+        assert transport.wait_for_every_joint(deadline_s=5.0), (
+            "/joint_states never reported these joints: "
+            f"{transport.missing_joints()}. Refusing to move: the HAL zero-fills "
+            "unreported joints, so the 'measured' pose would be partly fiction. "
+            "Is openarm_bringup's ros2_control stack up?"
+        )
+
+        measured = list(hal.read_state().position)
+        assert len(measured) == 16
+
+        target = list(measured)
+        target[joint_index] = measured[joint_index] + _DELTA_RAD
+
+        actions = _dispatch_slots(
+            manifest.action_contract.slots,
+            np.asarray(target, dtype=np.float32),
+            description=robot,
+        )
+        for action in actions:
+            action.tick_index = 1
+        for action in actions:
+            hal.send_action(action)
+
+        transport.spin_for(_SETTLE_S)
+        after = list(hal.read_state().position)
+
+        moved = after[joint_index] - measured[joint_index]
+        assert abs(after[joint_index] - target[joint_index]) < _ARRIVAL_TOL_RAD, (
+            f"{joint_label} did not reach its target: measured "
+            f"{measured[joint_index]:.4f} → commanded {target[joint_index]:.4f}, "
+            f"got {after[joint_index]:.4f} (moved {moved:+.4f} rad)"
+        )
+
+        for i, name in enumerate(probe.ros2_control_joint_names()):
+            if i == joint_index:
+                continue
+            drift = abs(after[i] - measured[i])
+            assert drift < _QUIET_TOL_RAD, (
+                f"commanded only {joint_label}, but {name} moved {drift:.4f} rad "
+                f"({measured[i]:.4f} → {after[i]:.4f}). A misrouted slot puts the "
+                "delta on the wrong joint, which is exactly this assertion."
+            )
+
+        # Idempotence: put it back where we found it before leaving.
+        restore = _dispatch_slots(
+            manifest.action_contract.slots,
+            np.asarray(measured, dtype=np.float32),
+            description=robot,
+        )
+        for action in restore:
+            action.tick_index = 2
+        for action in restore:
+            hal.send_action(action)
+        transport.spin_for(_SETTLE_S)
+        back = list(hal.read_state().position)
+        assert abs(back[joint_index] - measured[joint_index]) < _ARRIVAL_TOL_RAD, (
+            f"{joint_label} did not return to {measured[joint_index]:.4f} "
+            f"(left at {back[joint_index]:.4f}) — the cell is not where the test "
+            "found it."
+        )
+    finally:
+        # CLAUDE.md §2 requires an e-stop hook on HIL teardown. For this adapter
+        # `estop()` latches the HAL and raises rather than commanding hardware —
+        # the physical stop is the button, which is why this test is gated on
+        # someone being next to it.
+        if hal is not None:
+            try:
+                hal.estop()
+            except ROSEStopRequested:
+                pass
+            hal.disconnect()
+        node.destroy_node()
+        context.try_shutdown()


### PR DESCRIPTION
## What changed

The powered gate ADR-0102 has been missing, plus the `ros2_control` bridge the OpenArm never had.

#242 proved the composed 16-DoF vector reaches the four controllers correctly named and correctly sliced — but it never publishes, so it cannot see a sign flip, a scale error, or a joint the controller silently ignores. This closes command→motion.

| file | |
|---|---|
| `tests/hil/_openarm_ros_transport.py` | the 4-way bimanual bridge — HIL counterpart of `_aloha_ros_transport` for the OpenArm's fan-out |
| `tests/hil/test_openarm_slot_group_motion.py` | the one test in the tree that commands a real OpenArm to move |
| `tests/hil/test_openarm_ros_transport.py` | the transport's own tests, which need only a ROS install |
| `tests/hil/test_openarm_bringup_agreement.py` | the HAL's controller/joint table vs `openarm_bringup`'s YAML — no hardware at all |

## Why a small delta is not by itself a small motion

This is the part worth reviewing carefully. The wire format is `trajectory_msgs/JointTrajectory`: an **absolute** position with a deadline, not a delta. Travel is `(target − measured) / time_from_start`, so the distance moved is set by *how wrong the command is* — which is exactly the quantity under test. Picking a small number does not bound it.

Three things do:

- **every target is measured-pose + delta on one joint**, the other fifteen held at their measured values, so a correct command is a near-no-op;
- **the run refuses to start** until all 16 joints have appeared on `/joint_states`. `OpenArmRealHAL` zero-fills unreported joints into a full 16-DoF vector, so a partial state reads downstream as a plausible pose containing zeros — command "measured + delta" on top of that and the cell slews toward home. `test_a_partial_joint_state_is_reported_missing` proves the gate actually catches this;
- **`time_from_start` is stretched to 0.8 s** (production hardcodes 0.1 s), bounding the rate by construction. Consequence, stated in the test: this does **not** validate the production 100 ms deadline, only where the values land.

## Gates

Two, independent, both explicit:

```
OPENRAL_OPENARM_ALLOW_MOTION=1   # this bench can move
OPENRAL_OPENARM_ATTENDED=1       # someone is at the E-stop right now
```

Separate on purpose: a rig that leaves the first exported must not thereby become a rig that moves unattended. Neither is set in CI or by `just test`.

Cases run gripper-first — 1-DoF, lowest inertia, no reach, and the actuator ADR-0102 exists for, since the pre-0102 code dropped its command silently — then the most distal arm joint, which proves an *arm* slot lands on the right arm joint rather than only that the gripper slot works. Each restores the measured pose before returning, so the suite is idempotent (CLAUDE.md §2).

## On the transport

Simpler than ALOHA's, because ADR-0102 puts `joint_names` **in the message**: it forwards them rather than keeping a second copy of the slice table that could drift out of step with the HAL. It is built from `ros2_control_joint_names()` — the URDF namespace (`openarm_left_joint1`) that `/joint_states` is keyed by, not the manifest's (`left_joint1`). That distinction is the one #242 learned the hard way.

`publish` raises on an unknown topic or a name/value width mismatch rather than dropping the command — silently dropping is the ADR-0102 failure mode itself.

## How tested

```
16 passed, 40 skipped   # tests/hil/, ROS host, no cell attached
 4 passed               # bringup agreement, on the cell, nothing energised
```

The 11 transport tests and #242's preflight run; the motion tests skip on their gates. The transport suite uses real publishers and real messages over DDS on an **isolated domain with LOCALHOST discovery** — not ceremony for a suite whose whole subject is arm command topics, given #227 (a stray graph reaching a live OpenArm on another host).

Writing them caught two real bugs off-cell, which is the argument for the transport having its own tests: a missing `_on_joint_state` callback, and `rclpy.spin_once` reaching for the uninitialised default context instead of the node's own.

`ruff check` / `ruff format` clean; `tools/refresh_methods_linenos.py --check` clean; `docs/methods/12-tests-hil.md` updated.

## The bringup-agreement suite (added after review started)

Asked to bring the controllers up and just *observe*, I checked what activation costs first:

```cpp
// openarm_simple_hardware.cpp:223
hardware_interface::CallbackReturn OpenArmHW::on_activate(...)
  openarm_->enable_all();        // ← line 227
```

Activating energises **all sixteen motors** — so "read-only observation" isn't read-only. But the thing it would have proved is on disk, so this suite reads it instead.

The HAL's `_command_groups` is a hand-copied transcription of names that live in a **different repo** (`openarm_ros2`) on a different cadence, and nothing had ever compared the two. The failure mode if they drift is the worst kind: a `JointTrajectoryController` handed joints it does not own **rejects the whole message** — no publisher-side exception, nothing unusual on `/joint_states`, the arm simply doesn't move, which is indistinguishable from a policy choosing to hold still. That is the ADR-0102 failure shape one layer further out.

The gripper is the trap, and the reason the file exists: bringup calls it `openarm_left_finger_joint1`, **not** `openarm_left_gripper`. `_gripper`, `_gripper_joint` and `_finger_joint` are all wrong, and all fail silently.

Verified on the cell against the real config — **4 passed**, CAN counters unchanged, nothing energised. Four for four, gripper included. Gated on `openarm_bringup` being on the ament prefix path, so it skips cleanly off-rig.

## Not yet run on hardware

The cell was in use and unattended. This lands so it can be **reviewed before anyone powers it** — which is the right order for the only test that moves a real arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

