### PR TITLE
feat(launch)!: ship the sim world-voxel grid at 15 mm (#253's ruling)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,9 +61,13 @@ repos:
           #     ("collecting childrens toys"); the benchmark matches on the
           #     exact string, so fixing the grammar would break task lookup.
           #   froms           — plural of Docker's `FROM` keyword.
+          #   sroll           — the SENSOR-prefixed unpacking of a static
+          #     transform (`sx, sy, sz, sroll, spitch, syaw`) in
+          #     deploy_e2e.launch.py. An identifier, not prose; "scroll" would
+          #     break the tuple it destructures.
           #   unparseable / overrideable / re-use / re-declaring — accepted
           #     variant spellings already used consistently in the tree.
-          - "--ignore-words-list=som,deques,nd,socio-economic,implementors,te,theses,empy,alph,crashers,ot,mis,ans,childrens,froms,unparseable,overrideable,re-use,re-declaring"
+          - "--ignore-words-list=som,deques,nd,socio-economic,implementors,te,theses,empy,alph,crashers,ot,mis,ans,childrens,froms,unparseable,overrideable,re-use,re-declaring,sroll"
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v3.4.0
     hooks:

--- a/packages/openral_rskill_ros/launch/deploy_e2e.launch.py
+++ b/packages/openral_rskill_ros/launch/deploy_e2e.launch.py
@@ -217,9 +217,28 @@ def _octomap_resolution(hal_mode: str) -> float:
 
     **A finer grid is LESS conservative**, not more: the cell half-diagonal is
     the kernel's quantisation term, so shrinking it makes the kernel stop later
-    and nearer. That is the point of the experiment and the reason this is an
-    override rather than a new default -- it needs the measurement in §5 plus a
-    safety-WG ruling before any value but the shipped one ships.
+    and nearer. Sim ships **15 mm** as of #253's ruling; real hardware stays at
+    50 mm.
+
+    Why sim moved and real did not. The evidence is entirely sim: replayed on
+    the real kernel over identical payload poses, `PickPlaceCounterToSink` (the
+    DOP-only, field-typical payload) goes from **154** false stops of 182
+    genuinely-clear poses at 25 mm with a box-lowered payload to **15** at
+    15 mm with #266's refinement -- 90% fewer, with all 7 real contacts still
+    caught. Neither lever alone is worth much (12% and 10%); the terms ADD, so
+    both have to move. See `docs/reference/collision-validation-evidence.md`
+    and hazard-log Entry 027.
+
+    None of that measures a real map. Sim rasterises a kitchen's own solid
+    geometry; a real map comes from a depth camera and is dilated by the
+    octree->grid bridge, and its error budget is larger, not smaller
+    (`docs/reference/world-map-fidelity.md`). Taking 50 mm down on sim evidence
+    would be shipping a reduction in conservatism where none was measured.
+
+    15 mm is also the finest value that ships without touching
+    `octree_to_grid.cpp`'s `kMaxCells`: 141 cells/axis is 2 803 221 against the
+    4 000 000 guard (70% of it), where 12.5 mm needs 4 826 809 and is refused
+    outright.
     """
     override = os.environ.get("OPENRAL_OCTOMAP_RESOLUTION_M", "").strip()
     if override:
@@ -231,7 +250,7 @@ def _octomap_resolution(hal_mode: str) -> float:
         # silently empty grid. Fall through to the shipped default.
         if 0.001 <= value <= 0.5:
             return value
-    return 0.025 if hal_mode == "sim" else 0.05
+    return 0.015 if hal_mode == "sim" else 0.05
 
 
 def _octomap_frames(description: RobotDescription) -> tuple[str, str]:
@@ -1128,7 +1147,7 @@ def compose_runtime_graph(context: LaunchContext, *_args: object, **_kwargs: obj
             # deploy keeps 2 cm.
             "world_voxel_margin_m": _world_voxel_margin_m(hal_mode),
             # Derived from the coverage ball and the octree resolution rather
-            # than pinned: 85^3 = 614 125 at the shipped 25 mm, 141^3 at 15 mm.
+            # than pinned: 141^3 = 2 803 221 at the shipped sim 15 mm, 85^3 at 25 mm.
             # See `_world_voxel_max_cells` for why a hand-kept derived constant
             # is the wrong shape here.
             "world_voxel_max_cells": _world_voxel_max_cells(_octomap_resolution(hal_mode)),

--- a/tests/unit/test_deploy_e2e_voxel_resolution.py
+++ b/tests/unit/test_deploy_e2e_voxel_resolution.py
@@ -75,17 +75,37 @@ def test_an_unusable_resolution_falls_back_to_the_shipped_default(
     """
     for bad in ("", "   ", "not-a-number", "0", "-0.015", "1.5"):
         monkeypatch.setenv("OPENRAL_OCTOMAP_RESOLUTION_M", bad)
-        assert launch_module._octomap_resolution("sim") == 0.025, bad
+        assert launch_module._octomap_resolution("sim") == 0.015, bad
         assert launch_module._octomap_resolution("real") == 0.05, bad
 
 
-def test_without_the_override_the_shipped_defaults_are_unchanged(
+def test_the_shipped_defaults_are_15_mm_in_sim_and_50_mm_on_hardware(
     launch_module: object,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """#253's ruling, and the half of it that deliberately did NOT move.
+
+    Sim ships 15 mm: replayed on the real kernel over identical payload poses,
+    the DOP-only field-typical payload goes from 154 false stops of 182
+    genuinely-clear poses (box @ 25 mm) to 15 (refined @ 15 mm), every real
+    contact still caught. The terms ADD, so this only pays alongside #266 --
+    15 mm alone was 10%.
+
+    Real hardware stays at 50 mm because none of that evidence is about a real
+    map: sim rasterises a kitchen's own solid geometry, a real map comes from a
+    depth camera and is dilated by the octree->grid bridge, and its error
+    budget is larger. Moving it on sim evidence would be a reduction in
+    conservatism nobody measured. That asymmetry is the point of this test, so
+    a later edit cannot quietly bring the two into line.
+    """
     monkeypatch.delenv("OPENRAL_OCTOMAP_RESOLUTION_M", raising=False)
-    assert launch_module._octomap_resolution("sim") == 0.025
+    assert launch_module._octomap_resolution("sim") == 0.015
     assert launch_module._octomap_resolution("real") == 0.05
+    # 15 mm is the finest value that ships without touching `kMaxCells`:
+    # 141/axis is 2 803 221 against the 4 000 000 guard, where 12.5 mm needs
+    # 4 826 809 and is refused outright.
+    assert launch_module._world_voxel_max_cells(0.015) == 2803221
+    assert launch_module._world_voxel_max_cells(0.015) < 4_000_000
 
 
 def _load_tool(name: str) -> object:


### PR DESCRIPTION
Closes #253 for sim. Real hardware is a **separate** PR with its own gate.

## What changes

`_octomap_resolution` sim default **25 mm → 15 mm**. Real hardware untouched here (50 mm).

**A finer grid is LESS conservative.** The cell half-diagonal is the kernel's quantisation term, so this is a deliberate reduction in the envelope — 21.65 mm → 12.99 mm — not a correctness fix.

## Why it ships now, when the same lever measured null in September

Because the term beside it moved. A stop needs

```
true clearance ≤ payload overhang + cell reach
```

Those **add**. Taking 8.66 mm off a ~50 mm sum left nearly every stop on the same side of the threshold — that was the null. #266 took the payload overhang from ~29–35 mm to ~9–10 mm, and the same 8.66 mm now decides the outcome.

Measured by **replay** on the real kernel — identical payload poses through every condition, no policy in the loop. `PickPlaceCounterToSink`, the **DOP-only** payload (hull over `kMaxTightHullVertices`, so stage 1 alone — the field-typical case), 182 genuinely-clear poses of 189:

| condition | false stops | real contacts caught (of 7) |
|---|---:|---:|
| box @ 25 mm | 154 (84.6 %) | 7 |
| refined @ 25 mm | 136 (12 % fewer) | 7 |
| box @ 15 mm | 138 (**10 % fewer — this PR's lever alone**) | 7 |
| **refined @ 15 mm** | **15 (90 % fewer)** | **7** |

**Every real contact still caught in every condition**, including the tightest — the property the check exists for.

## Why real hardware is not in this PR

None of that evidence is about a real map. Sim rasterises a kitchen's own solid geometry; a real map is depth-camera derived and dilated by the octree→grid bridge, and `docs/reference/world-map-fidelity.md` states plainly that the live map stops **more** often than the rasterised one, never less. The test pinning both defaults now records the asymmetry so a later edit cannot quietly bring them into line.

## Cost side — unchanged, and still real

- grid 0.6 → 2.8 MB republished at 10 Hz: **28 MB/s of DDS against 6**
- hazard-log **Entry 027**'s staleness trade stands: break-even end-effector speed **0.58 m/s** at median staleness, **0.16 m/s at p99**, against the current XR-1 checkpoint's 0.051 m/s. **A faster policy re-opens this trade.**
- 15 mm is the finest value that ships without raising `octree_to_grid.cpp`'s `kMaxCells`: 141/axis = 2 803 221 of 4 000 000 (70 %). 12.5 mm needs 4 826 809 and is refused outright — there is no headroom for a further halving.

## Safety-WG gate

This is a deliberate reduction in conservatism and needs sign-off. Hazard-log **Entry 027** already exists for exactly this ruling and is being updated with the evidence above; its sign-off must be ticked by a human, not by the agent that wrote it.

## Also in this branch

A prior `fix(ci)` commit for a pre-existing codespell false positive (`sroll`, the sensor-prefixed unpacking of a static transform) that blocks any commit touching this launch file.

Refs #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVrppMan2ts7WZe944fkTL