### PR TITLE
fix(plan,evidence): the 18.9 mm over-approximation is bimodal, not "the cell"

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -283,6 +283,35 @@ can only reach the 3 link stops. **No amount of geometry work can recover the
 penetrating to advisory. It does **not** clear the three real contacts, which
 is correct: those are the stops the kernel exists for.
 
+**Correction (same day): the 18.9 mm median is bimodal, and only half of it is
+the cell.** Splitting the same 20 adjudicable stops by how much of the excess a
+25 mm cell can actually account for:
+
+| class | n | excess over certified truth | which lever reaches it |
+| --- | ---: | --- | --- |
+| **A — genuinely touching** (real gap ≤ 0) | 3 | 1.0, 10.9, 11.0 mm | **none, correctly** — these must keep stopping |
+| **B — quantisation** (clear, excess ≤ 21.65 mm) | 8 | 9.5 … 19.5 mm | **#253**, voxel 25 → 15 mm |
+| **C — not explained by the cell** (excess > 21.65 mm) | 9 | **23.4 … 84.6 mm** | **#254 / ADR-0101** — occupancy no nearby real body explains |
+
+Class C is the one that changes the lever order. An excess of 84.6 mm cannot be
+a 25 mm cell's half-diagonal under any argument, so **a finer grid does not
+reach those stops at all** — that is arithmetic, not judgement. Four of the nine
+are `utensil` against `counter_1_right_group_top_0`, the counter the payload was
+lifted *from*, which is the stale pre-attach silhouette the attach sweep window
+exists to clear; the rest name a surface tens of millimetres from anything the
+certified probe could find.
+
+And within class B, three stops already have an excess under **12.99 mm** — a
+15 mm grid's own half-diagonal — so they would not clear either. **25 → 15 mm
+plausibly converts 5 of 20 stops; class C is 9 of 20.** The two levers are still
+complementary, but the claim above that "the over-approximation *is* the cell"
+holds for 8 stops and is wrong for 9. `#253` and `#254` carry this split.
+
+*Method note:* a finer cell moves the kernel's reported depth **toward**
+certified truth rather than subtracting a fixed amount from it, so a genuinely
+touching pair keeps stopping at any resolution. Reasoning by subtraction on the
+reported depth gives the wrong answer for class A and was corrected here.
+
 **Which phase the stops happen in — and it is never the pick.** Traced each
 stop against the run's own `automatic sim attachment revision` (grasp),
 `support_witness_separated` (payload leaves its support) and

--- a/docs/reference/collision-validation-evidence.md
+++ b/docs/reference/collision-validation-evidence.md
@@ -2665,6 +2665,16 @@ with more than 20 mm, and the worst is `panda_link7` stopped at −23.4 mm while
 **61.2 mm clear**. Median over-approximation: **18.9 mm**, which is essentially
 the 25 mm cell half-diagonal (`25·√3/2 = 21.65 mm`).
 
+**Corrected the same day — the 18.9 mm median is bimodal.** Of the 20
+adjudicable stops, **3** are genuinely touching, **8** have an excess a 25 mm
+cell can account for (≤ 21.65 mm), and **9** have an excess of **23.4–84.6 mm**,
+which no cell of that size can explain. A finer grid reaches the middle class
+only: 25 → 15 mm plausibly converts **5 of 20**, while the unexplained class is
+**9 of 20** and belongs to ADR-0101 / #254. Note also that a finer cell moves
+reported depth *toward* certified truth rather than subtracting a fixed amount,
+so reasoning by subtraction misclassifies the touching stops. `PLAN.md` §5
+carries the table.
+
 That reorders the levers, and the full per-stop table is in `PLAN.md` §5: the
 stop population is 86 % payload, payload primitives were already measured tight
 (−1.5 mm beyond the voxel term), so **no geometry work can recover the 18.9 mm


### PR DESCRIPTION
Follow-up correction to #257, which I merged before catching this.

#257 concluded that the gate-ON stops' median **18.9 mm** over-approximation "is essentially the 25 mm cell half-diagonal", and promoted voxel resolution to the first lever on that basis. Splitting the **same 20 adjudicable stops** by how much of the excess a 25 mm cell can actually account for shows the median was hiding two populations:

| class | n | excess over certified truth | which lever reaches it |
| --- | ---: | --- | --- |
| **A — genuinely touching** (real gap ≤ 0) | 3 | 1.0, 10.9, 11.0 mm | **none, correctly** |
| **B — quantisation** (clear, excess ≤ 21.65 mm) | 8 | 9.5 … 19.5 mm | **#253**, voxel 25 → 15 mm |
| **C — not explained by the cell** (excess > 21.65 mm) | **9** | **23.4 … 84.6 mm** | **#254 / ADR-0101** |

An **84.6 mm** excess cannot be a 25 mm cell's half-diagonal under any argument, so **a finer grid does not reach class C at all** — arithmetic, not judgement.

Four of the nine are `utensil` against `counter_1_right_group_top_0` — the counter the payload was lifted *from*, i.e. the stale pre-attach silhouette the attach sweep window exists to clear. The rest name a surface tens of millimetres from anything the certified probe could find.

And within class B, **three stops already sit under 12.99 mm**, a 15 mm grid's own half-diagonal, so they would not clear either. **25 → 15 mm plausibly converts 5 of 20 stops; class C is 9 of 20.**

The levers stay complementary — that part of #257 holds. What was wrong is "the over-approximation *is* the cell": true for 8 stops, wrong for 9, and the lever ordering rested on it.

## The method error, recorded

A finer cell moves the kernel's reported depth **toward** certified truth rather than subtracting a fixed amount from it. Reasoning by subtraction on the reported depth — which is how I first checked whether 8.66 mm would clear a stop — misclassifies the genuinely-touching class, and would have produced the claim that a real contact gets wrongly cleared. It does not: a touching pair keeps stopping at any resolution. Written into `PLAN.md` so the next person doesn't repeat it.

## Where it goes

Both `PLAN.md` §5 and the evidence ledger's 2026-09-10 entry. The split is carried into #253 and #254 as the evidence each ruling needs.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtssNMqKXzZLfBhW7idZx2