### PR TITLE
feat(hal): gate the ros2_control transport on shape, not ancestry

### DIFF
--- a/docs/methods/01-hal.md
+++ b/docs/methods/01-hal.md
@@ -470,7 +470,7 @@ _Real-hardware adapter for the Enactic OpenArm v2.  Commands `openarm_bringup`'s
 - `class OpenArmRealHAL(RosControlHAL)` — 16-DoF real-HW adapter, same action layout as `OpenArmMujocoHAL`.  Three behaviours that each guard a *silent* failure: (a) **fan-out** — the bimanual bringup spawns four controllers (per-side arm + gripper), so one action is sliced across four topics, and every message is built before any is published so a rejected action cannot leave one arm on a new chunk and the other on a stale setpoint; (b) **read by name** — those four controllers publish into `/joint_states` independently with no ordering guarantee, so `read_state` matches by ros2_control joint name and returns manifest order, raising rather than zero-filling when a joint is absent (a missing gripper reading as `0.0` is a plausible pose and would go unnoticed); (c) **bus preflight** — `connect()` refuses a CAN link that is missing, is not a CAN device, or is down, because a HAL reporting "connected" over a dead bus makes every `send_action` succeed while the arm stands still.  `estop_recovery = RESETTABLE`.
   - `__init__(description=None, *, left_can_interface='openarm_left', right_can_interface='openarm_right', left_arm_controller=..., left_gripper_controller=..., right_arm_controller=..., right_gripper_controller=..., joint_state_topic='/joint_states', publish_fn=None, state_fn=None, staleness_limit_s=0.5, require_can_links=True)` — Rejects a manifest that is not 16-joint, or whose joints lack `sim_joint_name` (which for the OpenArm *is* the URDF joint name — the one copy of the logical→ros2_control mapping).
   - `ros2_control_joint_names() -> list[str]` — 16 URDF names in action-vector order.
-  - `command_topics() -> list[str]` — The four `/…/joint_trajectory` topics.
+  - `command_bindings() -> dict[str, ControllerKind]` — The four `/…/joint_trajectory` topics, all `JOINT_TRAJECTORY`: `openarm_bringup` configures each gripper as a 1-DoF `JointTrajectoryController` rather than a gripper action server, so grippers and arms take the same message.
   - `health() -> HALHealthReport` — Cached per-bus state from `connect()`; performs no I/O (lifecycle diagnostics heartbeat).
   - `send_action(action)` — **ADR-0102 slot groups.** A `tick_group_size > 1` action is staged (`SlotGroupStager`) instead of published; the tick's slots are composed into one 16-DoF `JOINT_POSITION` action by `_compose_group` and fan out through the same all-or-nothing publish as a whole-vector action. A **standalone** gripper action raises `ROSConfigError` — the four bimanual controllers are driven from one joint vector, so there is nowhere to put it, and the pre-0102 code fell through to `if action.joint_targets is None: return` and dropped it silently (arms moving, grippers never actuating, nothing on the wire).
   - `_compose_group(group) -> Action` — Delegates to `compose_slot_group` over `description.joints`; logs `hal.send_action.slot_group`.
@@ -560,32 +560,35 @@ _SO100DigitalTwin — in-process simulator for the SO-100 follower arm._
 ### `python/hal/src/openral_hal/ros_control.py`
 _RosControlHAL — `ros2_control`-backed HAL adapter._
 
-- `class RosControlHAL` — `ros2_control`-backed HAL adapter. (L72)
-  - `__init__(description, controller_name, *, joint_state_topic='/joint_states', command_topic=None, publish_fn=None, state_fn=None, staleness_limit_s=0.5)` (L101)
-  - `attach_transport(publish_fn, state_fn, stamp_fn=None) -> None` — Bind a live transport after construction; `build_hal` runs before any ROS node exists, so a real deployment cannot pass one to `__init__`. `stamp_fn` is the transport's per-message arrival clock and is what makes the staleness check a freshness check rather than a time-since-connect check. Rejects a non-callable `stamp_fn` at wire-up. (L136)
-  - `command_topics() -> list[str]` — Every controller topic this HAL publishes to; one per entry becomes a transport publisher. Overridden by the bimanual OpenArm (4). (L175)
-  - `ros2_control_joint_names() -> list[str]` — Joint names in ros2_control's namespace, action order; what `/joint_states` is keyed by. Overridden where URDF names differ from manifest names (OpenArm). (L185)
-  - **(property)** `joint_state_topic -> str` — The aggregated `sensor_msgs/JointState` topic this HAL reads. (L195)
-  - `connect() -> None` (L201)
+- `class ControllerKind(StrEnum)` — Which ros2_control controller sits behind one command topic, and therefore which message type commands it: `JOINT_TRAJECTORY` (`trajectory_msgs/JointTrajectory` — every ros2_control robot in this repo, OpenArm's 1-DoF grippers included) and `FORWARD_COMMAND` (`std_msgs/Float64MultiArray`, the `forward_command_controller` family; no in-repo robot yet). Declared rather than assumed because publishing the wrong type is **silent** — DDS never delivers it, so the arm does not move and nothing logs an error. Re-exported from `openral_hal`. (L57)
+- `class RosControlHAL` — `ros2_control`-backed HAL adapter. (L109)
+  - `__init__(description, controller_name, *, joint_state_topic='/joint_states', command_topic=None, publish_fn=None, state_fn=None, staleness_limit_s=0.5)` (L138)
+  - `attach_transport(publish_fn, state_fn, stamp_fn=None) -> None` — Bind a live transport after construction; `build_hal` runs before any ROS node exists, so a real deployment cannot pass one to `__init__`. `stamp_fn` is the transport's per-message arrival clock and is what makes the staleness check a freshness check rather than a time-since-connect check. Rejects a non-callable `stamp_fn` at wire-up. (L173)
+  - `command_bindings() -> dict[str, ControllerKind]` — Every controller topic this HAL publishes to, each with the wire format its controller speaks; one entry becomes one typed transport publisher. Insertion order is the `send_action` fan-out order. **This is the override point for a new robot** — overridden by the bimanual OpenArm (4 topics, all `JOINT_TRAJECTORY`). (L212)
+  - `command_topics() -> list[str]` — Derived from `command_bindings()` so the topic list and the declared formats cannot drift; override `command_bindings`, not this. (L226)
+  - `ros2_control_joint_names() -> list[str]` — Joint names in ros2_control's namespace, action order; what `/joint_states` is keyed by. Overridden where URDF names differ from manifest names (OpenArm). (L234)
+  - **(property)** `joint_state_topic -> str` — The aggregated `sensor_msgs/JointState` topic this HAL reads. (L244)
+  - `connect() -> None` (L250)
   - `disconnect() -> None` — inherited from `HALBase` (flag-and-log default; no extra teardown needed).
-  - `read_state() -> JointState` — Age is measured from `stamp_fn()` when a transport supplied one, else from `connect()`. (L221)
-  - `send_action(action) -> None` — Publish JointTrajectory; carries `joint_names` so no transport keeps a second copy of the mapping. (L263)
-  - `estop() -> None` (L298)
+  - `read_state() -> JointState` — Age is measured from `stamp_fn()` when a transport supplied one, else from `connect()`. (L270)
+  - `send_action(action) -> None` — Publish JointTrajectory; carries `joint_names` so no transport keeps a second copy of the mapping. (L312)
+  - `estop() -> None` (L347)
   - private: `_require_connected`, `_validate_action`
-- `_default_publish(topic, msg) -> None` — No-op publish when no real ROS 2 node. (L62)
+- `_default_publish(topic, msg) -> None` — No-op publish when no real ROS 2 node. (L99)
 
 ### `python/hal/src/openral_hal/ros_control_transport.py`
 _Production `rclpy` transport shared by every real `RosControlHAL` robot._
 
-- `class RosControlDrivable(Protocol)` — **runtime-checkable**, structural: what a HAL must expose to be driven by `RosControlTransport` (`command_topics`, `ros2_control_joint_names`, `joint_state_topic`, `attach_transport`). The lifecycle node's wiring gates on *this*, not on `isinstance(hal, RosControlHAL)`, so a ros2_control robot that reimplements the fan-out on `HALBase` rather than inheriting (`AlohaHAL` does) can opt in by shape instead of being silently skipped. Non-method member (`joint_state_topic` is a property) so `isinstance` works but `issubclass` raises — gate with `isinstance`. (L49)
-- `class RosControlTransport` — Bridges one `RosControlHAL` to live ros2_control topics. Built only from what the HAL reports about itself (`command_topics()`, `ros2_control_joint_names()`, `joint_state_topic`), so a one-controller UR and the four-controller bimanual OpenArm are one code path and a new robot needs no transport code. Wired automatically by the lifecycle node under `hal_mode:=real`. **Reuse watch:** the canonical real-HW ros2_control bridge — do not hand-roll publishers in a per-robot HAL. (L99)
-  - `__init__(node, *, command_topics, joint_names, joint_state_topic='/joint_states')` — Refuses an empty topic or joint list. (L116)
-  - `publish(topic, msg) -> None` — One command dict → `JointTrajectory` on that controller. Publishes the chunk's final step only (a point is an absolute target the controller interpolates toward). Raises on a topic the HAL never declared, **and on a payload it cannot express** (no `joint_targets` key — e.g. Aloha's `{"position": …}` gripper command): dropping that quietly would be a silent no-op on the actuation path. An empty `joint_targets` list is the distinct, benign "nothing to send this tick". (L185)
-  - `state() -> dict[str, object]` — Newest joint state projected onto the HAL's joint order; merged **by name, never index**, since split controllers publish independently. (L263)
-  - `last_arrival() -> float` — `time.monotonic()` of the newest message; 0.0 before the first. Feeds `RosControlHAL.attach_transport(stamp_fn=...)`. (L284)
-  - `seen_joints() -> set[str]` (L290)
-  - `missing_joints() -> list[str]` (L294)
+- `class RosControlDrivable(Protocol)` — **runtime-checkable**, structural: what a HAL must expose to be driven by `RosControlTransport` (`command_bindings`, `ros2_control_joint_names`, `joint_state_topic`, `attach_transport`). The lifecycle node's wiring gates on *this*, not on `isinstance(hal, RosControlHAL)`, so a ros2_control robot that reimplements the fan-out on `HALBase` rather than inheriting can opt in by shape instead of being silently skipped. Non-method member (`joint_state_topic` is a property) so `isinstance` works but `issubclass` raises — gate with `isinstance`. (L53)
+- `class RosControlTransport` — Bridges one `RosControlHAL` to live ros2_control topics. Built only from what the HAL reports about itself (`command_bindings()`, `ros2_control_joint_names()`, `joint_state_topic`), so a one-controller UR and the four-controller bimanual OpenArm are one code path and a new robot needs no transport code. Wired automatically by the lifecycle node under `hal_mode:=real`. **Reuse watch:** the canonical real-HW ros2_control bridge — do not hand-roll publishers in a per-robot HAL. (L101)
+  - `__init__(node, *, command_topics, joint_names, joint_state_topic='/joint_states', command_kinds=None)` — Refuses an empty topic or joint list, and a `command_kinds` entry naming a topic not in `command_topics` (a typo there would silently leave the real topic on the `JOINT_TRAJECTORY` default). Topics absent from `command_kinds` default to `JOINT_TRAJECTORY`. (L122)
+  - `publish(topic, msg) -> None` — One command dict → the message type this topic's declared `ControllerKind` calls for. Publishes the chunk's final step only (a point is an absolute target the controller interpolates toward). Raises on a topic the HAL never declared, **and on a payload it cannot express** (no `joint_targets` key — e.g. a `{"position": …}` gripper command): dropping that quietly would be a silent no-op on the actuation path. An empty `joint_targets` list is the distinct, benign "nothing to send this tick". (L206)
+  - `state() -> dict[str, object]` — Newest joint state projected onto the HAL's joint order; merged **by name, never index**, since split controllers publish independently. (L303)
+  - `last_arrival() -> float` — `time.monotonic()` of the newest message; 0.0 before the first. Feeds `RosControlHAL.attach_transport(stamp_fn=...)`. (L324)
+  - `seen_joints() -> set[str]` (L330)
+  - `missing_joints() -> list[str]` (L334)
   - private: `_time_from_start_s`, `_on_joint_state`
