### PR TITLE
docs(evidence): #275 across 27 rounds — the excess is bimodal, and the deep mode indicts the cell

### DIFF
--- a/docs/reference/collision-validation-evidence.md
+++ b/docs/reference/collision-validation-evidence.md
@@ -2741,6 +2741,88 @@ earlier today went 0/6 and 2/6. n is far too small and nothing here touched the
 kernel's decisions.
 
 
+### 2026-09-13 — #275 across 27 rounds: the payload-vs-voxel excess is **bimodal**
+
+Three batteries on `fridge` gate-ON, 27 rounds, every payload-vs-voxel stop,
+sorted by excess (certified mesh→world truth minus the kernel's reported depth):
+
+| run | kernel | certified | **excess** | verdict | rotation | max-slip |
+| --- | ---: | ---: | ---: | --- | ---: | ---: |
+| r05′ | −7.54 | −5.21 | 2.32 | `attached_payload` | — | — |
+| r05 | −0.28 | +5.09 | 5.37 | `solid_world` | 3.69° | 4.28 |
+| r22 | −6.34 | −0.54 | 5.80 | `attached_payload` | 0.51° | 1.11 |
+| r10 | −12.42 | +0.47 | 12.89 | `attached_payload` | 0.655° | 2.79 |
+| r20 | −17.58 | +0.53 | 18.11 | `attached_payload` | 0.047° | 1.03 |
+| r11 | −15.99 | +4.32 | 20.31 | `solid_world` | 2.8° | 4.81 |
+| **r24** | −31.22 | +1.06 | **32.28** | `solid_world` | **16.72°** | **26.70** |
+| r01′ | −34.67 | −0.25 | 34.42 | `attached_payload` | — | — |
+| r03′ | −33.65 | +2.07 | 35.72 | `solid_world` | — | — |
+| **r25** | −32.64 | **+12.64** | **45.29** | `solid_world` | 0.79° | 1.59 |
+
+(′ = the earlier battery, which predates the slip instrument.)
+
+**Six stops at 2–20 mm all close** inside the known budget: DOP overhang
+(≤ 6.40 mm, measured by support functions over 4096 directions) + payload slip +
+the 12.99 mm cell half-diagonal. **Four at 32–45 mm do not.** The deep mode is
+**4 of 10 stops**, not an outlier, and it costs ~30 mm of standoff on stops where
+the payload is demonstrably clear.
+
+### Eliminated, each by measurement
+
+- **Payload model.** Box overhang median 12.86 / max 23.47 mm; **26-DOP median
+  1.71 / max 6.40 mm**. The hull ships **0 vertices** for any RoboCasa mesh
+  (1983 verts against `_HULL_DEDUP_CEILING` 640), so #267's benefit in sim is
+  delivered entirely by the DOP and the convex hull never engages.
+- **A cell inside the payload.** r03′'s mesh is **9.11 mm clear** of the cell the
+  kernel reports −33.65 mm into; 0 of 8 cube corners inside the payload hull.
+- **The predicted step.** Every stop is `step=0` (predictive), so the snapshot's
+  measured state is one action-step behind. Re-running the reconstruction with
+  the kernel's **own `joint_positions_rad`** changes nothing on r25.
+- **Rotational slip.** r24 has 16.72° / 26.7 mm, which accounts for essentially
+  its whole 32 mm — but **r25, the deepest at 45.29 mm, has 0.79° / 1.59 mm**.
+  Rotation explains one of the four and no more. *It was declared "confirmed" on
+  r24 alone and refuted by the next round; that claim is withdrawn.*
+
+### What the deepest stop leaves
+
+Decomposing r25, the cleanest deep instance:
+
+| | |
+| --- | --- |
+| kernel reported (DOP→cube) | −32.64 mm |
+| reconstructed at the recorded pose, using the kernel's own joints | **+8.38 mm** |
+| → discrepancy | **41.02 mm** |
+| `payload_model_slip` | translation **0.75 mm**, rotation **0.79°** |
+| certified mesh→world | **+12.64 mm** — the payload is nowhere near anything |
+
+The kernel's model is within 0.75 mm of the body and the configuration is the
+kernel's own, so the *pose* cannot carry a 41 mm error. Searching cells near the
+recorded one, an offset of **(0, +2, +2) cells** reproduces −29.61 mm against the
+kernel's −32.64 mm.
+
+**That indicts the cell, not the geometry.** `decode_is_latest: true` — true on
+every stop in these batteries — was read too strongly: it says the bridge used
+the newest grid it **held**, not that this is the grid the kernel **checked**,
+and inside one `/clock` tick (every stamp in the graph quantises to 50 ms)
+nothing downstream can distinguish them. That is the gap the kernel's grid
+disclosure closes (#281, hazard-log Entry 030), which is therefore **on** #275's
+critical path rather than beside it — a reversal of what this page said earlier.
+
+### Standing caveats on this entry
+
+- The reconstruction is a **separating-axis lower bound** over the cube's axes
+  plus 13 canonical directions — exact only when a face normal separates.
+  Millimetre values carry error bars; the tens-of-millimetres discrepancy does
+  not.
+- The nearby-cell search examined **729 candidates**; one matching by chance is
+  expected. It is corroboration, **not** proof.
+- **#275's cause has been wrongly identified four times** — phantom occupancy,
+  payload leak, rotation, and "the decode is not the problem" — twice on a single
+  data point. The decode hypothesis above is the fifth and is **unconfirmed**.
+  The test that settles it is a battery on master with `decode_source: origin`,
+  which names the cell exactly.
+
+
 ## Standing caveats
 
 Eleven things a reader should carry away, all of them stated by the artifacts


### PR DESCRIPTION
Closes a gap: #279's code landed but its evidence-page entry did not, and that entry was already stale by the time it would have merged. This replaces it with the **final** state after 27 rounds.

## The result

Six payload-vs-voxel stops at **2–20 mm excess all close** inside the known budget (DOP ≤ 6.40 mm + slip + 12.99 mm cell term). **Four at 32–45 mm do not.** The deep mode is **4 of 10 stops** — not an outlier — and costs ~30 mm of standoff on stops where the payload is demonstrably clear.

## Eliminated, each by measurement

- **Payload model** — DOP max **6.40 mm**; the hull ships **0 vertices** for any RoboCasa mesh (1983 verts vs a 640 ceiling), so #267's sim benefit is entirely the DOP and the hull never engages.
- **Cell inside the payload** — r03′'s mesh is **9.11 mm clear** of the cell reporting −33.65 mm.
- **The predicted step** — every stop is `step=0`; re-running with the kernel's own `joint_positions_rad` changes nothing.
- **Rotational slip** — r24 has 16.72°/26.7 mm, but **r25, the deepest at 45.29 mm, has 0.79°/1.59 mm**. I declared rotation confirmed off r24 alone and was refuted by the next round. Withdrawn.

## What r25 leaves

41.02 mm between the kernel's −32.64 mm and the +8.38 mm reconstructed at the recorded pose *using the kernel's own joints* — with the model 0.75 mm from the body and the payload **12.64 mm clear of everything**. A cell offset by **(0, +2, +2)** reproduces the kernel's number.

**That indicts the cell.** `decode_is_latest: true` was read too strongly: it says the bridge used the newest grid it **held**, not that this is the grid the kernel **checked**. So #281's disclosure is **on** #275's critical path — reversing what this page said earlier, and I've said so in the entry rather than quietly changing it.

## Not proven

The reconstruction is a separating-axis **lower bound**. The nearby-cell search had **729 candidates** — corroboration, not proof. And **#275's cause has been wrongly identified four times**; this is the fifth hypothesis and it is unconfirmed. The test that settles it is a battery on master with `decode_source: origin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVrppMan2ts7WZe944fkTL