### PR TITLE
docs(reference): record the public OpenArm policy candidates

### DIFF
--- a/docs/reference/vla_compatibility.md
+++ b/docs/reference/vla_compatibility.md
@@ -186,6 +186,32 @@ therefore not packaged as an rSkill and cannot be claimed as real-robot ready.
 |---|---|---|---|---|---|---|---|---|
 | Organizer GR00T N1.7 `turning_on_radio` checkpoint ([baseline](https://behavior.stanford.edu/challenge/baselines.html)) | OmniGibson / Isaac Sim | `r1pro` | **61-D** official R1Pro proprio order | 224² RGB under the official `DefaultWrapper` (`RGBDFullResWrapper` crashes at boot on the pinned OmniGibson build — it reads joint state before the physics views exist) | **23-D** base velocity (3) + torso (4) + arms (7+7) + symmetric grippers (1+1) | `rskills/gr00t-n17-b1k-turning-on-radio` | **Unknown** for the organizer Drive artifact | Runs through `openral behavior serve`, `openral sim run`, `openral benchmark run --suite behavior`, or the full `openral deploy sim` graph. Deploy preserves the 61-D state and commits all six safety-approved typed slots as one simulator step. |
 
+### 3.12 OpenArm v2 (bimanual, real cell)
+
+`rskills/` ships no OpenArm policy: the cell's own checkpoint is not
+distributable and is installed from its own Hub repo, so the lab-gated OpenArm
+tests resolve a policy through the local install registry
+(`tests/hil/conftest._installed_slot_rskill("openarm")`). The rows below are
+the **public** candidates inspected for an in-tree fixture, measured against
+what `robots/openarm/robot.yaml` and `scenes/deploy/openarm_restock_shelf.yaml`
+require: a 16-D state and a 16-D action over `left_joint1..7`, `left_gripper`,
+`right_joint1..7`, `right_gripper` in radians, three RGB views, and an action
+contract whose four slots are that joint list split 7 / 1 / 7 / 1.
+
+| VLA (HF ID) | Sim env | Robot tag | State dim | Cameras | Action dim | rSkill | License | Notes |
+|---|---|---|---|---|---|---|---|---|
+| `yangjq713/openarm_water_bottle_grasp_policy` | real cell | `openarm` | **16** ✓ | `base_0_rgb`, `left_wrist_0_rgb`, `right_wrist_0_rgb`, all 224² ✓ | **16** ✓ | — | Apache-2.0 | **Closest structural match.** `pi0` (not π0.5) LoRA adapter over `lerobot/pi0_base` — `adapter_config.json` targets the gemma expert q/v plus `state_proj`/`action_in_proj`/`action_out_proj`/`action_time_mlp_*`, so the base weights must be fetched separately (adapter is 5.6 MB). `chunk_size` 50, `n_action_steps` 50, fp32, MEAN_STD state/action normalization. The three views map 1:1 onto the deploy scene's `context` / `wrist_left` / `wrist_right`. **Channel order unverified**: its dataset `openarm/water_bottle_grasp` is not public, so nothing confirms the 16 channels are ordered left-arm-then-right-arm. That ordering is what the slot block asserts, and a swap would drive the wrong arm. |
+| `playercc7/pi05_openarm_pick_cup` | real cell | `openarm` | **66** ✗ | `left_cam`, `right_cam` (720×1280), `head_camera` (360×640) | **16** ✓ | — | Apache-2.0 | π0.5 with full weights (7.4 GB safetensors) and processor safetensors in the repo. Action dim matches, but the 66-D state is far richer than the 16 joint positions the HAL reports, so it would need a state assembler before the contract holds. Three views, but at native 720p/360p rather than 224². |
+| `AiSaurabhPatil/openarm-pi05-finetuned` | Isaac Sim | `openarm` | **16** ✓ (from `norm_stats.json`) | not declared in the checkpoint metadata | 16 (presumed) | — | Apache-2.0 | π0.5 bimanual, but an **openpi/Orbax** checkpoint (`params/` with ocdbt shards, `_CHECKPOINT_METADATA`), not a lerobot `model.safetensors`. OpenRAL's π0.5 path goes through lerobot's policy class, so this needs an openpi→lerobot conversion before it is loadable here. |
+| `puppet-robotics/openarm_tile-flip_2026-01-10` | real cell | — | **8** ✗ | `wrist` (480×640), `ego` (720×1280) | **8** ✗ | — | Apache-2.0 | π0.5, single-arm (7 joints + gripper). Does not fit the bimanual contract; a candidate only for a future single-arm OpenArm scene. |
+
+What a manifest still cannot claim from checkpoint inspection alone: the
+action channel order (above), a latency budget, and any eval result. All three
+need one run on the cell. The slot block itself is mechanical — it is the
+robot description's 16 joints split 7 / 1 / 7 / 1 — so once the channel order
+is confirmed against the training dataset, a wrapper for the first row is a
+manifest plus a measured `eval/` entry.
+
 ---
 
 ## 4. Sim Environment Reference


### PR DESCRIPTION
## What
Adds §3.12 to the VLA compatibility matrix: the four public OpenArm checkpoints on the Hub, each inspected against the contract the in-tree OpenArm robot and deploy scene require. This branch is also the parking spot for the restock stack (`scenes/deploy/openarm_restock_shelf.yaml`, `scenes/deploy/drivers/zedm_openarm_override.yaml`, `tests/hil/test_openarm_restock_deploy_preflight.py`, `tests/hil/test_openarm_slot_group_motion.py`), which it carries unchanged from `master`.

## Why
#274 removed `rskill-pi05-openarm-restock_shelf-bf16` because the cell's policy is not distributable, and rewired the lab-gated OpenArm tests to resolve a policy through the local install registry. That leaves a question for anyone who wants an in-tree OpenArm fixture again: is there a public checkpoint that fits? The matrix had no OpenArm section at all, so there was nowhere to record the answer.

The target contract, from `robots/openarm/robot.yaml` and the deploy scene:

| | required |
| --- | --- |
| joints | 16 — `left_joint1..7`, `left_gripper`, `right_joint1..7`, `right_gripper` |
| state dim | 16 |
| action dim | 16, radians |
| slots | that joint list split 7 / 1 / 7 / 1 |
| cameras | three RGB (`context`, `wrist_left`, `wrist_right`) |

## Findings

| candidate | state | action | verdict |
| --- | --- | --- | --- |
| `yangjq713/openarm_water_bottle_grasp_policy` | **16** ✓ | **16** ✓ | closest match; three views map 1:1 onto the scene's camera slots |
| `playercc7/pi05_openarm_pick_cup` | 66 ✗ | 16 ✓ | needs a state assembler |
| `AiSaurabhPatil/openarm-pi05-finetuned` | 16 ✓ | 16 (presumed) | openpi/Orbax, needs conversion to lerobot |
| `puppet-robotics/openarm_tile-flip_2026-01-10` | 8 ✗ | 8 ✗ | single-arm |

Every figure is read off the checkpoint's own `config.json`, `adapter_config.json` or `norm_stats.json` on the Hub — no inference from model cards.

Two things stop the first row from becoming a manifest today, and the section says so rather than papering over them:

- It is a **pi0 LoRA adapter** over `lerobot/pi0_base` (5.6 MB of adapter targeting the gemma expert's q/v plus the state and action projections), not a standalone π0.5 checkpoint. The base weights load separately.
- Its training dataset `openarm/water_bottle_grasp` is **not public**, so nothing confirms the 16 action channels are ordered left-arm-then-right-arm. That ordering is exactly what the slot block asserts, and a swap would drive the wrong arm on real hardware.

The slot block itself is mechanical: the robot description's 16 joints split 7 / 1 / 7 / 1. So once channel order is confirmed against the training data, a wrapper is a manifest plus a measured `eval/` entry. Latency budget and eval numbers still need one run on the cell; inspection cannot supply them.

## Open question for the maintainer
Whether `master` should also lose the restock deploy scene. It is not private — no weights, just the cell's cameras and robot binding — and it currently backs six unit-test fixtures (`test_deploy_launch_interpreter`, `test_scene_drivers`, `test_foxglove_deploy_wiring`, `test_cli_deploy_sim`, `test_all_manifests_validate`, and the ROS package's `test_deploy_e2e_scene_sensor_mounts`) plus a comment in `deploy_e2e.launch.py` and the OpenArm HAL README. Removing it means repointing those six at `openarm_tabletop.yaml` or `openarm_zed_octomap.yaml`, which assert scene-specific structure the restock scene supplies (three rig cameras with `parent_frame` mounts, the ZED driver override). That is a deliberate coverage change, not a mechanical delete, so it is not in this branch yet.

## How tested
Docs-only change. `ruff check .` clean; `pytest tests/unit -k "doc or readme or compat"` → 207 passed, 24 skipped (skips are missing `rclpy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gav1cocYsZccqFxyB4N6vu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gav1cocYsZccqFxyB4N6vu)_