+- `_message_type(kind) -> type` — The one place a `ControllerKind` becomes a ROS message class. Adding an enum member without extending this raises at wire-up rather than publishing a plausible-but-wrong type onto the actuation path; `tests/unit/test_ros_control_transport.py::test_every_controller_kind_maps_to_a_message_type` pins that. (L373)
 
 ### `python/hal/src/openral_hal/sim_transport.py`
 _SimTransport — in-memory simulated `ros2_control` transport._

--- a/docs/methods/01-hal.md
+++ b/docs/methods/01-hal.md
@@ -577,13 +577,14 @@ _RosControlHAL — `ros2_control`-backed HAL adapter._
 ### `python/hal/src/openral_hal/ros_control_transport.py`
 _Production `rclpy` transport shared by every real `RosControlHAL` robot._
 
-- `class RosControlTransport` — Bridges one `RosControlHAL` to live ros2_control topics. Built only from what the HAL reports about itself (`command_topics()`, `ros2_control_joint_names()`, `joint_state_topic`), so a one-controller UR and the four-controller bimanual OpenArm are one code path and a new robot needs no transport code. Wired automatically by the lifecycle node under `hal_mode:=real`. **Reuse watch:** the canonical real-HW ros2_control bridge — do not hand-roll publishers in a per-robot HAL. (L58)
-  - `__init__(node, *, command_topics, joint_names, joint_state_topic='/joint_states')` — Refuses an empty topic or joint list. (L75)
-  - `publish(topic, msg) -> None` — One command dict → `JointTrajectory` on that controller. Publishes the chunk's final step only (a point is an absolute target the controller interpolates toward). Raises on a topic the HAL never declared. (L143)
-  - `state() -> dict[str, object]` — Newest joint state projected onto the HAL's joint order; merged **by name, never index**, since split controllers publish independently. (L206)
-  - `last_arrival() -> float` — `time.monotonic()` of the newest message; 0.0 before the first. Feeds `RosControlHAL.attach_transport(stamp_fn=...)`. (L227)
-  - `seen_joints() -> set[str]` (L233)
-  - `missing_joints() -> list[str]` (L237)
+- `class RosControlDrivable(Protocol)` — **runtime-checkable**, structural: what a HAL must expose to be driven by `RosControlTransport` (`command_topics`, `ros2_control_joint_names`, `joint_state_topic`, `attach_transport`). The lifecycle node's wiring gates on *this*, not on `isinstance(hal, RosControlHAL)`, so a ros2_control robot that reimplements the fan-out on `HALBase` rather than inheriting (`AlohaHAL` does) can opt in by shape instead of being silently skipped. Non-method member (`joint_state_topic` is a property) so `isinstance` works but `issubclass` raises — gate with `isinstance`. (L49)
+- `class RosControlTransport` — Bridges one `RosControlHAL` to live ros2_control topics. Built only from what the HAL reports about itself (`command_topics()`, `ros2_control_joint_names()`, `joint_state_topic`), so a one-controller UR and the four-controller bimanual OpenArm are one code path and a new robot needs no transport code. Wired automatically by the lifecycle node under `hal_mode:=real`. **Reuse watch:** the canonical real-HW ros2_control bridge — do not hand-roll publishers in a per-robot HAL. (L99)
+  - `__init__(node, *, command_topics, joint_names, joint_state_topic='/joint_states')` — Refuses an empty topic or joint list. (L116)
+  - `publish(topic, msg) -> None` — One command dict → `JointTrajectory` on that controller. Publishes the chunk's final step only (a point is an absolute target the controller interpolates toward). Raises on a topic the HAL never declared, **and on a payload it cannot express** (no `joint_targets` key — e.g. Aloha's `{"position": …}` gripper command): dropping that quietly would be a silent no-op on the actuation path. An empty `joint_targets` list is the distinct, benign "nothing to send this tick". (L185)
+  - `state() -> dict[str, object]` — Newest joint state projected onto the HAL's joint order; merged **by name, never index**, since split controllers publish independently. (L263)
+  - `last_arrival() -> float` — `time.monotonic()` of the newest message; 0.0 before the first. Feeds `RosControlHAL.attach_transport(stamp_fn=...)`. (L284)
+  - `seen_joints() -> set[str]` (L290)
+  - `missing_joints() -> list[str]` (L294)
   - private: `_time_from_start_s`, `_on_joint_state`
 
 ### `python/hal/src/openral_hal/sim_transport.py`

--- a/packages/openral_hal_openarm/README.md
+++ b/packages/openral_hal_openarm/README.md
@@ -84,3 +84,16 @@ rate ~600 Hz).
 Only then start this package's lifecycle node with `hal_mode:=real`. It attaches
 its `RosControlTransport` automatically and leaves the global `/joint_states` to
 the controller's own `joint_state_broadcaster`.
+
+### Checking the transport without the arm
+
+`tests/sim/test_openarm_hal_ros2_control.py` stands the same stack up over
+`mock_components/GenericSystem` — real `controller_manager`, real
+`joint_trajectory_controller`, real `joint_state_broadcaster`, fake motors — and
+drives it through the production `RosControlHAL` + `RosControlTransport`. Run it
+before touching the rig: it catches a mistyped command topic, a wrong
+`ControllerKind` or a joint-name mismatch in seconds, with no power on the arm.
+It needs only `ros-$ROS_DISTRO-ros2-control` and
+`ros-$ROS_DISTRO-ros2-controllers`, not the vendor stack, and skips where those
+are absent. What it cannot check is anything physical — following error, CAN
+timing, bus health — which is why the checks above still matter.

--- a/python/hal/src/openral_hal/__init__.py
+++ b/python/hal/src/openral_hal/__init__.py
@@ -93,7 +93,7 @@ from openral_hal.protocol import (
     ResettableLifecycleEStopHAL,
 )
 from openral_hal.resolver import build_hal
