### PR TITLE
feat(launch)!: take the real-hardware world-voxel grid to 20 mm — on sim evidence only

### DIFF
--- a/packages/openral_rskill_ros/launch/deploy_e2e.launch.py
+++ b/packages/openral_rskill_ros/launch/deploy_e2e.launch.py
@@ -220,25 +220,33 @@ def _octomap_resolution(hal_mode: str) -> float:
     and nearer. Sim ships **15 mm** as of #253's ruling; real hardware stays at
     50 mm.
 
-    Why sim moved and real did not. The evidence is entirely sim: replayed on
-    the real kernel over identical payload poses, `PickPlaceCounterToSink` (the
-    DOP-only, field-typical payload) goes from **154** false stops of 182
-    genuinely-clear poses at 25 mm with a box-lowered payload to **15** at
-    15 mm with #266's refinement -- 90% fewer, with all 7 real contacts still
-    caught. Neither lever alone is worth much (12% and 10%); the terms ADD, so
-    both have to move. See `docs/reference/collision-validation-evidence.md`
-    and hazard-log Entry 027.
+    The sim evidence: replayed on the real kernel over identical payload poses,
+    `PickPlaceCounterToSink` (the DOP-only, field-typical payload) goes from
+    **154** false stops of 182 genuinely-clear poses at 25 mm with a
+    box-lowered payload to **15** at 15 mm with #266's refinement -- 90% fewer,
+    with all 7 real contacts still caught. Neither lever alone is worth much
+    (12% and 10%); the terms ADD, so both have to move. See
+    `docs/reference/collision-validation-evidence.md` and hazard-log Entry 027.
 
-    None of that measures a real map. Sim rasterises a kitchen's own solid
-    geometry; a real map comes from a depth camera and is dilated by the
-    octree->grid bridge, and its error budget is larger, not smaller
-    (`docs/reference/world-map-fidelity.md`). Taking 50 mm down on sim evidence
-    would be shipping a reduction in conservatism where none was measured.
+    **Real hardware ships 20 mm on that same sim evidence, and nothing else.**
+    No real map has been measured at any resolution. Sim rasterises a kitchen's
+    own solid geometry; a real map comes from a depth camera and is dilated by
+    the octree->grid bridge, and `docs/reference/world-map-fidelity.md` is
+    explicit that the live map stops MORE often than the rasterised one, never
+    less. The quantisation term is also not the only thing between the payload
+    and reality on hardware -- depth noise, extrinsics and the octree dilation
+    sit beside it, and 50 -> 20 mm removes 25.98 mm of guaranteed margin while
+    leaving those untouched. Recorded as a deliberate reduction in
+    conservatism, gated on the safety-WG, in its own hazard-log entry. It
+    should be re-measured on a real map before it is relied on.
 
-    15 mm is also the finest value that ships without touching
-    `octree_to_grid.cpp`'s `kMaxCells`: 141 cells/axis is 2 803 221 against the
-    4 000 000 guard (70% of it), where 12.5 mm needs 4 826 809 and is refused
-    outright.
+    20 mm on hardware and 15 mm in sim, not one value, because the two maps
+    have different error budgets and the sim one is the only one with numbers.
+
+    Cell counts against `octree_to_grid.cpp`'s `kMaxCells` (4 000 000): sim
+    15 mm is 141/axis = 2 803 221 (70% of the guard, and the finest value that
+    ships without raising it -- 12.5 mm needs 4 826 809 and is refused); real
+    20 mm is 106/axis = 1 191 016.
     """
     override = os.environ.get("OPENRAL_OCTOMAP_RESOLUTION_M", "").strip()
     if override:
@@ -250,7 +258,7 @@ def _octomap_resolution(hal_mode: str) -> float:
         # silently empty grid. Fall through to the shipped default.
         if 0.001 <= value <= 0.5:
             return value
-    return 0.015 if hal_mode == "sim" else 0.05
+    return 0.015 if hal_mode == "sim" else 0.02
 
 
 def _octomap_frames(description: RobotDescription) -> tuple[str, str]:

--- a/tests/unit/test_deploy_e2e_voxel_resolution.py
+++ b/tests/unit/test_deploy_e2e_voxel_resolution.py
@@ -76,10 +76,10 @@ def test_an_unusable_resolution_falls_back_to_the_shipped_default(
     for bad in ("", "   ", "not-a-number", "0", "-0.015", "1.5"):
         monkeypatch.setenv("OPENRAL_OCTOMAP_RESOLUTION_M", bad)
         assert launch_module._octomap_resolution("sim") == 0.015, bad
-        assert launch_module._octomap_resolution("real") == 0.05, bad
+        assert launch_module._octomap_resolution("real") == 0.02, bad
 
 
-def test_the_shipped_defaults_are_15_mm_in_sim_and_50_mm_on_hardware(
+def test_the_shipped_defaults_are_15_mm_in_sim_and_20_mm_on_hardware(
     launch_module: object,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -91,16 +91,23 @@ def test_the_shipped_defaults_are_15_mm_in_sim_and_50_mm_on_hardware(
     contact still caught. The terms ADD, so this only pays alongside #266 --
     15 mm alone was 10%.
 
-    Real hardware stays at 50 mm because none of that evidence is about a real
-    map: sim rasterises a kitchen's own solid geometry, a real map comes from a
-    depth camera and is dilated by the octree->grid bridge, and its error
-    budget is larger. Moving it on sim evidence would be a reduction in
-    conservatism nobody measured. That asymmetry is the point of this test, so
-    a later edit cannot quietly bring the two into line.
+    Real hardware ships 20 mm -- finer than the 50 mm it replaces, coarser than
+    sim's 15 mm, and on sim evidence alone. No real map has been measured at
+    any resolution: sim rasterises a kitchen's own solid geometry, a real map
+    is depth-camera derived and dilated by the octree->grid bridge, and its
+    error budget is larger, with depth noise and extrinsics sitting beside the
+    quantisation term this shrinks.
+
+    The two values stay DIFFERENT on purpose, which is the point of this test:
+    a later edit that collapses them to one number would be asserting the two
+    maps have the same error budget, and nothing has shown that.
     """
     monkeypatch.delenv("OPENRAL_OCTOMAP_RESOLUTION_M", raising=False)
     assert launch_module._octomap_resolution("sim") == 0.015
-    assert launch_module._octomap_resolution("real") == 0.05
+    assert launch_module._octomap_resolution("real") == 0.02
+    assert launch_module._octomap_resolution("sim") != launch_module._octomap_resolution("real")
+    # Both inside `kMaxCells` (4 000 000), with the real grid the roomier one.
+    assert launch_module._world_voxel_max_cells(0.02) == 1191016
     # 15 mm is the finest value that ships without touching `kMaxCells`:
     # 141/axis is 2 803 221 against the 4 000 000 guard, where 12.5 mm needs
     # 4 826 809 and is refused outright.


### PR DESCRIPTION
**Stacked on #269.** Merge that first; this diff is only the real-hardware half so the two gates stay separable.

## What changes

`_octomap_resolution` real default **50 mm → 20 mm**. Cell half-diagonal **43.30 → 17.32 mm**, i.e. **25.98 mm of guaranteed standoff given up** on a real robot.

## The thing the WG has to weigh, stated without decoration

**This ships on sim evidence and nothing else. No real map has been measured at any resolution.**

The replay that justifies the sim move (#269) rasterises a kitchen's own solid geometry. A real map is depth-camera derived and dilated by the octree→grid bridge. `docs/reference/world-map-fidelity.md` is explicit that the live map stops **more** often than the rasterised one, never less — so the sim numbers do not transfer, and this PR does not claim they do.

Worse for the margin arithmetic: **quantisation is not the only term on hardware.** Depth noise, extrinsics and the octree dilation sit beside it and are untouched by this change. So the *fraction* of the real error budget being given up is larger than 25.98 mm suggests — we just don't know by how much, because it has never been measured.

**It should be re-measured on a real map before it is relied on.** That is not a formality; it is the only thing that would turn this from a defensible guess into an evidenced change.

## Why 20 mm and not 15 mm

Sim ships 15 mm, hardware 20 mm — deliberately **two values**, because the two maps have different error budgets and only one of them has numbers. Collapsing them to one would be asserting an equivalence nobody has shown, so the test pinning them now asserts they **differ**.

1 191 016 cells at 106/axis, well inside `octree_to_grid.cpp`'s 4 000 000 `kMaxCells`.

## Safety-WG gate

Deliberate reduction in conservatism **on real hardware**, which is a stronger claim than #269's. Needs its own hazard-log entry — Entry 027 covers the sim 25 → 15 mm ruling and does not cover this — and a human sign-off. I can draft the entry; I cannot tick it.

Refs #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVrppMan2ts7WZe944fkTL