-from openral_hal.ros_control import RosControlHAL
+from openral_hal.ros_control import ControllerKind, RosControlHAL
 from openral_hal.sawyer_real import (
     SAWYER_DESCRIPTION,
     SAWYER_REAL_DESCRIPTION,
@@ -143,6 +143,7 @@ __all__ = [
     "AlohaHAL",
     "AlohaMujocoHAL",
     "AnvilOpenArmV2MujocoHAL",
+    "ControllerKind",
     "EStopRecovery",
     "FrankaPandaHAL",
     "FrankaPandaRealHAL",

--- a/python/hal/src/openral_hal/lifecycle.py
+++ b/python/hal/src/openral_hal/lifecycle.py
@@ -1541,11 +1541,11 @@ if _ROS2_AVAILABLE:
             """
             from openral_hal.ros_control_transport import RosControlDrivable
 
-            # Structural, not by ancestry: any HAL exposing the four members of
+            # Structural, not by ancestry: any HAL exposing the members of
             # `RosControlDrivable` gets wired. Gating on `isinstance(...,
             # RosControlHAL)` would skip a ros2_control robot that reimplements
-            # the same fan-out on `HALBase` instead of inheriting — which the
-            # repo already contains — leaving it with no transport and no error.
+            # the same fan-out on `HALBase` instead of inheriting, leaving it
+            # with no transport and no error.
             hal = self._hal
             if not isinstance(hal, RosControlDrivable):
                 return
@@ -1555,11 +1555,13 @@ if _ROS2_AVAILABLE:
 
             from openral_hal.ros_control_transport import RosControlTransport
 
+            bindings = hal.command_bindings()
             transport = RosControlTransport(
                 self,
-                command_topics=hal.command_topics(),
+                command_topics=list(bindings),
                 joint_names=hal.ros2_control_joint_names(),
                 joint_state_topic=hal.joint_state_topic,
+                command_kinds=bindings,
             )
             hal.attach_transport(transport.publish, transport.state, transport.last_arrival)
             self._ros_control_transport = transport
@@ -1575,9 +1577,10 @@ if _ROS2_AVAILABLE:
             if self._joint_state_pub is not None:
                 self.destroy_publisher(self._joint_state_pub)
                 self._joint_state_pub = None
+            kinds = ", ".join(sorted({k.value for k in bindings.values()}))
             self.get_logger().info(
-                f"ros2_control transport attached: {len(hal.command_topics())} command "
-                f"topic(s), reading {hal.joint_state_topic}; global /joint_states left to "
+                f"ros2_control transport attached: {len(bindings)} command topic(s) "
+                f"[{kinds}], reading {hal.joint_state_topic}; global /joint_states left to "
                 "the controller's joint_state_broadcaster."
             )
 

--- a/python/hal/src/openral_hal/lifecycle.py
+++ b/python/hal/src/openral_hal/lifecycle.py
@@ -1539,10 +1539,15 @@ if _ROS2_AVAILABLE:
             per-robot code. The serial arms (SO-100/SO-101) own their bus and
             are correctly skipped by the isinstance check.
             """
-            from openral_hal.ros_control import RosControlHAL
+            from openral_hal.ros_control_transport import RosControlDrivable
 
+            # Structural, not by ancestry: any HAL exposing the four members of
+            # `RosControlDrivable` gets wired. Gating on `isinstance(...,
+            # RosControlHAL)` would skip a ros2_control robot that reimplements
+            # the same fan-out on `HALBase` instead of inheriting — which the
+            # repo already contains — leaving it with no transport and no error.
             hal = self._hal
-            if not isinstance(hal, RosControlHAL):
+            if not isinstance(hal, RosControlDrivable):
                 return
             hal_mode = self.get_parameter("hal_mode").get_parameter_value().string_value or "sim"
             if hal_mode != "real":

--- a/python/hal/src/openral_hal/openarm_real.py
+++ b/python/hal/src/openral_hal/openarm_real.py
@@ -75,7 +75,7 @@ from openral_hal._real_description import make_real_description
 from openral_hal._slot_group import GRIPPER_MODES, SlotGroupStager, compose_slot_group
 from openral_hal.openarm import OPENARM_DESCRIPTION
 from openral_hal.protocol import EStopRecovery, HALHealthReport
-from openral_hal.ros_control import RosControlHAL
+from openral_hal.ros_control import ControllerKind, RosControlHAL
 
 __all__ = [
     "OPENARM_REAL_DESCRIPTION",
@@ -262,15 +262,20 @@ class OpenArmRealHAL(RosControlHAL):
         """
         return list(self._ros2_names)
 
-    def command_topics(self) -> list[str]:
-        """Return the four command topics this adapter publishes to.
+    def command_bindings(self) -> dict[str, ControllerKind]:
+        """Return the four command topics this adapter publishes to, with kinds.
+
+        All four are `JointTrajectoryController` instances — `openarm_bringup`
+        configures each gripper as a 1-DoF one rather than a gripper action
+        server, so the grippers take the same `trajectory_msgs/JointTrajectory`
+        the arms do.
 
         Example:
             >>> from openral_hal.openarm_real import OpenArmRealHAL
             >>> OpenArmRealHAL(require_can_links=False).command_topics()[1]
             '/left_gripper_controller/joint_trajectory'
         """
-        return [topic for topic, _, _ in self._command_groups]
+        return {topic: ControllerKind.JOINT_TRAJECTORY for topic, _, _ in self._command_groups}
 
     # ── Lifecycle ─────────────────────────────────────────────────────────────
 

--- a/python/hal/src/openral_hal/ros_control.py
+++ b/python/hal/src/openral_hal/ros_control.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable
+from enum import StrEnum
 
 import structlog
 from openral_core.exceptions import (
@@ -50,7 +51,43 @@ from openral_core.schemas import Action, JointState, RobotDescription
 
 from openral_hal._base import HALBase, _raw_floats
 
-__all__ = ["RosControlHAL"]
+__all__ = ["ControllerKind", "RosControlHAL"]
+
+
+class ControllerKind(StrEnum):
+    """Which ros2_control controller sits behind one command topic.
+
+    A command topic is not self-describing: the topic name says nothing about
+    the message type the controller expects, and publishing the wrong type is
+    *silent* — DDS simply never delivers it, so the arm does not move and
+    nothing anywhere logs an error. That is the same class of failure as the
+    no-op transport this layer already had to fix once, so the wire format is
+    declared rather than assumed.
+
+    A HAL names the kind per topic in `command_bindings`; `RosControlTransport`
+    builds the matching publisher and message from it. Adding a robot whose
+    controllers differ therefore means declaring a kind, not writing transport
+    code.
+
+    Only kinds this transport can actually build a message for belong here —
+    an unlisted controller must fail loudly at wire-up rather than be
+    approximated by a neighbouring one.
+    """
+
+    #: `joint_trajectory_controller/JointTrajectoryController`, commanded via
+    #: `trajectory_msgs/JointTrajectory` on `~/joint_trajectory`. Every
+    #: ros2_control robot in this repo uses this, grippers included (OpenArm's
+    #: are 1-DoF instances of it).
+    JOINT_TRAJECTORY = "joint_trajectory"
+
+    #: The `forward_command_controller` family — `ForwardCommandController`,
+    #: `position_controllers/JointGroupPositionController` and siblings —
+    #: commanded via `std_msgs/Float64MultiArray` on `~/commands`. No robot in
+    #: this repo uses one yet; it is here because it is the other type a
+    #: ros2_control arm is commonly configured with, and because two kinds are
+    #: what make the dispatch real rather than a rename of an assumption.
+    FORWARD_COMMAND = "forward_command"
+
 
 log = structlog.get_logger(__name__)
 
@@ -172,15 +209,27 @@ class RosControlHAL(HALBase):
         self._stamp_fn = stamp_fn
         self._last_state_time = time.monotonic()
 
-    def command_topics(self) -> list[str]:
-        """Return every controller topic this HAL publishes to.
+    def command_bindings(self) -> dict[str, ControllerKind]:
+        """Return each controller topic this HAL publishes to, with its kind.
 
-        One topic for a single-controller arm; robots whose controllers are
-        split (the bimanual OpenArm's arm+gripper per side) override this. A
-        transport builds one publisher per entry, so it never needs to know
-        which robot it is serving.
+        One entry for a single-controller arm; robots whose controllers are
+        split (the bimanual OpenArm's arm+gripper per side) override this.
+        Insertion order is the fan-out order `send_action` uses, so it is
+        load-bearing.
+
+        This is the override point for a new robot: declaring the topic *and*
+        the message type its controller speaks is what lets the transport
+        publish without guessing, so adding a robot needs no transport code.
         """
-        return [self._command_topic]
+        return {self._command_topic: ControllerKind.JOINT_TRAJECTORY}
+
+    def command_topics(self) -> list[str]:
+        """Return every controller topic this HAL publishes to, in fan-out order.
+
+        Derived from `command_bindings` so the topic list and the declared wire
+        formats cannot drift apart. Override `command_bindings`, not this.
+        """
+        return list(self.command_bindings())
 
     def ros2_control_joint_names(self) -> list[str]:
         """Return the joint names in ros2_control's namespace, in action order.

--- a/python/hal/src/openral_hal/ros_control_transport.py
+++ b/python/hal/src/openral_hal/ros_control_transport.py
@@ -12,15 +12,17 @@ the gap went unnoticed.
 This transport is robot-agnostic on purpose. It is built entirely from what the
 HAL already reports about itself:
 
-* `command_topics()` — one `JointTrajectory` publisher per entry, so a
-  single-controller UR and the four-controller bimanual OpenArm are the same
-  code path.
+* `command_bindings()` — one publisher per entry, typed by the entry's
+  `ControllerKind`, so a single-controller UR and the four-controller bimanual
+  OpenArm are the same code path.
 * `ros2_control_joint_names()` — the names `/joint_states` is keyed by.
 * `joint_state_topic` — the aggregated state topic.
 
 Adding a robot therefore needs no transport code at all: give its HAL those
 three (the base class already answers all of them) and the lifecycle node wires
-this automatically.
+this automatically. A robot whose controllers speak a format not yet in
+`ControllerKind` is the one case that needs a change here — and it fails loudly
+at wire-up rather than publishing a type DDS will silently drop.
 
 Joint state is merged **by name, never by index**. Independently publishing
 controllers give no ordering guarantee, and on a robot whose controllers are
@@ -39,6 +41,8 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import structlog
 
+from openral_hal.ros_control import ControllerKind
+
 if TYPE_CHECKING:  # pragma: no cover - import-time typing only
     from rclpy.node import Node
 
@@ -49,20 +53,18 @@ __all__ = ["RosControlDrivable", "RosControlTransport"]
 class RosControlDrivable(Protocol):
     """What a HAL must expose to be driven by `RosControlTransport`.
 
-    Membership is **structural, not by ancestry**. `RosControlHAL` and its
-    subclasses satisfy it, but so does any other HAL that grows these four
-    members — which matters because the repo already has a real ros2_control
-    robot that is not a `RosControlHAL` subclass (`AlohaHAL`, which reimplements
-    the same fan-out on `HALBase`). Gating the lifecycle node's wiring on
-    inheritance would silently leave such a robot with no transport at all,
-    which is the failure this whole surface exists to prevent.
+    Membership is **structural, not by ancestry**, so a HAL that reimplements
+    the ros2_control fan-out on `HALBase` rather than inheriting still gets
+    wired. Gating the lifecycle node on `isinstance(..., RosControlHAL)` would
+    leave such a robot with no transport and no error — the failure this whole
+    surface exists to prevent.
 
     A HAL opts in by answering these; the base class answers all four, so for
     most robots that is automatic.
     """
 
-    def command_topics(self) -> list[str]:
-        """Controller topics this HAL publishes to; one publisher per entry."""
+    def command_bindings(self) -> dict[str, ControllerKind]:
+        """Controller topics this HAL publishes to, each with its wire format."""
         ...
 
     def ros2_control_joint_names(self) -> list[str]:
@@ -106,6 +108,10 @@ class RosControlTransport:
         joint_names: ros2_control joint names, from
             `hal.ros2_control_joint_names()`.
         joint_state_topic: Aggregated state topic, from `hal.joint_state_topic`.
+        command_kinds: Wire format per topic, from `hal.command_bindings()`.
+            A topic absent from the mapping defaults to
+            `ControllerKind.JOINT_TRAJECTORY`, which is what every
+            ros2_control robot in this repo runs.
 
     Raises:
         ROSConfigError: If no command topic or no joint name was given — a HAL
@@ -120,6 +126,7 @@ class RosControlTransport:
         command_topics: list[str],
         joint_names: list[str],
         joint_state_topic: str = "/joint_states",
+        command_kinds: dict[str, ControllerKind] | None = None,
     ) -> None:
         """Create one publisher per command topic and subscribe to the state topic."""
         # `openral_hal` must import without a ROS 2 install (unit tests, docs
@@ -138,6 +145,17 @@ class RosControlTransport:
                 "reported none, so incoming /joint_states could not be matched."
             )
 
+        kinds = dict(command_kinds or {})
+        unknown = sorted(set(kinds) - set(command_topics))
+        if unknown:
+            raise ROSConfigError(
+                f"RosControlTransport was given controller kinds for topic(s) {unknown} "
+                f"that are not in command_topics {sorted(command_topics)}. A kind that "
+                "names no topic silently governs nothing, which is how a controller ends "
+                "up commanded with the wrong message type."
+            )
+        self._kinds = {t: kinds.get(t, ControllerKind.JOINT_TRAJECTORY) for t in command_topics}
+
         from rclpy.qos import (  # noqa: PLC0415  # reason: rclpy is a ROS-only dep; the HAL package must import without it
             DurabilityPolicy,
             HistoryPolicy,
@@ -145,7 +163,6 @@ class RosControlTransport:
             ReliabilityPolicy,
         )
         from sensor_msgs.msg import JointState as RosJointState  # noqa: PLC0415
-        from trajectory_msgs.msg import JointTrajectory  # noqa: PLC0415  # reason: ROS-only dep
 
         self._node = node
         self._joint_names = list(joint_names)
@@ -159,8 +176,12 @@ class RosControlTransport:
             history=HistoryPolicy.KEEP_LAST,
             depth=_COMMAND_DEPTH,
         )
+        # One publisher per topic, typed by the kind the HAL declared. Getting
+        # this wrong is invisible at runtime — DDS drops a mismatched type
+        # without delivering it and without erroring — so the type is chosen
+        # here, once, from the declaration rather than assumed at publish time.
         self._pubs = {
-            topic: node.create_publisher(JointTrajectory, topic, command_qos)
+            topic: node.create_publisher(_message_type(self._kinds[topic]), topic, command_qos)
             for topic in command_topics
         }
 
@@ -183,7 +204,12 @@ class RosControlTransport:
     # ── Injected callables ────────────────────────────────────────────────────
 
     def publish(self, topic: str, msg: dict[str, object]) -> None:
-        """Send one HAL command dict to its controller as a `JointTrajectory`.
+        """Send one HAL command dict to its controller in that controller's format.
+
+        The message type follows the `ControllerKind` the HAL declared for this
+        topic in `command_bindings` — `trajectory_msgs/JointTrajectory` for a
+        `JointTrajectoryController`, `std_msgs/Float64MultiArray` for the
+        forward-command family.
 
         The message's own `joint_names` are used verbatim, so this cannot
         misroute a value the HAL placed correctly; it falls back to the full
@@ -222,9 +248,10 @@ class RosControlTransport:
         if "joint_targets" not in msg:
             raise ROSConfigError(
                 f"RosControlTransport cannot express the command {sorted(msg)} sent to "
-                f"{topic!r}: it publishes trajectory_msgs/JointTrajectory and so requires "
-                "'joint_targets'. Teach this transport that controller's message type "
-                "rather than letting the command be dropped."
+                f"{topic!r}: every ControllerKind it publishes is commanded from "
+                f"'joint_targets', and this one ({self._kinds[topic].value}) is no "
+                "exception. Add the kind that controller speaks to ControllerKind rather "
+                "than letting the command be dropped."
             )
         targets = msg.get("joint_targets")
         if not isinstance(targets, list) or not targets:
@@ -244,6 +271,19 @@ class RosControlTransport:
                 f"chunk's final step has "
                 f"{len(last_step) if isinstance(last_step, list) else 'a non-list'}."
             )
+
+        kind = self._kinds[topic]
+        if kind is ControllerKind.FORWARD_COMMAND:
+            from std_msgs.msg import Float64MultiArray  # noqa: PLC0415  # reason: ROS-only dep
+
+            # A forward controller takes a bare vector in the order its own
+            # `joints` parameter declares — there is no room in the message for
+            # names, so the HAL's ordering is the whole contract. The length
+            # check above is therefore the only guard available.
+            command = Float64MultiArray()
+            command.data = [float(v) for v in last_step]
+            publisher.publish(command)
+            return
 
         from trajectory_msgs.msg import (  # noqa: PLC0415  # reason: ROS-only dep
             JointTrajectory,
@@ -328,3 +368,31 @@ class RosControlTransport:
 #: Default trajectory deadline. Matches the 100 ms the production HALs assume
 #: for a single-step command; overridden per message via `time_from_start_s`.
 _DEFAULT_TIME_FROM_START_S = 0.1
+
+
+def _message_type(kind: ControllerKind) -> type:
+    """Return the ROS message class one `ControllerKind` is commanded with.
+
+    Imported at call time so this module still imports without a ROS 2
+    installation (unit tests, docs builds, CI lanes with no rclpy).
+
+    Raises:
+        ROSConfigError: For a kind with no message mapping. Unreachable while
+            the enum and this function agree; it exists so that adding a member
+            without teaching this function fails at wire-up rather than
+            publishing a plausible-but-wrong type onto the actuation path.
+    """
+    from openral_core.exceptions import ROSConfigError  # noqa: PLC0415
+
+    if kind is ControllerKind.JOINT_TRAJECTORY:
+        from trajectory_msgs.msg import JointTrajectory  # noqa: PLC0415  # reason: ROS-only dep
+
+        return JointTrajectory
+    if kind is ControllerKind.FORWARD_COMMAND:
+        from std_msgs.msg import Float64MultiArray  # noqa: PLC0415  # reason: ROS-only dep
+
+        return Float64MultiArray
+    raise ROSConfigError(  # pragma: no cover - guarded by test_every_controller_kind_maps
+        f"RosControlTransport has no message type for ControllerKind {kind!r}. "
+        "Add one here in the same change that adds the enum member."
+    )

--- a/python/hal/src/openral_hal/ros_control_transport.py
+++ b/python/hal/src/openral_hal/ros_control_transport.py
@@ -34,14 +34,55 @@ since `connect()`.
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import structlog
 
 if TYPE_CHECKING:  # pragma: no cover - import-time typing only
     from rclpy.node import Node
 
-__all__ = ["RosControlTransport"]
+__all__ = ["RosControlDrivable", "RosControlTransport"]
+
+
+@runtime_checkable
+class RosControlDrivable(Protocol):
+    """What a HAL must expose to be driven by `RosControlTransport`.
+
+    Membership is **structural, not by ancestry**. `RosControlHAL` and its
+    subclasses satisfy it, but so does any other HAL that grows these four
+    members — which matters because the repo already has a real ros2_control
+    robot that is not a `RosControlHAL` subclass (`AlohaHAL`, which reimplements
+    the same fan-out on `HALBase`). Gating the lifecycle node's wiring on
+    inheritance would silently leave such a robot with no transport at all,
+    which is the failure this whole surface exists to prevent.
+
+    A HAL opts in by answering these; the base class answers all four, so for
+    most robots that is automatic.
+    """
+
+    def command_topics(self) -> list[str]:
+        """Controller topics this HAL publishes to; one publisher per entry."""
+        ...
+
+    def ros2_control_joint_names(self) -> list[str]:
+        """Joint names in ros2_control's namespace, in action-vector order."""
+        ...
+
+    @property
+    def joint_state_topic(self) -> str:
+        """Aggregated ``sensor_msgs/JointState`` topic to read."""
+        ...
+
+    def attach_transport(
+        self,
+        publish_fn: Callable[[str, dict[str, object]], None],
+        state_fn: Callable[[], dict[str, object]],
+        stamp_fn: Callable[[], float] | None = None,
+    ) -> None:
+        """Bind the live transport's callables to this HAL."""
+        ...
+
 
 log = structlog.get_logger(__name__)
 
@@ -81,8 +122,9 @@ class RosControlTransport:
         joint_state_topic: str = "/joint_states",
     ) -> None:
         """Create one publisher per command topic and subscribe to the state topic."""
-        # install (unit tests, docs builds, CI lanes with no rclpy), so every ROS symbol is
-        # imported at call time rather than module scope.
+        # `openral_hal` must import without a ROS 2 install (unit tests, docs
+        # builds, CI lanes with no rclpy), so every ROS symbol below is imported
+        # at call time rather than at module scope — hence the PLC0415 waivers.
         from openral_core.exceptions import ROSConfigError  # noqa: PLC0415
 
         if not command_topics:
@@ -157,8 +199,9 @@ class RosControlTransport:
             msg: The HAL's command dict.
 
         Raises:
-            ROSConfigError: The topic is not one this transport owns — contract
-                drift between HAL and transport, which must be loud.
+            ROSConfigError: The topic is not one this transport owns, or the
+                payload is a shape this transport cannot express — both are
+                contract drift between HAL and transport, which must be loud.
         """
         from openral_core.exceptions import ROSConfigError  # noqa: PLC0415
 
@@ -170,8 +213,22 @@ class RosControlTransport:
                 f"Declared: {sorted(self._pubs)}"
             )
 
+        # A payload this transport cannot express must be loud. Returning
+        # quietly would drop a command on the actuation path with nothing above
+        # debug in the logs — the exact silent no-op this transport exists to
+        # end. A HAL whose controllers take something else (a scalar gripper
+        # position, say) needs that message type implemented here, not skipped
+        # at runtime.
+        if "joint_targets" not in msg:
+            raise ROSConfigError(
+                f"RosControlTransport cannot express the command {sorted(msg)} sent to "
+                f"{topic!r}: it publishes trajectory_msgs/JointTrajectory and so requires "
+                "'joint_targets'. Teach this transport that controller's message type "
+                "rather than letting the command be dropped."
+            )
         targets = msg.get("joint_targets")
         if not isinstance(targets, list) or not targets:
+            # Distinct from the above: the HAL had nothing to send this tick.
             log.debug("hal.transport.empty_command", topic=topic)
             return
         raw_names = msg.get("joint_names")

--- a/python/hal/src/openral_hal/ros_control_transport.py
+++ b/python/hal/src/openral_hal/ros_control_transport.py
@@ -374,7 +374,10 @@ def _message_type(kind: ControllerKind) -> type:
     """Return the ROS message class one `ControllerKind` is commanded with.
 
     Imported at call time so this module still imports without a ROS 2
-    installation (unit tests, docs builds, CI lanes with no rclpy).
+    installation (unit tests, docs builds, CI lanes with no rclpy). Each class is
+    bound to an explicitly annotated local on the way out: with no ROS 2 install
+    to import from, mypy sees these as `Any`, and returning `Any` from a
+    `-> type` function is exactly what `--strict` rejects.
 
     Raises:
         ROSConfigError: For a kind with no message mapping. Unreachable while
@@ -384,14 +387,17 @@ def _message_type(kind: ControllerKind) -> type:
     """
     from openral_core.exceptions import ROSConfigError  # noqa: PLC0415
 
+    message_type: type
     if kind is ControllerKind.JOINT_TRAJECTORY:
         from trajectory_msgs.msg import JointTrajectory  # noqa: PLC0415  # reason: ROS-only dep
 
-        return JointTrajectory
+        message_type = JointTrajectory
+        return message_type
     if kind is ControllerKind.FORWARD_COMMAND:
         from std_msgs.msg import Float64MultiArray  # noqa: PLC0415  # reason: ROS-only dep
 
-        return Float64MultiArray
+        message_type = Float64MultiArray
+        return message_type
     raise ROSConfigError(  # pragma: no cover - guarded by test_every_controller_kind_maps
         f"RosControlTransport has no message type for ControllerKind {kind!r}. "
         "Add one here in the same change that adds the enum member."

--- a/robots/openarm/openarm.urdf
+++ b/robots/openarm/openarm.urdf
@@ -733,9 +733,6 @@
       </state_interface>
     </joint>
     <joint name="left_finger_joint2">
-      <param name="mimic">openarm_left_finger_joint1</param>
-      <param name="multiplier">-1.0</param>
-      <command_interface name="position"/>
       <state_interface name="position">
         <param name="initial_value">0.0</param>
       </state_interface>
@@ -861,9 +858,6 @@
       </state_interface>
     </joint>
     <joint name="right_finger_joint2">
-      <param name="mimic">openarm_right_finger_joint1</param>
-      <param name="multiplier">-1.0</param>
-      <command_interface name="position"/>
       <state_interface name="position">
         <param name="initial_value">0.0</param>
       </state_interface>

--- a/tests/sim/test_openarm_hal_ros2_control.py
+++ b/tests/sim/test_openarm_hal_ros2_control.py
@@ -1,0 +1,445 @@
+# SPDX-License-Identifier: Apache-2.0
+"""`RosControlHAL` must actually move a `ros2_control` robot — proven without the robot.
+
+Every other sim test in this tier drives a HAL straight into MuJoCo, which is precisely why
+the production actuation path could stay broken for so long: `OpenArmMujocoHAL` and friends
+bypass the transport entirely, so no amount of sim coverage said anything about whether a
+real arm would move. The two defects fixed on live hardware on 2026-09-08 — a `publish_fn`
+that was a `log.debug` no-op, and a staleness watchdog that measured time since `connect()` —
+were both invisible here for that reason.
+
+This file closes that gap by standing up the *real* stack and leaving only the motors out:
+
+* real `controller_manager` (`ros2_control_node`), running at 100 Hz,
+* real `joint_trajectory_controller/JointTrajectoryController`,
+* real `joint_state_broadcaster` publishing `/joint_states`,
+* `mock_components/GenericSystem` as the hardware plugin.
+
+Only the last is a stand-in, and it is upstream ros2_control's own fake-hardware component,
+not a mock we wrote — the boundary double CLAUDE.md §1.11 allows. Everything OpenRAL owns is
+the production article: `RosControlHAL`, `RosControlTransport`, the declared `ControllerKind`,
+the QoS profiles, and the by-name joint-state merge. What this cannot prove is physics — the
+mock echoes commands into state with no dynamics, so tolerances, following error and timing
+still belong to `tests/hil/`.
+
+The robot description is the repo's own vendored `robots/openarm/openarm.urdf`, which already
+declares `mock_components/GenericSystem`; the controller config is derived from that file's
+`<ros2_control>` blocks so the two cannot drift.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import os
+import shutil
+import signal
+import subprocess
+import time
+import xml.etree.ElementTree as ET
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.sim
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_URDF = _REPO_ROOT / "robots" / "openarm" / "openarm.urdf"
+
+#: The `<ros2_control>` block this test brings up, and the controller spawned over it.
+_HARDWARE_COMPONENT = "left_hardware_interface"
+_ARM_CONTROLLER = "left_joint_trajectory_controller"
+
+#: How long the stack gets to come up. Generous because the first `ros2 run` on a cold host
+#: pays for ament index construction; the steady-state cost is a couple of seconds.
+_BRINGUP_TIMEOUT_S = 60.0
+
+
+def _unavailable() -> str | None:
+    """Return why this test cannot run here, or None if it can.
+
+    A dev host with ROS 2 sourced runs it for real; a CI runner without one skips. Per
+    CLAUDE.md §1.11 the dependency is skipped, never faked.
+    """
+    if shutil.which("ros2") is None:
+        return "ros2 CLI not on PATH — source a ROS 2 install"
+    for module in ("rclpy", "trajectory_msgs", "sensor_msgs"):
+        if importlib.util.find_spec(module) is None:
+            return f"{module} not importable — source a ROS 2 install"
+    from ament_index_python.packages import PackageNotFoundError, get_package_share_directory
+
+    # `mock_components` ships inside `hardware_interface` on Jazzy, so checking that package
+    # covers the fake-hardware plugin as well as the resource manager.
+    for package in (
+        "controller_manager",
+        "joint_trajectory_controller",
+        "joint_state_broadcaster",
+        "robot_state_publisher",
+        "hardware_interface",
+    ):
+        try:
+            get_package_share_directory(package)
+        except (PackageNotFoundError, ValueError):
+            return (
+                f"ROS 2 package '{package}' not installed — "
+                "`apt install ros-$ROS_DISTRO-ros2-control`"
+            )
+    return None
+
+
+_SKIP_REASON = _unavailable()
+
+
+def _controlled_joints(component: str) -> list[str]:
+    """Return the joints one `<ros2_control>` block commands, in URDF order.
+
+    Read from the URDF rather than restated here: a controller whose `joints` list disagrees
+    with the hardware component fails to activate, and a hand-copied list is exactly how that
+    disagreement gets introduced. Mimic joints are excluded — ros2_control drives them from
+    their target and rejects a command interface on them.
+    """
+    root = ET.parse(_URDF).getroot()
+    for block in root.findall("ros2_control"):
+        if block.get("name") != component:
+            continue
+        return [
+            joint.get("name", "")
+            for joint in block.findall("joint")
+            if joint.find("command_interface") is not None
+        ]
+    raise AssertionError(f"{_URDF} declares no <ros2_control> block named {component!r}.")
+
+
+def _targets_within_limits(joints: list[str]) -> list[float]:
+    """Pick one reachable target per joint, from that joint's own URDF limits.
+
+    Derived rather than hardcoded for the same reason the joint list is: the arm joints and
+    the gripper finger have very different ranges (the finger's is entirely negative), so a
+    literal vector that looks harmless is easy to write and lands outside a limit. The
+    fractions differ per index so the assertion would catch a transport that published the
+    right values in the wrong order.
+    """
+    root = ET.parse(_URDF).getroot()
+    limits = {
+        joint.get("name"): joint.find("limit")
+        for joint in root.findall("joint")
+        if joint.find("limit") is not None
+    }
+    targets: list[float] = []
+    for i, name in enumerate(joints):
+        limit = limits[name]
+        lower, upper = float(limit.get("lower", -1.0)), float(limit.get("upper", 1.0))  # type: ignore[union-attr]  # reason: filtered above
+        targets.append(lower + (0.25 + 0.04 * i) * (upper - lower))
+    return targets
+
+
+def _write_controller_config(path: Path, joints: list[str]) -> Path:
+    """Write the `controller_manager` params for a single-arm trajectory controller."""
+    joint_block = "\n".join(f"      - {name}" for name in joints)
+    path.write_text(
+        "controller_manager:\n"
+        "  ros__parameters:\n"
+        "    update_rate: 100\n"
+        "    joint_state_broadcaster:\n"
+        "      type: joint_state_broadcaster/JointStateBroadcaster\n"
+        f"    {_ARM_CONTROLLER}:\n"
+        "      type: joint_trajectory_controller/JointTrajectoryController\n"
+        "\n"
+        f"{_ARM_CONTROLLER}:\n"
+        "  ros__parameters:\n"
+        "    joints:\n"
+        f"{joint_block}\n"
+        "    command_interfaces: [position]\n"
+        "    state_interfaces: [position, velocity]\n"
+    )
+    return path
+
+
+def _spawn(argv: list[str], log: Path, env: dict[str, str]) -> subprocess.Popen[bytes]:
+    """Start one ROS node in its own process group so teardown can take the whole tree."""
+    handle = log.open("wb")
+    # Fixed argv, no shell. `start_new_session` is what makes teardown reliable: `ros2 run`
+    # execs the node as a child, so signalling the group is the only way to take both.
+    return subprocess.Popen(
+        argv, stdout=handle, stderr=subprocess.STDOUT, env=env, start_new_session=True
+    )
+
+
+def _terminate(process: subprocess.Popen[bytes]) -> None:
+    """Stop a node and everything it spawned, escalating to SIGKILL."""
+    if process.poll() is not None:
+        return
+    try:
+        os.killpg(os.getpgid(process.pid), signal.SIGINT)
+        process.wait(timeout=10)
+    except (subprocess.TimeoutExpired, ProcessLookupError):
+        with contextlib.suppress(OSError):
+            os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+
+
+@pytest.fixture(scope="module")
+def ros2_control_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[list[str]]:
+    """Bring the mock ros2_control graph up once, and yield the commanded joint names.
+
+    Module-scoped: a `controller_manager` bringup costs several seconds and nothing in this
+    file mutates the graph in a way the next test would notice — the mock hardware's state is
+    whatever the last command left, which each test sets for itself.
+    """
+    if _SKIP_REASON is not None:
+        pytest.skip(_SKIP_REASON)
+
+    tmp = tmp_path_factory.mktemp("ros2_control")
+    joints = _controlled_joints(_HARDWARE_COMPONENT)
+    config = _write_controller_config(tmp / "controllers.yaml", joints)
+
+    # The conftest pins ROS_DOMAIN_ID per pytest PID; the children inherit it, which is what
+    # keeps this graph off any real robot's domain. Deliberately NOT setting
+    # ROS_AUTOMATIC_DISCOVERY_RANGE — see tests/sim/conftest.py for the hang it causes across
+    # a process boundary the test does not launch into a single environment.
+    env = dict(os.environ)
+
+    processes: list[subprocess.Popen[bytes]] = []
+    try:
+        # controller_manager takes the description from the /robot_description topic on Jazzy,
+        # so robot_state_publisher is a required participant, not a convenience.
+        processes.append(
+            _spawn(
+                [
+                    "ros2",
+                    "run",
+                    "robot_state_publisher",
+                    "robot_state_publisher",
+                    "--ros-args",
+                    "-p",
+                    f"robot_description:={_URDF.read_text()}",
+                ],
+                tmp / "robot_state_publisher.log",
+                env,
+            )
+        )
+        processes.append(
+            _spawn(
+                [
+                    "ros2",
+                    "run",
+                    "controller_manager",
+                    "ros2_control_node",
+                    "--ros-args",
+                    "--params-file",
+                    str(config),
+                ],
+                tmp / "controller_manager.log",
+                env,
+            )
+        )
+
+        deadline = time.monotonic() + _BRINGUP_TIMEOUT_S
+        for controller in ("joint_state_broadcaster", _ARM_CONTROLLER):
+            remaining = max(1.0, deadline - time.monotonic())
+            # The spawner blocks until the controller is configured and active, then exits,
+            # so its return code is the readiness signal — no polling needed.
+            spawned = subprocess.run(
+                ["ros2", "run", "controller_manager", "spawner", controller],
+                capture_output=True,
+                timeout=remaining,
+                env=env,
+                check=False,
+            )
+            if spawned.returncode != 0:
+                manager_log = (tmp / "controller_manager.log").read_text(errors="replace")
+                pytest.fail(
+                    f"Could not activate {controller!r} (exit {spawned.returncode}).\n"
+                    f"spawner stderr:\n{spawned.stderr.decode(errors='replace')}\n"
+                    f"controller_manager log:\n{manager_log}"
+                )
+        yield joints
+    finally:
+        for process in reversed(processes):
+            _terminate(process)
+
+
+def _drive(joints: list[str]):  # type: ignore[no-untyped-def]  # reason: rclpy types are unavailable at lint time
+    """Build the production HAL + transport pair against the live graph.
+
+    Deliberately a plain `RosControlHAL`, not `OpenArmRealHAL`: the point is the generic
+    ros2_control path every robot in that family inherits, and `OpenArmRealHAL` additionally
+    demands live CAN buses and its rig's `openarm_`-prefixed joint names, neither of which
+    exists here.
+    """
+    from openral_core.schemas import (
+        ControlMode,
+        EmbodimentKind,
+        JointSpec,
+        JointType,
+        RobotCapabilities,
+        RobotDescription,
+        SafetyEnvelope,
+    )
+    from openral_hal.ros_control import RosControlHAL
+    from openral_hal.ros_control_transport import RosControlTransport
+
+    description = RobotDescription(
+        name="openarm_left_ros2_control",
+        embodiment_kind=EmbodimentKind.MANIPULATOR,
+        joints=[
+            JointSpec(
+                name=name,
+                joint_type=JointType.REVOLUTE,
+                parent_link="base" if i == 0 else joints[i - 1],
+                child_link=name,
+            )
+            for i, name in enumerate(joints)
+        ],
+        capabilities=RobotCapabilities(supported_control_modes=[ControlMode.JOINT_POSITION]),
+        safety=SafetyEnvelope(),
+    )
+    return RosControlHAL(description, controller_name=_ARM_CONTROLLER), RosControlTransport
+
+
+@contextlib.contextmanager
+def _driver_node(name: str):  # type: ignore[no-untyped-def]  # reason: rclpy types are unavailable at lint time
+    """Yield `(node, spin)` on a private rclpy context, torn down on the way out.
+
+    A private context (rather than `rclpy.init()`) keeps each test's participant separate and
+    leaves the process's default context untouched for the rest of the tier. That forces the
+    executor to be created against the same context too — `rclpy.spin_once(node)` reaches for
+    the *default* context and fails on a node that does not belong to it.
+    """
+    import rclpy
+    from rclpy.executors import SingleThreadedExecutor
+    from rclpy.node import Node
+
+    context = rclpy.Context()
+    context.init()
+    node = Node(name, context=context)
+    executor = SingleThreadedExecutor(context=context)
+    executor.add_node(node)
+
+    def spin(seconds: float) -> None:
+        end = time.monotonic() + seconds
+        while time.monotonic() < end:
+            executor.spin_once(timeout_sec=0.02)
+
+    try:
+        yield node, spin
+    finally:
+        executor.remove_node(node)
+        node.destroy_node()
+        context.shutdown()
+
+
+def _wait_until(spin, predicate, timeout_s: float) -> bool:  # type: ignore[no-untyped-def]  # reason: rclpy types are unavailable at lint time
+    """Spin until `predicate()` holds or the timeout expires; report which happened.
+
+    DDS discovery takes a beat — a fresh participant does not see an existing publisher for
+    something on the order of a second — so every wait here is a poll, never a bare sleep.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        spin(0.1)
+    return predicate()
+
+
+def test_a_command_reaches_a_real_controller_and_state_comes_back(
+    ros2_control_stack: list[str],
+) -> None:
+    """The whole actuation path, end to end, with only the motors mocked.
+
+    This is the test that would have caught the no-op `publish_fn`: it asserts the arm's
+    measured position *changed to the commanded value*, which is only true if a correctly
+    typed message reached a real `JointTrajectoryController`.
+    """
+    from openral_core.schemas import Action, ControlMode
+
+    joints = ros2_control_stack
+    hal, transport_cls = _drive(joints)
+
+    with _driver_node("openral_ros2_control_sim") as (node, spin):
+        transport = transport_cls(
+            node,
+            command_topics=list(hal.command_bindings()),
+            joint_names=hal.ros2_control_joint_names(),
+            joint_state_topic=hal.joint_state_topic,
+            command_kinds=hal.command_bindings(),
+        )
+        hal.attach_transport(transport.publish, transport.state, transport.last_arrival)
+        hal.connect()
+
+        assert _wait_until(spin, lambda: transport.last_arrival() != 0.0, 15.0), (
+            f"No sensor_msgs/JointState arrived on {hal.joint_state_topic} — "
+            "joint_state_broadcaster is active but the subscriber never matched."
+        )
+        assert transport.missing_joints() == [], (
+            "The state topic never reported these joints, so the by-name merge would "
+            f"silently zero-fill them: {transport.missing_joints()}"
+        )
+
+        # Freshness is a safety control (CLAUDE.md §1.1): against a live broadcaster this must
+        # not raise, and it did before the arrival clock replaced the connect clock.
+        spin(1.0)
+        hal.read_state()
+
+        target = _targets_within_limits(joints)
+        hal.send_action(
+            Action(
+                control_mode=ControlMode.JOINT_POSITION,
+                horizon=1,
+                joint_targets=[target],
+                stamp_ns=time.time_ns(),
+            )
+        )
+
+        def _arrived() -> bool:
+            reached = hal.read_state()
+            return max(abs(a - b) for a, b in zip(reached.position, target, strict=True)) < 1e-3
+
+        assert _wait_until(spin, _arrived, 10.0), (
+            f"Commanded {target} but the controller reports "
+            f"{list(hal.read_state().position)}. The command did not reach the controller, "
+            "or reached it in a form it ignored."
+        )
+        assert hal.read_state().name == joints
+
+
+def test_the_joint_state_merge_is_by_name_not_by_arrival_order(
+    ros2_control_stack: list[str],
+) -> None:
+    """`/joint_states` carries both arms; only the commanded seven may be read back.
+
+    `joint_state_broadcaster` publishes every joint the resource manager owns — 18 here, both
+    `<ros2_control>` blocks — in an order no publisher guarantees. A positional read would
+    therefore return another limb's values under this arm's names.
+    """
+    from sensor_msgs.msg import JointState as RosJointState
+
+    joints = ros2_control_stack
+    hal, transport_cls = _drive(joints)
+    seen: list[list[str]] = []
+
+    with _driver_node("openral_ros2_control_names") as (node, spin):
+        transport = transport_cls(
+            node,
+            command_topics=list(hal.command_bindings()),
+            joint_names=hal.ros2_control_joint_names(),
+            joint_state_topic=hal.joint_state_topic,
+            command_kinds=hal.command_bindings(),
+        )
+        node.create_subscription(
+            RosJointState, "/joint_states", lambda m: seen.append(list(m.name)), 10
+        )
+        hal.attach_transport(transport.publish, transport.state, transport.last_arrival)
+        hal.connect()
+
+        assert _wait_until(spin, lambda: bool(seen), 15.0), (
+            "joint_state_broadcaster published nothing."
+        )
+        published = set(seen[-1])
+        assert published > set(joints), (
+            "This assertion is only meaningful while the broadcaster publishes more joints "
+            f"than this controller owns; it published {sorted(published)}."
+        )
+        state = hal.read_state()
+        assert state.name == joints, "read_state must project onto the HAL's own joints only."

--- a/tests/unit/test_ros_control_transport.py
+++ b/tests/unit/test_ros_control_transport.py
@@ -305,3 +305,74 @@ def test_attach_transport_rejects_a_value_where_a_clock_was_expected() -> None:
     hal = _hal()
     with pytest.raises(ROSConfigError, match="callable"):
         hal.attach_transport(lambda t, m: None, lambda: {}, 123.4)  # type: ignore[arg-type]  # reason: the mistake under test
+
+
+# ── Who gets a transport, and what happens to a payload it can't express ──────
+
+
+def test_membership_is_structural_not_by_ancestry() -> None:
+    """The lifecycle node gates on this Protocol, so its shape decides who gets wired.
+
+    Gating on `isinstance(hal, RosControlHAL)` instead would skip a ros2_control robot that
+    reimplements the same fan-out on `HALBase` rather than inheriting it — `AlohaHAL` does
+    exactly that today — leaving it with no transport and no error to say so.
+    """
+    from openral_hal.openarm_real import OpenArmRealHAL
+    from openral_hal.ros_control_transport import RosControlDrivable
+
+    assert isinstance(_hal(), RosControlDrivable)
+    assert isinstance(OpenArmRealHAL(require_can_links=False), RosControlDrivable)
+
+    class OptsInWithoutInheriting:
+        """Any HAL that grows the four members qualifies, whatever its base class."""
+
+        def command_topics(self) -> list[str]:
+            return ["/c/joint_trajectory"]
+
+        def ros2_control_joint_names(self) -> list[str]:
+            return ["j0"]
+
+        @property
+        def joint_state_topic(self) -> str:
+            return "/joint_states"
+
+        def attach_transport(self, publish_fn, state_fn, stamp_fn=None) -> None:  # type: ignore[no-untyped-def]  # reason: structural stand-in
+            return None
+
+    assert isinstance(OptsInWithoutInheriting(), RosControlDrivable)
+
+
+def test_a_hal_missing_the_surface_is_not_drivable() -> None:
+    """The serial arms own their own bus and must not be handed a ros2_control transport."""
+    from openral_hal.ros_control_transport import RosControlDrivable
+
+    class SerialArm:
+        pass
+
+    assert not isinstance(SerialArm(), RosControlDrivable)
+
+
+@requires_rclpy
+def test_an_unexpressible_payload_raises_instead_of_vanishing() -> None:
+    """A command shape this transport cannot publish must not be dropped quietly.
+
+    `AlohaHAL` sends its grippers `{"position": float}` rather than `joint_targets`. Skipping
+    that at runtime would be a silent no-op on the actuation path — the failure this whole
+    transport exists to end — so it raises and names the keys instead.
+    """
+    import rclpy
+    from openral_hal.ros_control_transport import RosControlTransport
+    from rclpy.node import Node
+
+    ctx = rclpy.Context()
+    ctx.init()
+    node = Node("t_unexpressible", context=ctx)
+    try:
+        tr = RosControlTransport(node, command_topics=["/g/command"], joint_names=["g0"])
+        with pytest.raises(ROSConfigError, match="cannot express"):
+            tr.publish("/g/command", {"position": 0.5, "stamp_ns": 0})
+        # An empty chunk is a different thing: the HAL had nothing to send.
+        tr.publish("/g/command", {"joint_targets": [], "joint_names": ["g0"]})
+    finally:
+        node.destroy_node()
+        ctx.shutdown()

--- a/tests/unit/test_ros_control_transport.py
+++ b/tests/unit/test_ros_control_transport.py
@@ -38,7 +38,7 @@ from openral_core.schemas import (
     RobotDescription,
     SafetyEnvelope,
 )
-from openral_hal.ros_control import RosControlHAL
+from openral_hal.ros_control import ControllerKind, RosControlHAL
 
 requires_rclpy = pytest.mark.skipif(
     importlib.util.find_spec("rclpy") is None
@@ -78,6 +78,48 @@ def test_a_plain_hal_reports_one_command_topic_and_its_manifest_joint_names() ->
     assert hal.command_topics() == ["/joint_trajectory_controller/joint_trajectory"]
     assert hal.ros2_control_joint_names() == ["j0", "j1"]
     assert hal.joint_state_topic == "/joint_states"
+
+
+def test_a_plain_hal_declares_its_controller_kind_rather_than_leaving_it_implied() -> None:
+    """The wire format is part of the contract, not a transport-side assumption.
+
+    A topic name says nothing about the message type its controller accepts, and publishing
+    the wrong one is silent: DDS declines to deliver it, so the arm does not move and nothing
+    logs an error. Declaring the kind is what lets the transport pick a publisher type instead
+    of guessing one.
+    """
+    assert _hal().command_bindings() == {
+        "/joint_trajectory_controller/joint_trajectory": ControllerKind.JOINT_TRAJECTORY
+    }
+
+
+def test_command_topics_is_derived_from_the_bindings_so_the_two_cannot_drift() -> None:
+    """One source of truth. A HAL overrides `command_bindings`; the topic list follows."""
+
+    class TwoControllers(RosControlHAL):
+        def command_bindings(self) -> dict[str, ControllerKind]:
+            return {
+                "/arm/joint_trajectory": ControllerKind.JOINT_TRAJECTORY,
+                "/gripper/commands": ControllerKind.FORWARD_COMMAND,
+            }
+
+    hal = TwoControllers(_description(), controller_name="unused")
+    assert hal.command_topics() == ["/arm/joint_trajectory", "/gripper/commands"]
+
+
+def test_every_controller_kind_maps_to_a_message_type() -> None:
+    """Adding an enum member without teaching the transport would be a silent wrong type.
+
+    `_message_type` is the single place that turns a declared kind into a publisher, so an
+    unmapped member must fail here rather than reach a controller.
+    """
+    from openral_hal.ros_control_transport import _message_type
+
+    for kind in ControllerKind:
+        try:
+            assert _message_type(kind) is not None
+        except ImportError:  # reason: per-kind, and only the ROS-less lane
+            pytest.skip("ROS 2 message packages not importable — source a ROS 2 install")
 
 
 def test_openarm_overrides_still_win_over_the_new_base_defaults() -> None:
@@ -314,8 +356,8 @@ def test_membership_is_structural_not_by_ancestry() -> None:
     """The lifecycle node gates on this Protocol, so its shape decides who gets wired.
 
     Gating on `isinstance(hal, RosControlHAL)` instead would skip a ros2_control robot that
-    reimplements the same fan-out on `HALBase` rather than inheriting it — `AlohaHAL` does
-    exactly that today — leaving it with no transport and no error to say so.
+    reimplements the same fan-out on `HALBase` rather than inheriting it, leaving it with no
+    transport and no error to say so.
     """
     from openral_hal.openarm_real import OpenArmRealHAL
     from openral_hal.ros_control_transport import RosControlDrivable
@@ -324,10 +366,10 @@ def test_membership_is_structural_not_by_ancestry() -> None:
     assert isinstance(OpenArmRealHAL(require_can_links=False), RosControlDrivable)
 
     class OptsInWithoutInheriting:
-        """Any HAL that grows the four members qualifies, whatever its base class."""
+        """Any HAL that grows the members qualifies, whatever its base class."""
 
-        def command_topics(self) -> list[str]:
-            return ["/c/joint_trajectory"]
+        def command_bindings(self) -> dict[str, ControllerKind]:
+            return {"/c/joint_trajectory": ControllerKind.JOINT_TRAJECTORY}
 
         def ros2_control_joint_names(self) -> list[str]:
             return ["j0"]
@@ -356,9 +398,10 @@ def test_a_hal_missing_the_surface_is_not_drivable() -> None:
 def test_an_unexpressible_payload_raises_instead_of_vanishing() -> None:
     """A command shape this transport cannot publish must not be dropped quietly.
 
-    `AlohaHAL` sends its grippers `{"position": float}` rather than `joint_targets`. Skipping
-    that at runtime would be a silent no-op on the actuation path — the failure this whole
-    transport exists to end — so it raises and names the keys instead.
+    A HAL that sends `{"position": float}` rather than `joint_targets` is asking for a
+    controller format this transport does not build. Skipping that at runtime would be a
+    silent no-op on the actuation path — the failure this whole transport exists to end —
+    so it raises and names the keys instead.
     """
     import rclpy
     from openral_hal.ros_control_transport import RosControlTransport
@@ -373,6 +416,68 @@ def test_an_unexpressible_payload_raises_instead_of_vanishing() -> None:
             tr.publish("/g/command", {"position": 0.5, "stamp_ns": 0})
         # An empty chunk is a different thing: the HAL had nothing to send.
         tr.publish("/g/command", {"joint_targets": [], "joint_names": ["g0"]})
+    finally:
+        node.destroy_node()
+        ctx.shutdown()
+
+
+@requires_rclpy
+def test_a_forward_command_topic_publishes_float64multiarray_not_a_trajectory() -> None:
+    """The declared kind decides the publisher's type, which is the whole point.
+
+    A `ForwardCommandController` subscribes to `std_msgs/Float64MultiArray`. Publishing a
+    `trajectory_msgs/JointTrajectory` at it is not an error anyone sees — the types simply
+    never match, so the controller receives nothing and the robot stands still.
+    """
+    import rclpy
+    from openral_hal.ros_control_transport import RosControlTransport
+    from rclpy.node import Node
+    from std_msgs.msg import Float64MultiArray
+
+    ctx = rclpy.Context()
+    ctx.init()
+    node = Node("t_forward_kind", context=ctx)
+    try:
+        tr = RosControlTransport(
+            node,
+            command_topics=["/forward_position_controller/commands"],
+            joint_names=["j0", "j1"],
+            command_kinds={"/forward_position_controller/commands": ControllerKind.FORWARD_COMMAND},
+        )
+        pub = tr._pubs["/forward_position_controller/commands"]
+        assert pub.msg_type is Float64MultiArray
+        # And the same HAL payload still publishes cleanly through the other format.
+        tr.publish(
+            "/forward_position_controller/commands",
+            {"joint_targets": [[0.1, 0.2]], "joint_names": ["j0", "j1"]},
+        )
+    finally:
+        node.destroy_node()
+        ctx.shutdown()
+
+
+@requires_rclpy
+def test_a_kind_naming_no_declared_topic_is_rejected_at_wire_up() -> None:
+    """A kind that governs nothing is a typo, and a typo here picks the wrong message type.
+
+    Silently ignoring it would leave the mistyped topic on the JointTrajectory default, which
+    is exactly the silent mismatch the declaration exists to prevent.
+    """
+    import rclpy
+    from openral_hal.ros_control_transport import RosControlTransport
+    from rclpy.node import Node
+
+    ctx = rclpy.Context()
+    ctx.init()
+    node = Node("t_stray_kind", context=ctx)
+    try:
+        with pytest.raises(ROSConfigError, match="not in command_topics"):
+            RosControlTransport(
+                node,
+                command_topics=["/arm/joint_trajectory"],
+                joint_names=["j0"],
+                command_kinds={"/arm/joint_trajctory": ControllerKind.FORWARD_COMMAND},
+            )
     finally:
         node.destroy_node()
         ctx.shutdown()


### PR DESCRIPTION
## What changed

Follow-up to #246, from a question worth asking: *why does SO-101 use `HALBase` while other robots use `RosControlHAL`?*

The premise turned out to be slightly off — `HALBase` is the universal base and `RosControlHAL` is its ros2_control specialization — but chasing it found real holes.

### 1. The gate was wrong

The lifecycle node wired a transport only to `isinstance(hal, RosControlHAL)`. Membership is now the `RosControlDrivable` **Protocol**: any HAL exposing `command_bindings`, `ros2_control_joint_names`, `joint_state_topic` and `attach_transport` gets wired, whatever its base class. `RosControlHAL` answers all four, so its subclasses are unchanged and future robots opt in by shape rather than by inheritance.

### 2. The transport dropped commands silently

It returned after a `log.debug` whenever a payload carried no `joint_targets`. On the actuation path that is a command that goes nowhere with nothing above debug in the logs — the precise failure mode this transport was written to end. It now raises and names the keys. An empty `joint_targets` list stays the distinct, benign "nothing to send this tick".

### 3. Controller kind is declared, not assumed

`RosControlTransport` built a `trajectory_msgs/JointTrajectory` publisher for **every** command topic, because every ros2_control robot in this repo happens to run a `JointTrajectoryController`. A robot whose controller takes something else — the `forward_command_controller` family with its `std_msgs/Float64MultiArray` being the common case — would have been published at with a type DDS declines to deliver: no motion, no error, nothing above debug. Same silent class as the no-op `publish_fn` and the connect-clock watchdog.

`RosControlHAL.command_bindings() -> dict[str, ControllerKind]` replaces `command_topics()` as the override point; `command_topics()` is derived from it so the topic list and the declared formats cannot drift. `_message_type` is the single place a kind becomes a message class, and an unmapped kind raises at wire-up rather than publishing a plausible-but-wrong type.

`FORWARD_COMMAND` has no in-repo consumer today. It is here because it is the other type a ros2_control arm is commonly configured with, and because a one-member enum would just be an assumption wearing a type.

### 4. A sim tier that exercises the wire

`tests/sim/` drove HALs straight into MuJoCo, bypassing the transport entirely — which is why the whole family could be broken while sim stayed green. `tests/sim/test_openarm_hal_ros2_control.py` stands up a real `controller_manager`, a real `joint_trajectory_controller` and a real `joint_state_broadcaster` over `mock_components/GenericSystem`, then drives it with the production HAL + transport and asserts the arm reached the commanded pose.

Only the hardware plugin is a stand-in, and it is upstream ros2_control's own — the boundary double CLAUDE.md §1.11 allows. Verified by mutation: re-introducing the `publish` no-op fails the test.

### 5. `fix(robots)`: the vendored OpenArm URDF could not be loaded

Separate prior commit (§1.15). `robots/openarm/openarm.urdf` shipped `<ros2_control>` blocks that no `controller_manager` can load — both finger joints are URDF mimic joints yet declared a `<command_interface>`, which the resource manager rejects:

```
what():  Joint 'left_finger_joint2' has mimic attribute not set to false:
         Activated mimic joints cannot have command interfaces.
```

They also carried a legacy `<param name="mimic">` naming `openarm_left_finger_joint1`, a joint this file does not define. Nothing caught it because nothing had ever loaded this file into ros2_control; the new sim test does, which is how it surfaced. No joint renamed, no kinematic element touched.

## ALOHA: the migration this PR was expected to enable is the wrong move

The open question from #246 was whether to migrate `AlohaHAL` onto `RosControlHAL`. Answered from Interbotix's published sources, and the answer is **no**:

- `Interbotix/aloha`'s `aloha_bringup.launch.py` includes `interbotix_xsarm_control/xsarm_control.launch.py`, which launches the **`interbotix_xs_sdk` `xs_sdk` node** — a direct Dynamixel driver.
- There is no `controller_manager`, no `JointTrajectoryController`, no `/arm_controller/joint_trajectory` anywhere in that stack.
- Its actual interface is `/<robot_name>/commands/joint_group` (`interbotix_xs_msgs/JointGroupCommand`), `/commands/joint_single`, and `/<robot_name>/joint_states`.

So ALOHA belongs in the same family as SO-100/SO-101 — a vendor-driver robot for which `HALBase` is architecturally correct. `RosControlHAL` would be the wrong base.

What *is* wrong is that `AlohaHAL`'s topics are fiction: `/left_arm/arm_controller/joint_trajectory` and `/left_arm/gripper_controller/command` exist on no real ALOHA. Publishing to a topic with no subscriber is not an error in ROS, so it passes its tests and would never move the arm. `robots/aloha_bimanual/robot.yaml` wires `hal.real: AlohaHAL`, so it is a live path.

Left out of this PR deliberately: rewriting a real robot's on-wire contract is a behavioural change that should be confirmed against the cell, and it is orthogonal to the generalization here.

## How tested

`tests/unit/test_ros_control_transport.py` now has 20 tests (5 new for the binding/dispatch surface); `tests/sim/test_openarm_hal_ros2_control.py` adds 2, passing in ~4 s against a live ros2_control stack and skipping cleanly without one. Full unit suite: 5399 passed. The single failure, `test_sim_attached_hal.py::test_task_success_logger_reaches_the_openral_otel_bridge_namespace`, is pre-existing cross-file ordering pollution — it passes in isolation and reproduces identically with this branch's changes stashed.

`ruff`, `ruff format` and `mypy --strict -p openral_hal` clean; methods inventory updated and `refresh_methods_linenos.py --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJQMsWc18W7e9GnZkdPBpV
